### PR TITLE
Potential fix for code scanning alert no. 107: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
   merge_group:
     branches: [ main ]
 
+permissions:
+  contents: read
+  security-events: write
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1


### PR DESCRIPTION
Potential fix for [https://github.com/gitstore-dev/GitStore/security/code-scanning/107](https://github.com/gitstore-dev/GitStore/security/code-scanning/107)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit least-privilege defaults.  
Best single fix without changing behavior:

- At workflow root (after `on:` block, before `env:`), add:
  - `contents: read` (needed for checkout/read repo contents)
  - `security-events: write` (needed by `github/codeql-action/upload-sarif` in `security-scan`)

This preserves existing functionality (including SARIF upload) while limiting token scopes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
