### PR TITLE
Potential fix for code scanning alert no. 38: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,6 +15,9 @@ on:
         options:
           - staging
           - production
+permissions:
+  contents: read
+  packages: write
 concurrency:
   group: deploy-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/gitstore-dev/GitStore/security/code-scanning/38](https://github.com/gitstore-dev/GitStore/security/code-scanning/38)

Add an explicit top-level `permissions` block in `.github/workflows/cd.yml` so all jobs, including `rollback`, inherit restricted token access by default.

Best minimal non-breaking fix for this file:
- Insert `permissions:` after the trigger/input section and before `concurrency:`.
- Use least privilege baseline:
  - `contents: read` (needed by checkout and general repo read access)
  - `packages: write` (required for pushing images to GHCR in build jobs)

This preserves current behavior (build/push still works) while avoiding broad default token permissions. If later you want tighter hardening, you can reduce workflow-level permissions and add job-specific overrides (for example `contents: write` only for release creation), but the single best fix here is a clear explicit workflow-level baseline.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
