### PR TITLE
chore(license): enforce TypeScript and JavaScript source headers

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -5,4 +5,5 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 "$REPO_ROOT/scripts/check-go-license-headers.sh" --staged
 "$REPO_ROOT/scripts/check-rust-license-headers.sh" --staged
+"$REPO_ROOT/scripts/check-js-license-headers.sh" --staged
 

--- a/.github/workflows/js-license-headers.yml
+++ b/.github/workflows/js-license-headers.yml
@@ -1,0 +1,47 @@
+name: JavaScript TypeScript License Headers
+
+on:
+  pull_request:
+    paths:
+      - '**/*.ts'
+      - '**/*.tsx'
+      - '**/*.js'
+      - '**/*.jsx'
+      - '**/*.mjs'
+      - '**/*.cjs'
+      - 'scripts/check-js-license-headers.sh'
+      - '.github/workflows/js-license-headers.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - '**/*.ts'
+      - '**/*.tsx'
+      - '**/*.js'
+      - '**/*.jsx'
+      - '**/*.mjs'
+      - '**/*.cjs'
+      - 'scripts/check-js-license-headers.sh'
+      - '.github/workflows/js-license-headers.yml'
+
+jobs:
+  check-js-license-headers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify all JS and TS files include headers (push)
+        if: github.event_name == 'push'
+        run: ./scripts/check-js-license-headers.sh --all
+
+      - name: Fetch pull request base branch
+        if: github.event_name == 'pull_request'
+        run: git fetch origin "${{ github.base_ref }}"
+
+      - name: Verify changed JS and TS files include current-year headers (pull request)
+        if: github.event_name == 'pull_request'
+        run: ./scripts/check-js-license-headers.sh --diff-base "origin/${{ github.base_ref }}"
+

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ yarn-error.log*
 !.vscode/tasks.json
 !.vscode/go.code-snippets
 !.vscode/rust.code-snippets
+!.vscode/javascript-typescript.code-snippets
 .idea/
 *.swp
 *.swo

--- a/.vscode/javascript-typescript.code-snippets
+++ b/.vscode/javascript-typescript.code-snippets
@@ -1,0 +1,14 @@
+{
+  "JS TS AGPL Header": {
+    "prefix": "gitjshdr",
+    "scope": "javascript,typescript,javascriptreact,typescriptreact",
+    "description": "Insert GitStore AGPL header",
+    "body": [
+      "// SPDX-License-Identifier: AGPL-3.0-or-later",
+      "// Copyright (c) ${CURRENT_YEAR} GitStore contributors",
+      "",
+      "${0}"
+    ]
+  }
+}
+

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -24,6 +24,18 @@
       "type": "shell",
       "command": "${workspaceFolder}/scripts/check-rust-license-headers.sh --all",
       "problemMatcher": []
+    },
+    {
+      "label": "js:check-license-headers-staged",
+      "type": "shell",
+      "command": "${workspaceFolder}/scripts/check-js-license-headers.sh --staged",
+      "problemMatcher": []
+    },
+    {
+      "label": "js:check-license-headers-all",
+      "type": "shell",
+      "command": "${workspaceFolder}/scripts/check-js-license-headers.sh --all",
+      "problemMatcher": []
     }
   ]
 }

--- a/gitstore-admin/astro.config.mjs
+++ b/gitstore-admin/astro.config.mjs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
 

--- a/gitstore-admin/playwright.config.ts
+++ b/gitstore-admin/playwright.config.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 import { defineConfig, devices } from '@playwright/test';
 
 /**

--- a/gitstore-admin/src/components/App.tsx
+++ b/gitstore-admin/src/components/App.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 import React, { type ReactNode, useMemo } from 'react';
 import { Provider as UrqlProvider } from 'urql';
 import { AuthProvider } from '../lib/auth-context';

--- a/gitstore-admin/src/components/Header.tsx
+++ b/gitstore-admin/src/components/Header.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 import React, { useState, useEffect } from 'react';
 import { useAuth } from '../lib/auth-context';
 import { PublishButton } from './shared/PublishButton';

--- a/gitstore-admin/src/components/ProtectedRoute.tsx
+++ b/gitstore-admin/src/components/ProtectedRoute.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 import React, { useEffect, type ReactNode } from 'react';
 import { useAuth } from '../lib/auth-context';
 

--- a/gitstore-admin/src/components/categories/CategoriesPage.tsx
+++ b/gitstore-admin/src/components/categories/CategoriesPage.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 import React from 'react';
 import { App } from '../App';
 import { ProtectedRoute } from '../ProtectedRoute';

--- a/gitstore-admin/src/components/categories/CategoryForm.tsx
+++ b/gitstore-admin/src/components/categories/CategoryForm.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 import React, { useState, useEffect } from 'react';
 import { MarkdownEditor } from '../shared/MarkdownEditor';
 

--- a/gitstore-admin/src/components/categories/CategoryList.tsx
+++ b/gitstore-admin/src/components/categories/CategoryList.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 import React, { useState, useEffect } from 'react';
 import { CategoryTree } from './CategoryTree';
 import { LoadingSpinner } from '../shared/LoadingSpinner';

--- a/gitstore-admin/src/components/categories/CategoryTree.tsx
+++ b/gitstore-admin/src/components/categories/CategoryTree.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 import React, { useState } from 'react';
 import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautiful-dnd';
 

--- a/gitstore-admin/src/components/collections/CollectionForm.tsx
+++ b/gitstore-admin/src/components/collections/CollectionForm.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 import React, { useState } from 'react';
 import { MarkdownEditor } from '../shared/MarkdownEditor';
 import { ProductSelector } from './ProductSelector';

--- a/gitstore-admin/src/components/collections/CollectionList.tsx
+++ b/gitstore-admin/src/components/collections/CollectionList.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 import React, { useState, useEffect } from 'react';
 import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautiful-dnd';
 import { LoadingSpinner } from '../shared/LoadingSpinner';

--- a/gitstore-admin/src/components/collections/CollectionsPage.tsx
+++ b/gitstore-admin/src/components/collections/CollectionsPage.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 import React from 'react';
 import { App } from '../App';
 import { ProtectedRoute } from '../ProtectedRoute';

--- a/gitstore-admin/src/components/collections/ProductSelector.tsx
+++ b/gitstore-admin/src/components/collections/ProductSelector.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 import React, { useState, useEffect } from 'react';
 import { useQuery } from 'urql';
 

--- a/gitstore-admin/src/components/products/CreateProductPage.tsx
+++ b/gitstore-admin/src/components/products/CreateProductPage.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 import React, { useState } from 'react';
 import { ProductForm } from './ProductForm';
 

--- a/gitstore-admin/src/components/products/CreateProductRoutePage.tsx
+++ b/gitstore-admin/src/components/products/CreateProductRoutePage.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 import React from 'react';
 import { App } from '../App';
 import { ProtectedRoute } from '../ProtectedRoute';

--- a/gitstore-admin/src/components/products/EditProductPage.tsx
+++ b/gitstore-admin/src/components/products/EditProductPage.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 import React, { useState, useEffect } from 'react';
 import { ProductForm } from './ProductForm';
 import { ConflictModal } from '../shared/ConflictModal';

--- a/gitstore-admin/src/components/products/EditProductRoutePage.tsx
+++ b/gitstore-admin/src/components/products/EditProductRoutePage.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 import React from 'react';
 import { App } from '../App';
 import { ProtectedRoute } from '../ProtectedRoute';

--- a/gitstore-admin/src/components/products/ProductForm.tsx
+++ b/gitstore-admin/src/components/products/ProductForm.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 import React, { useState, useEffect } from 'react';
 import { MarkdownEditor } from '../shared/MarkdownEditor';
 

--- a/gitstore-admin/src/components/products/ProductList.tsx
+++ b/gitstore-admin/src/components/products/ProductList.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { LoadingSpinner } from '../shared/LoadingSpinner';

--- a/gitstore-admin/src/components/products/ProductsPage.tsx
+++ b/gitstore-admin/src/components/products/ProductsPage.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 import React from 'react';
 import { App } from '../App';
 import { ProtectedRoute } from '../ProtectedRoute';

--- a/gitstore-admin/src/components/shared/ConflictModal.tsx
+++ b/gitstore-admin/src/components/shared/ConflictModal.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 import React from 'react';
 
 interface Conflict {

--- a/gitstore-admin/src/components/shared/ErrorBoundary.tsx
+++ b/gitstore-admin/src/components/shared/ErrorBoundary.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 import React, { Component, ErrorInfo, ReactNode } from 'react';
 
 interface Props {

--- a/gitstore-admin/src/components/shared/LoadingSpinner.tsx
+++ b/gitstore-admin/src/components/shared/LoadingSpinner.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 import React, { useEffect } from 'react';
 
 // Inject spin keyframe once

--- a/gitstore-admin/src/components/shared/MarkdownEditor.tsx
+++ b/gitstore-admin/src/components/shared/MarkdownEditor.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 import React, { useState } from 'react';
 
 interface MarkdownEditorProps {

--- a/gitstore-admin/src/components/shared/PublishButton.tsx
+++ b/gitstore-admin/src/components/shared/PublishButton.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 import React, { useState } from 'react';
 
 interface PublishButtonProps {

--- a/gitstore-admin/src/components/shared/PublishModal.tsx
+++ b/gitstore-admin/src/components/shared/PublishModal.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 import React, { useState } from 'react';
 
 interface PublishModalProps {

--- a/gitstore-admin/src/env.d.ts
+++ b/gitstore-admin/src/env.d.ts
@@ -1,2 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 /// <reference path="../.astro/types.d.ts" />
 /// <reference types="vite/client" />

--- a/gitstore-admin/src/lib/auth-context.tsx
+++ b/gitstore-admin/src/lib/auth-context.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 import React, { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react';
 import { logger } from './logger';
 

--- a/gitstore-admin/src/lib/logger.ts
+++ b/gitstore-admin/src/lib/logger.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 // Structured logging utilities for Admin UI
 
 type LogLevel = 'debug' | 'info' | 'warn' | 'error';

--- a/gitstore-admin/src/lib/mutation-hooks.ts
+++ b/gitstore-admin/src/lib/mutation-hooks.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 /**
  * Custom hooks for mutations with urql
  * These hooks wrap urql useMutation for consistent error handling

--- a/gitstore-admin/src/lib/optimistic-updates.ts
+++ b/gitstore-admin/src/lib/optimistic-updates.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 // NOTE: This file contains optimistic update helpers that were originally for Apollo Client.
 // With urql, optimistic updates are handled differently. These functions are kept for
 // reference but may not be actively used. urql uses simpler cache updates.

--- a/gitstore-admin/src/lib/publish.ts
+++ b/gitstore-admin/src/lib/publish.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 import { Client } from 'urql';
 
 // Types matching GraphQL schema

--- a/gitstore-admin/src/lib/urql-client.ts
+++ b/gitstore-admin/src/lib/urql-client.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 // urql Client setup for GraphQL API
 
 import { createClient, fetchExchange, cacheExchange, type Client } from 'urql';

--- a/gitstore-admin/src/lib/validation.example.ts
+++ b/gitstore-admin/src/lib/validation.example.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 /**
  * Example usage of validation library
  * This file demonstrates how to use validators in components

--- a/gitstore-admin/src/lib/validation.ts
+++ b/gitstore-admin/src/lib/validation.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 /**
  * Client-side validation library
  * Validates required fields, formats, and constraints before mutation submission

--- a/gitstore-admin/src/pages/api/health.ts
+++ b/gitstore-admin/src/pages/api/health.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 // Health check endpoint for admin UI
 import type { APIRoute } from 'astro';
 

--- a/gitstore-admin/src/pages/api/ready.ts
+++ b/gitstore-admin/src/pages/api/ready.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 // Readiness check endpoint for admin UI
 import type { APIRoute } from 'astro';
 

--- a/gitstore-admin/tests/e2e/category_reorder.spec.ts
+++ b/gitstore-admin/tests/e2e/category_reorder.spec.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 import { test, expect } from '@playwright/test';
 
 /**

--- a/gitstore-admin/tests/e2e/debug-console.spec.ts
+++ b/gitstore-admin/tests/e2e/debug-console.spec.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 import { test, expect } from '@playwright/test';
 
 test('debug console errors', async ({ page }) => {

--- a/gitstore-admin/tests/e2e/product_crud.spec.ts
+++ b/gitstore-admin/tests/e2e/product_crud.spec.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 import { test, expect } from '@playwright/test';
 
 /**

--- a/gitstore-admin/tests/e2e/request_tracing.spec.ts
+++ b/gitstore-admin/tests/e2e/request_tracing.spec.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
 import { test, expect } from '@playwright/test';
 
 /**

--- a/scripts/check-js-license-headers.sh
+++ b/scripts/check-js-license-headers.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+CURRENT_YEAR="$(date +%Y)"
+LICENSE_ID_LINE='// SPDX-License-Identifier: AGPL-3.0-or-later'
+COPYRIGHT_REGEX='^// Copyright \(c\) ([0-9]{4})(-([0-9]{4}))? GitStore contributors$'
+
+MODE="all"
+DIFF_BASE=""
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/check-js-license-headers.sh [--all | --staged | --diff-base <ref>]
+
+Checks JavaScript/TypeScript files for required license headers.
+
+Modes:
+  --all               Check all tracked JS/TS files in the repository (default)
+  --staged            Check only staged added/modified JS/TS files
+  --diff-base <ref>   Check added/modified JS/TS files in <ref>...HEAD
+
+Checked extensions: .ts, .tsx, .js, .jsx, .mjs, .cjs
+
+Rules:
+  1. All checked files must include:
+     // SPDX-License-Identifier: AGPL-3.0-or-later
+     // Copyright (c) <year or year-year> GitStore contributors
+  2. For changed files (--staged / --diff-base), the copyright year must include
+     the current year.
+
+Generated files (containing "Code generated", "AUTO-GENERATED", or
+"DO NOT EDIT" in the first 12 lines) are skipped.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --all)
+      MODE="all"
+      shift
+      ;;
+    --staged)
+      MODE="staged"
+      shift
+      ;;
+    --diff-base)
+      MODE="diff"
+      DIFF_BASE="${2:-}"
+      if [[ -z "$DIFF_BASE" ]]; then
+        echo "error: --diff-base requires a git ref" >&2
+        exit 2
+      fi
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+cd "$REPO_ROOT"
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "error: must run inside a git repository" >&2
+  exit 2
+fi
+
+is_generated_file() {
+  local file="$1"
+  local head_lines
+  head_lines="$(head -n 12 "$file" 2>/dev/null || true)"
+  grep -Eqi 'Code generated|AUTO-GENERATED|DO NOT EDIT' <<<"$head_lines"
+}
+
+extract_copyright_line() {
+  local file="$1"
+  head -n 14 "$file" | grep -E '^// Copyright \(c\) ' | head -n 1 || true
+}
+
+current_year_present() {
+  local line="$1"
+  if [[ "$line" =~ ^//\ Copyright\ \(c\)\ ([0-9]{4})(-([0-9]{4}))?\ GitStore\ contributors$ ]]; then
+    local start_year="${BASH_REMATCH[1]}"
+    local end_year="${BASH_REMATCH[3]:-${BASH_REMATCH[1]}}"
+    if (( end_year == CURRENT_YEAR )); then
+      return 0
+    fi
+    if (( start_year == CURRENT_YEAR )); then
+      return 0
+    fi
+  fi
+  return 1
+}
+
+collect_files_all() {
+  git ls-files '*.ts' '*.tsx' '*.js' '*.jsx' '*.mjs' '*.cjs'
+}
+
+collect_files_staged_or_diff() {
+  local target="$1"
+  local git_cmd=(git diff --name-status --diff-filter=AMR)
+
+  if [[ "$target" == "staged" ]]; then
+    git_cmd+=(--cached)
+  else
+    git_cmd+=("${DIFF_BASE}...HEAD")
+  fi
+
+  git_cmd+=(-- '*.ts' '*.tsx' '*.js' '*.jsx' '*.mjs' '*.cjs')
+
+  "${git_cmd[@]}" | while read -r status p1 p2; do
+    case "$status" in
+      A|M)
+        printf '%s\t%s\n' "$status" "$p1"
+        ;;
+      R*)
+        printf 'M\t%s\n' "$p2"
+        ;;
+    esac
+  done
+}
+
+failures=0
+checked=0
+
+check_file() {
+  local status="$1"
+  local file="$2"
+
+  if [[ ! -f "$file" ]]; then
+    return
+  fi
+
+  if is_generated_file "$file"; then
+    return
+  fi
+
+  checked=$((checked + 1))
+
+  if ! head -n 14 "$file" | grep -Fxq "$LICENSE_ID_LINE"; then
+    echo "[FAIL] $file: missing SPDX license identifier" >&2
+    failures=$((failures + 1))
+    return
+  fi
+
+  local copyright_line
+  copyright_line="$(extract_copyright_line "$file")"
+
+  if [[ -z "$copyright_line" ]]; then
+    echo "[FAIL] $file: missing copyright line" >&2
+    failures=$((failures + 1))
+    return
+  fi
+
+  if ! [[ "$copyright_line" =~ $COPYRIGHT_REGEX ]]; then
+    echo "[FAIL] $file: invalid copyright format" >&2
+    failures=$((failures + 1))
+    return
+  fi
+
+  if [[ "$status" == "A" || "$status" == "M" ]]; then
+    if ! current_year_present "$copyright_line"; then
+      echo "[FAIL] $file: changed files must include current year ($CURRENT_YEAR)" >&2
+      failures=$((failures + 1))
+      return
+    fi
+  fi
+}
+
+if [[ "$MODE" == "all" ]]; then
+  while read -r file; do
+    [[ -n "$file" ]] || continue
+    check_file "ALL" "$file"
+  done < <(collect_files_all)
+else
+  while IFS=$'\t' read -r status file; do
+    [[ -n "$file" ]] || continue
+    check_file "$status" "$file"
+  done < <(collect_files_staged_or_diff "$MODE")
+fi
+
+if (( failures > 0 )); then
+  echo "Checked $checked file(s): $failures failure(s)." >&2
+  exit 1
+fi
+
+echo "JS/TS license header check passed ($checked file(s) checked)."
+

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -7,6 +7,7 @@ cd "$REPO_ROOT"
 git config core.hooksPath .githooks
 chmod +x .githooks/pre-commit scripts/check-go-license-headers.sh
 chmod +x scripts/check-rust-license-headers.sh
+chmod +x scripts/check-js-license-headers.sh
 
 echo "Git hooks installed (core.hooksPath=.githooks)."
 


### PR DESCRIPTION
## Summary
- add automated TypeScript/JavaScript license header verification for all tracked files and changed files
- extend the shared hook/CI/IDE workflow on top of the Go and Rust header tooling
- backfill AGPL headers across existing TypeScript and JavaScript sources
- keep docs changes in the Go PR branch as requested
## Testing
- ./scripts/check-js-license-headers.sh --all
