### PR TITLE
Potential fix for code scanning alert no. 61: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -175,6 +175,8 @@ jobs:
   deploy-staging:
     name: Deploy to Staging
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [build-git-service-image, build-api-image, build-admin-image]
     if: github.ref == 'refs/heads/main' || github.event.inputs.environment == 'staging'
     environment:


### PR DESCRIPTION
Potential fix for [https://github.com/gitstore-dev/GitStore/security/code-scanning/61](https://github.com/gitstore-dev/GitStore/security/code-scanning/61)

Add an explicit `permissions` block to the `deploy-staging` job in `.github/workflows/cd.yml`, scoped to least privilege.  
For this job, the minimal needed permission is `contents: read` (required by `actions/checkout`). This preserves current behavior while preventing inherited broader token scopes.

Best single fix in this snippet:
- Edit `.github/workflows/cd.yml`
- In job `deploy-staging` (around lines 176–183), insert:
  ```yml
  permissions:
    contents: read
  ```
  directly under `runs-on` (before `needs`/`if`/`environment`).

No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
