### PR TITLE
Potential fix for code scanning alert no. 62: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,5 +1,8 @@
 name: CD
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]
@@ -201,6 +204,8 @@ jobs:
   deploy-production:
     name: Deploy to Production
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: [build-git-service-image, build-api-image, build-admin-image, deploy-staging]
     if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.environment == 'production'
     environment:


### PR DESCRIPTION
Potential fix for [https://github.com/gitstore-dev/GitStore/security/code-scanning/62](https://github.com/gitstore-dev/GitStore/security/code-scanning/62)

Add an explicit top-level `permissions` block in `.github/workflows/cd.yml` to enforce least privilege by default, and then grant only the extra permission needed by this workflow’s release step.

Best fix here (without changing behavior):
- Set workflow-level default to `contents: read`.
- Add job-level permissions for `deploy-production` with `contents: write` (needed to create GitHub Releases), while keeping other jobs on read-only by default.

File/region to change:
- `.github/workflows/cd.yml`
  1. Insert root `permissions:` after `name: CD`.
  2. Insert `permissions:` under `deploy-production` job (near `runs-on`).

No imports/dependencies/methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
