### PR TITLE
Split CI build job into per-image jobs and enable BuildKit cache mounts

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,8 +25,8 @@ env:
   ADMIN_IMAGE: ${{ github.repository_owner }}/admin
 
 jobs:
-  build-images:
-    name: Build and Push Docker Images
+  build-git-service-image:
+    name: Build and Push Git Service Image
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -69,10 +69,33 @@ jobs:
         push: true
         tags: ${{ steps.meta-git-service.outputs.tags }}
         labels: ${{ steps.meta-git-service.outputs.labels }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-from: type=gha,scope=git-service
+        cache-to: type=gha,mode=max,scope=git-service
         outputs: >-
           type=image,name=target,"annotation-index.org.opencontainers.image.description=GitStore git service with built-in Git protocol handling, validation hooks, and websocket notifications"
+
+  build-api-image:
+    name: Build and Push API Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+
+    - name: Log in to Container Registry
+      uses: docker/login-action@v4
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Extract metadata for API
       id: meta-api
@@ -95,10 +118,33 @@ jobs:
         push: true
         tags: ${{ steps.meta-api.outputs.tags }}
         labels: ${{ steps.meta-api.outputs.labels }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-from: type=gha,scope=api
+        cache-to: type=gha,mode=max,scope=api
         outputs: >-
           type=image,name=target,"annotation-index.org.opencontainers.image.description=GitStore GraphQL API service for querying and publishing catalog data backed by the git service"
+
+  build-admin-image:
+    name: Build and Push Admin Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+
+    - name: Log in to Container Registry
+      uses: docker/login-action@v4
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Extract metadata for Admin
       id: meta-admin
@@ -121,8 +167,8 @@ jobs:
         push: true
         tags: ${{ steps.meta-admin.outputs.tags }}
         labels: ${{ steps.meta-admin.outputs.labels }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-from: type=gha,scope=admin
+        cache-to: type=gha,mode=max,scope=admin
         outputs: >-
           type=image,name=target,"annotation-index.org.opencontainers.image.description=GitStore admin web interface for managing products, categories, collections, and catalog publishing"
       continue-on-error: true  # Admin UI may not be implemented yet
@@ -130,7 +176,7 @@ jobs:
   deploy-staging:
     name: Deploy to Staging
     runs-on: ubuntu-latest
-    needs: build-images
+    needs: [build-git-service-image, build-api-image, build-admin-image]
     if: github.ref == 'refs/heads/main' || github.event.inputs.environment == 'staging'
     environment:
       name: staging
@@ -156,7 +202,7 @@ jobs:
   deploy-production:
     name: Deploy to Production
     runs-on: ubuntu-latest
-    needs: [build-images, deploy-staging]
+    needs: [build-git-service-image, build-api-image, build-admin-image, deploy-staging]
     if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.environment == 'production'
     environment:
       name: production

--- a/docker/admin.Dockerfile
+++ b/docker/admin.Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7
+
 # Multi-stage build for Admin UI (Node.js/Astro)
 # Build static assets on the native BuildKit platform to avoid qemu npm crashes
 # during multi-arch builds (linux/amd64,linux/arm64).
@@ -9,7 +11,8 @@ WORKDIR /build
 COPY admin-ui/package.json admin-ui/package-lock.json* ./
 
 # Install production dependencies only
-RUN npm ci --omit=dev
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci --omit=dev
 
 # Copy source code
 COPY admin-ui/ ./

--- a/docker/api.Dockerfile
+++ b/docker/api.Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7
+
 # Multi-stage build for GraphQL API (Go)
 FROM golang:1.26.1-alpine3.23 AS builder
 
@@ -9,14 +11,17 @@ WORKDIR /build
 COPY api/go.mod api/go.sum ./
 
 # Download dependencies
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 # Copy source code
 COPY api/ ./
 COPY shared/schemas /build/shared/schemas
 
 # Build application
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o api ./cmd/server
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=linux go build -o api ./cmd/server
 
 # Runtime stage
 FROM alpine:3.23.3

--- a/docker/git-service.Dockerfile
+++ b/docker/git-service.Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7
+
 # Multi-stage build for Git Server (Rust)
 # rust:1.94-alpine targets aarch64-unknown-linux-musl on ARM64 by default,
 # producing a fully musl-linked binary that runs on Alpine without glibc.
@@ -29,7 +31,10 @@ RUN mkdir src && \
     echo "pub fn lib() {}" > src/lib.rs
 
 # Build dependencies
-RUN cargo build --release && \
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/build/target \
+    cargo build --release && \
     rm -rf src
 
 # Copy actual source code
@@ -38,7 +43,10 @@ COPY git-server/src ./src
 # Build application.
 # Refresh mtimes for all source files so Cargo invalidates dummy artifacts
 # from the dependency-caching step and recompiles the real crate.
-RUN find src -type f -name '*.rs' -exec touch {} + && \
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/build/target \
+    find src -type f -name '*.rs' -exec touch {} + && \
     cargo build --release && \
     strip /build/target/release/gitstore-server
 

--- a/docker/git-service.Dockerfile
+++ b/docker/git-service.Dockerfile
@@ -48,7 +48,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/build/target \
     find src -type f -name '*.rs' -exec touch {} + && \
     cargo build --release && \
-    strip /build/target/release/gitstore-server
+    cp /build/target/release/gitstore-server /build/gitstore-server && \
+    strip /build/gitstore-server
 
 # Runtime stage
 # Alpine git has no perl dependency (unlike Debian), saving ~50 MB.
@@ -66,7 +67,7 @@ RUN apk add --no-cache \
 WORKDIR /app
 
 # Copy binary from builder
-COPY --from=builder /build/target/release/gitstore-server /app/gitstore-server
+COPY --from=builder /build/gitstore-server /app/gitstore-server
 
 # Allow libgit2 to open repositories in mounted volumes regardless of ownership.
 # libgit2 (used by the Rust git2 crate) enforces the same safe.directory check

--- a/docker/git-service.Dockerfile
+++ b/docker/git-service.Dockerfile
@@ -5,6 +5,9 @@
 # producing a fully musl-linked binary that runs on Alpine without glibc.
 FROM rust:1.94-alpine AS builder
 
+# Expose the BuildKit-provided TARGETARCH so we can key per-architecture caches.
+ARG TARGETARCH
+
 # pkgconf   – pkg-config shim for openssl-sys
 # openssl-dev / openssl-libs-static – headers + static .a for OPENSSL_STATIC=1
 # cmake + make – required by libgit2-sys bundled build (no system libgit2)
@@ -31,9 +34,9 @@ RUN mkdir src && \
     echo "pub fn lib() {}" > src/lib.rs
 
 # Build dependencies
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/build/target \
+RUN --mount=type=cache,id=cargo-registry-$TARGETARCH,target=/usr/local/cargo/registry \
+    --mount=type=cache,id=cargo-git-$TARGETARCH,target=/usr/local/cargo/git \
+    --mount=type=cache,id=cargo-target-$TARGETARCH,target=/build/target \
     cargo build --release && \
     rm -rf src
 
@@ -43,9 +46,9 @@ COPY git-server/src ./src
 # Build application.
 # Refresh mtimes for all source files so Cargo invalidates dummy artifacts
 # from the dependency-caching step and recompiles the real crate.
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/build/target \
+RUN --mount=type=cache,id=cargo-registry-$TARGETARCH,target=/usr/local/cargo/registry \
+    --mount=type=cache,id=cargo-git-$TARGETARCH,target=/usr/local/cargo/git \
+    --mount=type=cache,id=cargo-target-$TARGETARCH,target=/build/target \
     find src -type f -name '*.rs' -exec touch {} + && \
     cargo build --release && \
     cp /build/target/release/gitstore-server /build/gitstore-server && \


### PR DESCRIPTION
### Motivation
- Break the monolithic image build into per-image jobs to enable parallel builds and more granular caching for `git-service`, `api`, and `admin` images.
- Improve multi-arch build reliability and speed by leveraging BuildKit cache mounts and scoped GitHub Actions cache layers.
- Add explicit BuildKit syntax and cache mounts in Dockerfiles to reduce dependency fetch times and avoid qemu/npm issues during multi-arch builds.

### Description
- Update `/.github/workflows/cd.yml` to replace the single `build-images` job with three jobs: `build-git-service-image`, `build-api-image`, and `build-admin-image`, and update `deploy-staging`/`deploy-production` `needs` to depend on the three new jobs.
- Add scoped GHA cache usage in the workflow by setting `cache-from` and `cache-to` with `scope=` per image (`git-service`, `api`, `admin`).
- Add `# syntax=docker/dockerfile:1.7` to Dockerfiles and introduce BuildKit cache mounts for package managers and build caches: npm cache in `docker/admin.Dockerfile`, Go module and build caches in `docker/api.Dockerfile`, and Cargo/target caches in `docker/git-service.Dockerfile`.
- Minor Dockerfile improvements including preserving existing runtime behavior, ensuring `CMD` newline consistency, and using cached builds to accelerate rebuilds while keeping multi-arch support.

### Testing
- No automated tests were executed as part of this change in the provided rollout; CI workflow changes are expected to be validated when the workflow runs on the next push or tag.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e3ae76974483359bd7ba80303c4387)