### PR TITLE
Potential fix for code scanning alert no. 93: DOM text reinterpreted as HTML

### DIFF
--- a/gitstore-admin/package-lock.json
+++ b/gitstore-admin/package-lock.json
@@ -15,7 +15,8 @@
         "react-beautiful-dnd": "^13.1.1",
         "react-dom": "^18.2.0",
         "urql": "^5.0.1",
-        "uuid": "^9.0.1"
+        "uuid": "^9.0.1",
+        "dompurify": "^3.2.6"
       },
       "devDependencies": {
         "@graphql-codegen/cli": "^7.0.0",
@@ -10318,6 +10319,9 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6"
     }
   }
 }

--- a/gitstore-admin/package.json
+++ b/gitstore-admin/package.json
@@ -18,7 +18,8 @@
     "react-beautiful-dnd": "^13.1.1",
     "react-dom": "^18.2.0",
     "urql": "^5.0.1",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "dompurify": "^3.2.6"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^7.0.0",

--- a/gitstore-admin/src/components/shared/MarkdownEditor.tsx
+++ b/gitstore-admin/src/components/shared/MarkdownEditor.tsx
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 GitStore contributors
 
 import React, { useState } from 'react';
+import DOMPurify from 'dompurify';
 
 interface MarkdownEditorProps {
   value: string;
@@ -94,6 +95,8 @@ export function MarkdownEditor({
 
     return html;
   };
+
+  const sanitizedPreviewHtml = DOMPurify.sanitize(renderMarkdown(value));
 
   return (
     <div style={styles.container}>
@@ -220,7 +223,7 @@ export function MarkdownEditor({
         ) : (
           <div
             style={styles.preview}
-            dangerouslySetInnerHTML={{ __html: renderMarkdown(value) }}
+            dangerouslySetInnerHTML={{ __html: sanitizedPreviewHtml }}
           />
         )}
       </div>


### PR DESCRIPTION
Potential fix for [https://github.com/gitstore-dev/GitStore/security/code-scanning/93](https://github.com/gitstore-dev/GitStore/security/code-scanning/93)

Use a proven HTML sanitizer on the rendered markdown output **before** passing it to `dangerouslySetInnerHTML`.  
Best fix with minimal behavior change:

1. In `gitstore-admin/src/components/shared/MarkdownEditor.tsx`, import `DOMPurify`.
2. Keep existing markdown conversion logic.
3. Sanitize `renderMarkdown(value)` result using `DOMPurify.sanitize(...)`.
4. Use sanitized string in `dangerouslySetInnerHTML`.

This addresses all variants because all tainted flows converge at the same sink in `MarkdownEditor`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
