### PR TITLE
Potential fix for code scanning alert no. 40: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
   merge_group:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
@@ -125,6 +128,9 @@ jobs:
   security-scan:
     name: Security Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/gitstore-dev/GitStore/security/code-scanning/40](https://github.com/gitstore-dev/GitStore/security/code-scanning/40)

Add explicit `permissions` in `.github/workflows/ci.yml` to enforce least privilege.

Best fix here (without changing functionality) is:

- Add a **workflow-level** `permissions` block with `contents: read` so all jobs get a safe default.
- Add a **job-level** `permissions` block for `security-scan` with:
  - `contents: read` (checkout/read repository)
  - `security-events: write` (required to upload SARIF results)

This keeps all non-security jobs minimally scoped while allowing the security upload step to continue working.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
