### PR TITLE
fix: catalog init path resolution and libgit2 safe.directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ logs/
 
 
 test-repos/
+demo-catalog/

--- a/docker/git-server.Dockerfile
+++ b/docker/git-server.Dockerfile
@@ -48,6 +48,12 @@ WORKDIR /app
 # Copy binary from builder
 COPY --from=builder /build/target/release/gitstore-server /app/gitstore-server
 
+# Allow libgit2 to open repositories in mounted volumes regardless of ownership.
+# libgit2 (used by the Rust git2 crate) enforces the same safe.directory check
+# as git >= 2.35.2; writing to /etc/gitconfig satisfies it without requiring
+# the git binary at runtime.
+RUN printf '[safe]\n\tdirectory = *\n' > /etc/gitconfig
+
 # Create data directory
 RUN mkdir -p /data/repos
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,11 +9,16 @@ Creates a sample product catalog with categories, collections, and products for 
 ### Usage
 
 ```bash
-./scripts/init-demo-catalog.sh [catalog-path]
+./scripts/init-demo-catalog.sh [--data-dir <catalog-path>]
 ```
 
 **Arguments:**
-- `catalog-path` (optional): Directory where catalog will be created. Default: `./demo-catalog`
+- `--data-dir <catalog-path>` (optional): Data directory where `catalog.git` will be created
+
+**Path Resolution Precedence:**
+1. `GITSTORE_DATA_DIR` environment variable
+2. `--data-dir` flag
+3. `./demo-catalog` (default)
 
 **Example:**
 
@@ -22,12 +27,15 @@ Creates a sample product catalog with categories, collections, and products for 
 ./scripts/init-demo-catalog.sh
 
 # Create demo catalog in custom location
-./scripts/init-demo-catalog.sh ./my-catalog
+./scripts/init-demo-catalog.sh --data-dir ./my-catalog
+
+# Environment variable takes precedence over CLI argument
+GITSTORE_DATA_DIR=./from-env ./scripts/init-demo-catalog.sh
 ```
 
 ### What It Creates
 
-The script initializes a git repository with:
+The script initializes a git repository at `<CATALOG_PATH>/catalog.git` with:
 
 **Categories (4):**
 - Electronics (root)
@@ -61,7 +69,7 @@ After running the script:
 
 2. **Create a release tag:**
    ```bash
-   cd demo-catalog
+   cd $GITSTORE_DATA_DIR/catalog.git
    git tag -a v1.0.0 -m "Initial catalog release"
    ```
 

--- a/scripts/init-demo-catalog.sh
+++ b/scripts/init-demo-catalog.sh
@@ -3,20 +3,44 @@
 # Demo Catalog Initialization Script
 # Creates a sample product catalog with categories, collections, and products
 #
-# Usage: ./scripts/init-demo-catalog.sh [catalog-path]
+# Usage: ./scripts/init-demo-catalog.sh [--data-dir <catalog-path>]
 #
-# Example: ./scripts/init-demo-catalog.sh ./test-catalog
+# Example: ./scripts/init-demo-catalog.sh --data-dir ./test-catalog
 
 set -e
 
-# Default catalog path
-CATALOG_PATH="${1:-./demo-catalog}"
+# Parse command-line arguments
+CLI_DATA_DIR=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --data-dir)
+      if [ -z "$2" ]; then
+        echo "Error: --data-dir requires a value"
+        exit 1
+      fi
+      CLI_DATA_DIR="$2"
+      shift 2
+      ;;
+    *)
+      echo "Error: unexpected argument '$1'"
+      echo "Usage: $(basename "$0") [--data-dir <catalog-path>]"
+      exit 1
+      ;;
+  esac
+done
 
-echo "Initializing demo catalog at: $CATALOG_PATH"
+# Resolve catalog base directory with precedence:
+# 1) GITSTORE_DATA_DIR env var
+# 2) --data-dir flag
+# 3) ./demo-catalog
+CATALOG_PATH="${GITSTORE_DATA_DIR:-${CLI_DATA_DIR:-./demo-catalog}}"
+CATALOG_REPO_PATH="$CATALOG_PATH/catalog.git"
+
+echo "Initializing demo catalog at: $CATALOG_REPO_PATH"
 
 # Create catalog directory structure
-mkdir -p "$CATALOG_PATH"
-cd "$CATALOG_PATH"
+mkdir -p "$CATALOG_REPO_PATH"
+cd "$CATALOG_REPO_PATH"
 
 # Initialize git repository
 if [ ! -d .git ]; then
@@ -438,7 +462,7 @@ git commit -m "Add demo catalog with categories, collections, and products
 - Shows product-category-collection relationships"
 
 echo ""
-echo "✅ Demo catalog initialized successfully at: $CATALOG_PATH"
+echo "✅ Demo catalog initialized successfully at: $CATALOG_REPO_PATH"
 echo ""
 echo "Catalog contents:"
 echo "  - 4 categories (with 1 hierarchy: Electronics > Computers/Accessories)"
@@ -446,11 +470,11 @@ echo "  - 3 collections (Featured, New Arrivals, Best Sellers)"
 echo "  - 7 products (laptops, accessories, books)"
 echo ""
 echo "To use with GitStore:"
-echo "  1. Point git-server to this repository: $CATALOG_PATH"
+echo "  1. Point git-server data dir to: $CATALOG_PATH"
 echo "  2. Create a release tag: git tag -a v1.0.0 -m 'Initial release'"
 echo "  3. Git server will load and serve this catalog via GraphQL"
 echo ""
 echo "Example git operations:"
-echo "  cd $CATALOG_PATH"
+echo "  cd $CATALOG_REPO_PATH"
 echo "  git tag -a v1.0.0 -m 'Initial catalog release'"
 echo "  git log --oneline"


### PR DESCRIPTION
## Summary

Two related fixes to make `docker compose up` work out of the box with a demo catalog.

---

### `scripts/init-demo-catalog.sh` - path resolution + `catalog.git` layout

The script now resolves the catalog base directory with the following precedence, matching the git-server startup logic (`data_path.join("catalog.git")`):

1. `GITSTORE_DATA_DIR` environment variable
2. `--data-dir <path>` flag
3. `./demo-catalog` (default)

The bare repository is always created at `<CATALOG_PATH>/catalog.git`. Positional arguments are rejected with a clear error message.

---

### `docker/git-server.Dockerfile` - libgit2 `safe.directory` fix

libgit2 (Rust git2 crate) enforces the same ownership check as git >= 2.35.2. When a host directory is bind-mounted into the container the UID on disk does not match the container UID, causing:

```
repository path '/data/repos/catalog.git/' is not owned by current user; class=Config (7); code=Owner (-36)
```

Fix: write `[safe] directory = *` to `/etc/gitconfig` at build time. No `git` binary needed at runtime.

```dockerfile
RUN printf '[safe]\n\tdirectory = *\n' > /etc/gitconfig
```

---

### Other changes

- `scripts/README.md`: updated usage docs, precedence table, examples
- `.gitignore`: ignore `demo-catalog/`
