### PR TITLE
Update CI Docker actions and multi-arch build settings

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,7 +15,9 @@ on:
         options:
           - staging
           - production
-
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
 env:
   REGISTRY: ghcr.io
   GIT_SERVICE_IMAGE: ${{ github.repository_owner }}/git-service
@@ -37,10 +39,10 @@ jobs:
       uses: docker/setup-qemu-action@v4
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Log in to Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -48,7 +50,7 @@ jobs:
 
     - name: Extract metadata for Git Service
       id: meta-git-service
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       with:
         images: ${{ env.REGISTRY }}/${{ env.GIT_SERVICE_IMAGE }}
         tags: |
@@ -59,7 +61,7 @@ jobs:
           type=sha,prefix={{branch}}-
 
     - name: Build and push Git Service image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: ./docker/git-service.Dockerfile
@@ -69,10 +71,11 @@ jobs:
         labels: ${{ steps.meta-git-service.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=GitStore git service with built-in Git protocol handling, validation hooks, and websocket notifications
 
     - name: Extract metadata for API
       id: meta-api
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       with:
         images: ${{ env.REGISTRY }}/${{ env.API_IMAGE }}
         tags: |
@@ -83,7 +86,7 @@ jobs:
           type=sha,prefix={{branch}}-
 
     - name: Build and push API image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: ./docker/api.Dockerfile
@@ -96,7 +99,7 @@ jobs:
 
     - name: Extract metadata for Admin
       id: meta-admin
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       with:
         images: ${{ env.REGISTRY }}/${{ env.ADMIN_IMAGE }}
         tags: |
@@ -107,7 +110,7 @@ jobs:
           type=sha,prefix={{branch}}-
 
     - name: Build and push Admin image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: ./docker/admin.Dockerfile
@@ -126,7 +129,7 @@ jobs:
     if: github.ref == 'refs/heads/main' || github.event.inputs.environment == 'staging'
     environment:
       name: staging
-      url: https://staging.gitstore.example.com
+      url: https://sandbox.gitstore.dev
 
     steps:
     - uses: actions/checkout@v6
@@ -152,7 +155,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.environment == 'production'
     environment:
       name: production
-      url: https://gitstore.example.com
+      url: https://cloud.gitstore.dev
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -71,7 +71,8 @@ jobs:
         labels: ${{ steps.meta-git-service.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=GitStore git service with built-in Git protocol handling, validation hooks, and websocket notifications
+        outputs: >-
+          type=image,name=target,"annotation-index.org.opencontainers.image.description=GitStore git service with built-in Git protocol handling, validation hooks, and websocket notifications"
 
     - name: Extract metadata for API
       id: meta-api

--- a/docker/admin.Dockerfile
+++ b/docker/admin.Dockerfile
@@ -1,5 +1,7 @@
 # Multi-stage build for Admin UI (Node.js/Astro)
-FROM node:22-alpine3.21 AS builder
+# Build static assets on the native BuildKit platform to avoid qemu npm crashes
+# during multi-arch builds (linux/amd64,linux/arm64).
+FROM --platform=$BUILDPLATFORM node:lts-alpine3.22 AS builder
 
 WORKDIR /build
 

--- a/docker/git-service.Dockerfile
+++ b/docker/git-service.Dockerfile
@@ -50,8 +50,6 @@ RUN find src -type f -name '*.rs' -exec touch {} + && \
 # libgcc (for Rust/GCC stack unwinding) is needed alongside git.
 FROM alpine:3
 
-LABEL org.opencontainers.image.description="GitStore git service with built-in Git protocol handling, validation hooks, and websocket notifications"
-
 RUN apk add --no-cache \
     git \
     ca-certificates \


### PR DESCRIPTION
## Summary
- add deployment workflow concurrency control to prevent overlapping deploy runs
- upgrade Docker GitHub Actions versions in CI workflow
- switch admin build stage to `--platform=$BUILDPLATFORM` with `node:lts-alpine3.22` to avoid qemu npm crashes in multi-arch builds
- move git-service OCI description annotation from Dockerfile label to build output annotation in workflow
- update staging and production environment URLs in deployment workflow

## Why
These changes improve deployment reliability, keep CI Docker actions current, and stabilize multi-arch image builds.

## Files Changed
- `.github/workflows/cd.yml`
- `docker/admin.Dockerfile`
- `docker/git-service.Dockerfile`
