### PR TITLE
[codex] Add root Makefile workflows and faster git-service lifecycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ coverage/
 # Logs
 *.log
 logs/
+.gitstore/
 
 .claude/settings.json
 test-repos/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,33 @@ Auto-generated from all feature plans. Last updated: 2026-03-26
 ## Commands
 
 ### Workspace
+- `make help` — list root commands and common variables.
+- `make git` — run `gitstore-git-service` locally in the foreground using `GIT_DATA_DIR` (default: `.gitstore/repos`).
+- `make api` — run `gitstore-api` locally in the foreground. Requires `gitstore-api/.env` or shell env for required auth secrets.
+- `make dev` — run the native git service and API together in the foreground with shutdown trapping.
+- `make compose` — run the core Docker Compose stack (API + git service) in the foreground.
+- `DETACH=1 make compose` — run the core Docker Compose stack in the background.
+- `make scylla` — run only local Scylla services from `compose.yml` + `compose.scylla.yml`.
+- `make compose-scylla` — run the full core stack with Scylla from `compose.yml` + `compose.scylla.yml`.
+- `DETACH=1 make scylla` and `DETACH=1 make compose-scylla` — run those compose targets in the background.
+- `make ps`, `make logs`, `make stop`, `make down` — compose lifecycle helpers. Use `SERVICE=<name>` with `logs` or `stop` to scope the command.
+- `make bootstrap-token ADMIN_PASSWORD=<password>` — authenticate against GraphQL and print/cache a bootstrap bearer token.
+- `make bootstrap ADMIN_PASSWORD=<password>` — create the default namespace and repository through the running API.
+- `make bootstrap-namespace` / `make bootstrap-repository` — create only one bootstrap resource. `bootstrap-repository` requires the namespace to exist.
+- `make git-clean-data CONFIRM=1` — remove the native local git-service repository data directory only; does not remove Docker volumes.
+- `make build`, `make test`, `make lint`, `make license-check`, `make pr-ready` — aggregate development and PR readiness checks.
+- `make admin-compose`, `make admin-stop`, `make admin-down`, `make admin-logs` — optional admin compose wrappers.
+
+Common bootstrap variables:
+- `API_URL ?= http://localhost:4000/graphql`
+- `ADMIN_USERNAME ?= admin`
+- `ADMIN_PASSWORD` is required unless `BOOTSTRAP_TOKEN` is provided or a cached bootstrap token exists.
+- `BOOTSTRAP_TOKEN` overrides login/cached-token lookup.
+- `NAMESPACE ?= gitstore`
+- `NAMESPACE_DISPLAY_NAME ?= GitStore`
+- `NAMESPACE_TIER ?= USER`
+- `REPOSITORY ?= catalog`
+- `DEFAULT_BRANCH ?= main`
 
 ## Code Style
 
@@ -33,42 +60,12 @@ Auto-generated from all feature plans. Last updated: 2026-03-26
 <!-- MANUAL ADDITIONS START -->
 ## Development Guidelines
 
-- Before creating a PR do the following checks:
+- The root `Makefile` is the canonical command interface for this repository. Future repo-level commands must be added to the root `Makefile` and documented in this file.
+
+- Before creating a PR run:
 
   ```bash
-  # Check formatting and clippy for Rust
-  cd gitstore-git-service
-  cargo fmt --all -- --check
-  cargo clippy --all-targets --all-features -- -D warnings
-  cargo build --verbose
-  cargo test --verbose
-
-  # Check formatting and linting for Go
-  cd ../gitstore-api
-  if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then
-      echo "The following files need formatting:"
-      gofmt -s -l .
-      exit 1
-  fi
-  go vet ./...
-  # Setup $GOPATH/bin in PATH if not already
-  go install honnef.co/go/tools/cmd/staticcheck@latest
-  staticcheck ./...
-  go build -v ./...
-  go test -count=1 -v -race -coverprofile=coverage.txt -covermode=atomic ./...
-
-  # Check Go license headers (all files + branch diff)
-  cd ..
-  ./scripts/check-go-license-headers.sh --all
-  ./scripts/check-go-license-headers.sh --diff-base origin/main
-
-  # Check Rust license headers (all files + branch diff)
-  ./scripts/check-rust-license-headers.sh --all
-  ./scripts/check-rust-license-headers.sh --diff-base origin/main
-
-  # Check TypeScript/JavaScript license headers (all files + branch diff)
-  ./scripts/check-js-license-headers.sh --all
-  ./scripts/check-js-license-headers.sh --diff-base origin/main
+  make pr-ready
   ```
 
 - Install git hooks once per clone so staged Go/Rust/TS/JS files are checked automatically:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,284 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 GitStore contributors
+
+.DEFAULT_GOAL := help
+
+ROOT := $(CURDIR)
+API_DIR := $(ROOT)/gitstore-api
+GIT_SERVICE_DIR := $(ROOT)/gitstore-git-service
+
+API_ENV_FILE ?= $(API_DIR)/.env
+GIT_DATA_DIR ?= $(ROOT)/.gitstore/repos
+DIFF_BASE ?= origin/main
+
+COMPOSE_BAKE ?= true
+DETACH_FLAG := $(if $(filter 1 true yes,$(DETACH)),-d,)
+SERVICE ?=
+
+API_URL ?= http://localhost:4000/graphql
+ADMIN_USERNAME ?= admin
+ADMIN_PASSWORD ?=
+BOOTSTRAP_TOKEN ?=
+BOOTSTRAP_TOKEN_CACHE ?= $(ROOT)/.gitstore/bootstrap-token
+NAMESPACE ?= gitstore
+NAMESPACE_DISPLAY_NAME ?= GitStore
+NAMESPACE_TIER ?= USER
+REPOSITORY ?= catalog
+DEFAULT_BRANCH ?= main
+
+export API_URL ADMIN_USERNAME ADMIN_PASSWORD BOOTSTRAP_TOKEN BOOTSTRAP_TOKEN_CACHE
+export NAMESPACE NAMESPACE_DISPLAY_NAME NAMESPACE_TIER REPOSITORY DEFAULT_BRANCH
+
+.PHONY: help git api dev compose scylla compose-scylla ps logs stop down
+.PHONY: build test lint license-check pr-ready
+.PHONY: bootstrap bootstrap-token bootstrap-namespace bootstrap-repository git-clean-data
+.PHONY: admin-compose admin-down admin-stop admin-logs bootstrap-tools
+
+help: ## Show available targets and common variables.
+	@awk 'BEGIN {FS = ":.*##"; printf "GitStore make targets:\n"} /^[a-zA-Z0-9_.-]+:.*##/ {printf "  %-22s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+	@printf "\nCommon variables:\n"
+	@printf "  DETACH=1                  Run compose start targets in the background\n"
+	@printf "  COMPOSE_BAKE=true         Compose build bake setting for Docker Compose\n"
+	@printf "  SERVICE=<name>            Limit logs/stop to one compose service\n"
+	@printf "  GIT_DATA_DIR=%s\n" "$(GIT_DATA_DIR)"
+	@printf "  API_URL=%s\n" "$(API_URL)"
+	@printf "  ADMIN_USERNAME=%s\n" "$(ADMIN_USERNAME)"
+	@printf "  ADMIN_PASSWORD=<password> Required for login unless BOOTSTRAP_TOKEN or cached token is available\n"
+	@printf "  BOOTSTRAP_TOKEN=<token>   Use an existing bearer token for bootstrap\n"
+	@printf "  NAMESPACE=%s REPOSITORY=%s DEFAULT_BRANCH=%s\n" "$(NAMESPACE)" "$(REPOSITORY)" "$(DEFAULT_BRANCH)"
+
+git: ## Run gitstore-git-service locally in the foreground.
+	@mkdir -p "$(GIT_DATA_DIR)"
+	@cd "$(GIT_SERVICE_DIR)" && GITSTORE_GIT__DATA_DIR="$(GIT_DATA_DIR)" cargo run --bin git-service
+
+api: ## Run gitstore-api locally in the foreground.
+	@if [ ! -f "$(API_ENV_FILE)" ] && { [ -z "$${GITSTORE_AUTH__ADMIN__USERNAME:-}" ] || [ -z "$${GITSTORE_AUTH__ADMIN__PASSWORD_HASH:-}" ] || [ -z "$${GITSTORE_AUTH__JWT__SECRET:-}" ]; }; then \
+		echo "make api requires $(API_ENV_FILE) or shell env for GITSTORE_AUTH__ADMIN__USERNAME, GITSTORE_AUTH__ADMIN__PASSWORD_HASH, and GITSTORE_AUTH__JWT__SECRET"; \
+		exit 2; \
+	fi
+	@cd "$(API_DIR)" && go run ./cmd/server
+
+dev: ## Run local git service and API together in the foreground.
+	@if [ ! -f "$(API_ENV_FILE)" ] && { [ -z "$${GITSTORE_AUTH__ADMIN__USERNAME:-}" ] || [ -z "$${GITSTORE_AUTH__ADMIN__PASSWORD_HASH:-}" ] || [ -z "$${GITSTORE_AUTH__JWT__SECRET:-}" ]; }; then \
+		echo "make dev requires $(API_ENV_FILE) or shell env for GITSTORE_AUTH__ADMIN__USERNAME, GITSTORE_AUTH__ADMIN__PASSWORD_HASH, and GITSTORE_AUTH__JWT__SECRET"; \
+		exit 2; \
+	fi
+	@set -u; \
+	mkdir -p "$(GIT_DATA_DIR)"; \
+	tmp=$$(mktemp -d); \
+	fifo="$$tmp/done"; \
+	mkfifo "$$fifo"; \
+	cleanup() { \
+		trap - INT TERM EXIT; \
+		[ -n "$${git_pid:-}" ] && kill "$$git_pid" 2>/dev/null || true; \
+		[ -n "$${api_pid:-}" ] && kill "$$api_pid" 2>/dev/null || true; \
+		[ -n "$${git_pid:-}" ] && wait "$$git_pid" 2>/dev/null || true; \
+		[ -n "$${api_pid:-}" ] && wait "$$api_pid" 2>/dev/null || true; \
+		rm -rf "$$tmp"; \
+	}; \
+	trap 'cleanup; exit 130' INT; \
+	trap 'cleanup; exit 143' TERM; \
+	trap 'cleanup' EXIT; \
+	( set +e; \
+		cd "$(GIT_SERVICE_DIR)" || { printf 'git-service 1\n' > "$$fifo"; exit 0; }; \
+		GITSTORE_GIT__DATA_DIR="$(GIT_DATA_DIR)" cargo run --bin git-service & child=$$!; \
+		trap 'kill "$$child" 2>/dev/null; wait "$$child" 2>/dev/null; exit 143' INT TERM; \
+		wait "$$child"; status=$$?; \
+		printf 'git-service %s\n' "$$status" > "$$fifo"; \
+	) & git_pid=$$!; \
+	( set +e; \
+		cd "$(API_DIR)" || { printf 'api 1\n' > "$$fifo"; exit 0; }; \
+		go run ./cmd/server & child=$$!; \
+		trap 'kill "$$child" 2>/dev/null; wait "$$child" 2>/dev/null; exit 143' INT TERM; \
+		wait "$$child"; status=$$?; \
+		printf 'api %s\n' "$$status" > "$$fifo"; \
+	) & api_pid=$$!; \
+	read service status < "$$fifo"; \
+	echo "$$service exited with status $$status"; \
+	cleanup; \
+	trap - EXIT; \
+	exit "$$status"
+
+compose: ## Run API and git service with Docker Compose.
+	@COMPOSE_BAKE="$(COMPOSE_BAKE)" docker compose -f compose.yml up --build $(DETACH_FLAG)
+
+scylla: ## Run only local Scylla services with Docker Compose.
+	@COMPOSE_BAKE="$(COMPOSE_BAKE)" docker compose -f compose.yml -f compose.scylla.yml up $(DETACH_FLAG) scylla scylla-init
+
+compose-scylla: ## Run API, git service, and Scylla with Docker Compose.
+	@COMPOSE_BAKE="$(COMPOSE_BAKE)" docker compose -f compose.yml -f compose.scylla.yml up --build $(DETACH_FLAG)
+
+ps: ## Show compose service status.
+	@COMPOSE_BAKE="$(COMPOSE_BAKE)" docker compose -f compose.yml -f compose.scylla.yml -f compose.admin.yml ps
+
+logs: ## Follow compose logs; optionally pass SERVICE=<name>.
+	@COMPOSE_BAKE="$(COMPOSE_BAKE)" docker compose -f compose.yml -f compose.scylla.yml -f compose.admin.yml logs -f $(SERVICE)
+
+stop: ## Stop compose services; optionally pass SERVICE=<name>.
+	@COMPOSE_BAKE="$(COMPOSE_BAKE)" docker compose -f compose.yml -f compose.scylla.yml -f compose.admin.yml stop $(SERVICE)
+
+down: ## Stop and remove compose services and networks.
+	@COMPOSE_BAKE="$(COMPOSE_BAKE)" docker compose -f compose.yml -f compose.scylla.yml -f compose.admin.yml down
+
+build: ## Build Rust and Go services.
+	@cd "$(GIT_SERVICE_DIR)" && cargo build --verbose
+	@cd "$(API_DIR)" && go build -v ./...
+
+test: ## Run Rust and Go test suites.
+	@cd "$(GIT_SERVICE_DIR)" && cargo test --verbose
+	@cd "$(API_DIR)" && go test -count=1 -v -race -coverprofile=coverage.txt -covermode=atomic ./...
+
+lint: ## Run Rust formatting/clippy and Go formatting/vet/staticcheck.
+	@cd "$(GIT_SERVICE_DIR)" && cargo fmt --all -- --check
+	@cd "$(GIT_SERVICE_DIR)" && cargo clippy --all-targets --all-features -- -D warnings
+	@if [ "$$(cd "$(API_DIR)" && gofmt -s -l . | wc -l | tr -d ' ')" != "0" ]; then \
+		echo "The following files need formatting:"; \
+		cd "$(API_DIR)" && gofmt -s -l .; \
+		exit 1; \
+	fi
+	@cd "$(API_DIR)" && go vet ./...
+	@cd "$(API_DIR)" && go install honnef.co/go/tools/cmd/staticcheck@latest
+	@cd "$(API_DIR)" && "$$(go env GOPATH)"/bin/staticcheck ./...
+
+license-check: ## Run Go, Rust, and JS/TS license header checks.
+	@./scripts/check-go-license-headers.sh --all
+	@./scripts/check-go-license-headers.sh --diff-base "$(DIFF_BASE)"
+	@./scripts/check-rust-license-headers.sh --all
+	@./scripts/check-rust-license-headers.sh --diff-base "$(DIFF_BASE)"
+	@./scripts/check-js-license-headers.sh --all
+	@./scripts/check-js-license-headers.sh --diff-base "$(DIFF_BASE)"
+
+pr-ready: lint build test license-check ## Run the full PR readiness workflow.
+
+bootstrap: bootstrap-namespace bootstrap-repository ## Create the default namespace and repository through the API.
+
+bootstrap-tools:
+	@command -v curl >/dev/null 2>&1 || { echo "curl is required for bootstrap targets"; exit 127; }
+	@command -v jq >/dev/null 2>&1 || { echo "jq is required for bootstrap targets"; exit 127; }
+
+bootstrap-token: bootstrap-tools ## Login and print/cache a bootstrap bearer token.
+	@if [ -z "$${ADMIN_PASSWORD:-}" ]; then \
+		echo "ADMIN_PASSWORD is required for bootstrap-token"; \
+		exit 2; \
+	fi
+	@mkdir -p "$$(dirname "$${BOOTSTRAP_TOKEN_CACHE}")"
+	@query='mutation Login($$username: String!, $$password: String!) { login(input: { username: $$username, password: $$password }) { session { token } } }'; \
+	payload=$$(jq -n --arg query "$$query" --arg username "$${ADMIN_USERNAME}" --arg password "$${ADMIN_PASSWORD}" '{query: $$query, variables: {username: $$username, password: $$password}}'); \
+	response=$$(curl --silent --show-error --connect-timeout 5 -H 'Content-Type: application/json' --data "$$payload" "$${API_URL}") || { \
+		echo "Failed to reach GitStore API at $${API_URL}. Start it with make compose or make dev."; \
+		exit 1; \
+	}; \
+	if echo "$$response" | jq -e '(.errors // []) | length > 0' >/dev/null; then \
+		echo "$$response" | jq -r '.errors[]?.message' | sed 's/^/GraphQL error: /'; \
+		exit 1; \
+	fi; \
+	token=$$(echo "$$response" | jq -er '.data.login.session.token // empty') || { \
+		echo "Login response did not contain a token. Check ADMIN_USERNAME, ADMIN_PASSWORD, and API_URL."; \
+		exit 1; \
+	}; \
+	printf '%s\n' "$$token"; \
+	printf '%s\n' "$$token" > "$${BOOTSTRAP_TOKEN_CACHE}"; \
+	echo "Token cached at $${BOOTSTRAP_TOKEN_CACHE}" >&2
+
+bootstrap-namespace: bootstrap-tools ## Create only the bootstrap namespace.
+	@set -u; \
+	token="$${BOOTSTRAP_TOKEN:-}"; \
+	if [ -z "$$token" ] && [ -f "$${BOOTSTRAP_TOKEN_CACHE}" ]; then token=$$(cat "$${BOOTSTRAP_TOKEN_CACHE}"); fi; \
+	if [ -z "$$token" ]; then \
+		if [ -z "$${ADMIN_PASSWORD:-}" ]; then \
+			echo "ADMIN_PASSWORD is required unless BOOTSTRAP_TOKEN is provided or $${BOOTSTRAP_TOKEN_CACHE} exists"; \
+			exit 2; \
+		fi; \
+		query='mutation Login($$username: String!, $$password: String!) { login(input: { username: $$username, password: $$password }) { session { token } } }'; \
+		payload=$$(jq -n --arg query "$$query" --arg username "$${ADMIN_USERNAME}" --arg password "$${ADMIN_PASSWORD}" '{query: $$query, variables: {username: $$username, password: $$password}}'); \
+		response=$$(curl --silent --show-error --connect-timeout 5 -H 'Content-Type: application/json' --data "$$payload" "$${API_URL}") || { \
+			echo "Failed to reach GitStore API at $${API_URL}. Start it with make compose or make dev."; \
+			exit 1; \
+		}; \
+		if echo "$$response" | jq -e '(.errors // []) | length > 0' >/dev/null; then \
+			echo "$$response" | jq -r '.errors[]?.message' | sed 's/^/GraphQL error: /'; \
+			exit 1; \
+		fi; \
+		token=$$(echo "$$response" | jq -er '.data.login.session.token // empty') || { echo "Login response did not contain a token."; exit 1; }; \
+	fi; \
+	query='mutation CreateNamespace($$identifier: String!, $$displayName: String, $$tier: NamespaceTier!) { createNamespace(input: { identifier: $$identifier, displayName: $$displayName, tier: $$tier }) { namespace { id identifier tier } } }'; \
+	payload=$$(jq -n --arg query "$$query" --arg identifier "$${NAMESPACE}" --arg displayName "$${NAMESPACE_DISPLAY_NAME}" --arg tier "$${NAMESPACE_TIER}" '{query: $$query, variables: {identifier: $$identifier, displayName: $$displayName, tier: $$tier}}'); \
+	response=$$(curl --silent --show-error --connect-timeout 5 -H 'Content-Type: application/json' -H "Authorization: Bearer $$token" --data "$$payload" "$${API_URL}") || { \
+		echo "Failed to reach GitStore API at $${API_URL}. Start it with make compose or make dev."; \
+		exit 1; \
+	}; \
+	if echo "$$response" | jq -e '(.errors // []) | length > 0' >/dev/null; then \
+		echo "$$response" | jq -r '.errors[]?.message' | sed 's/^/GraphQL error: /'; \
+		exit 1; \
+	fi; \
+	echo "$$response" | jq -r '.data.createNamespace.namespace | "Created namespace \(.identifier) (\(.id))"'
+
+bootstrap-repository: bootstrap-tools ## Create only the bootstrap repository; namespace must already exist.
+	@set -u; \
+	token="$${BOOTSTRAP_TOKEN:-}"; \
+	if [ -z "$$token" ] && [ -f "$${BOOTSTRAP_TOKEN_CACHE}" ]; then token=$$(cat "$${BOOTSTRAP_TOKEN_CACHE}"); fi; \
+	if [ -z "$$token" ]; then \
+		if [ -z "$${ADMIN_PASSWORD:-}" ]; then \
+			echo "ADMIN_PASSWORD is required unless BOOTSTRAP_TOKEN is provided or $${BOOTSTRAP_TOKEN_CACHE} exists"; \
+			exit 2; \
+		fi; \
+		query='mutation Login($$username: String!, $$password: String!) { login(input: { username: $$username, password: $$password }) { session { token } } }'; \
+		payload=$$(jq -n --arg query "$$query" --arg username "$${ADMIN_USERNAME}" --arg password "$${ADMIN_PASSWORD}" '{query: $$query, variables: {username: $$username, password: $$password}}'); \
+		response=$$(curl --silent --show-error --connect-timeout 5 -H 'Content-Type: application/json' --data "$$payload" "$${API_URL}") || { \
+			echo "Failed to reach GitStore API at $${API_URL}. Start it with make compose or make dev."; \
+			exit 1; \
+		}; \
+		if echo "$$response" | jq -e '(.errors // []) | length > 0' >/dev/null; then \
+			echo "$$response" | jq -r '.errors[]?.message' | sed 's/^/GraphQL error: /'; \
+			exit 1; \
+		fi; \
+		token=$$(echo "$$response" | jq -er '.data.login.session.token // empty') || { echo "Login response did not contain a token."; exit 1; }; \
+	fi; \
+	query='query Namespace($$identifier: String!) { namespace(by: { identifier: $$identifier }) { id identifier } }'; \
+	payload=$$(jq -n --arg query "$$query" --arg identifier "$${NAMESPACE}" '{query: $$query, variables: {identifier: $$identifier}}'); \
+	response=$$(curl --silent --show-error --connect-timeout 5 -H 'Content-Type: application/json' -H "Authorization: Bearer $$token" --data "$$payload" "$${API_URL}") || { \
+		echo "Failed to reach GitStore API at $${API_URL}. Start it with make compose or make dev."; \
+		exit 1; \
+	}; \
+	if echo "$$response" | jq -e '(.errors // []) | length > 0' >/dev/null; then \
+		echo "$$response" | jq -r '.errors[]?.message' | sed 's/^/GraphQL error: /'; \
+		exit 1; \
+	fi; \
+	namespace_id=$$(echo "$$response" | jq -er '.data.namespace.id // empty') || { \
+		echo "Namespace \"$${NAMESPACE}\" was not found. Run make bootstrap-namespace first."; \
+		exit 1; \
+	}; \
+	query='mutation CreateRepository($$namespaceId: ID!, $$name: String!, $$defaultBranch: String!) { createRepository(input: { namespaceId: $$namespaceId, name: $$name, defaultBranch: $$defaultBranch }) { repository { id name defaultBranch storagePath namespace { identifier } } } }'; \
+	payload=$$(jq -n --arg query "$$query" --arg namespaceId "$$namespace_id" --arg name "$${REPOSITORY}" --arg defaultBranch "$${DEFAULT_BRANCH}" '{query: $$query, variables: {namespaceId: $$namespaceId, name: $$name, defaultBranch: $$defaultBranch}}'); \
+	response=$$(curl --silent --show-error --connect-timeout 5 -H 'Content-Type: application/json' -H "Authorization: Bearer $$token" --data "$$payload" "$${API_URL}") || { \
+		echo "Failed to reach GitStore API at $${API_URL}. Start it with make compose or make dev."; \
+		exit 1; \
+	}; \
+	if echo "$$response" | jq -e '(.errors // []) | length > 0' >/dev/null; then \
+		echo "$$response" | jq -r '.errors[]?.message' | sed 's/^/GraphQL error: /'; \
+		exit 1; \
+	fi; \
+	echo "$$response" | jq -r '.data.createRepository.repository | .storagePath as $$path | ($$path | split("/")[-1] | sub("\\.git$$"; "")) as $$repoId | "Created repository \(.namespace.identifier)/\(.name) (\(.id))\nClone URL: http://localhost:9418/\($$repoId)"'
+
+git-clean-data: ## Remove native local git-service repository data; requires CONFIRM=1.
+	@if [ "$(CONFIRM)" != "1" ]; then \
+		echo "Refusing to remove $(GIT_DATA_DIR). Re-run with CONFIRM=1."; \
+		exit 2; \
+	fi
+	@if [ -z "$(GIT_DATA_DIR)" ] || [ "$(GIT_DATA_DIR)" = "/" ]; then \
+		echo "Refusing to remove unsafe GIT_DATA_DIR=$(GIT_DATA_DIR)"; \
+		exit 2; \
+	fi
+	@rm -rf "$(GIT_DATA_DIR)"
+
+admin-compose: ## Run the optional admin compose stack.
+	@COMPOSE_BAKE="$(COMPOSE_BAKE)" docker compose -f compose.yml -f compose.admin.yml up --build $(DETACH_FLAG) admin
+
+admin-down: ## Stop and remove the admin compose stack.
+	@COMPOSE_BAKE="$(COMPOSE_BAKE)" docker compose -f compose.yml -f compose.admin.yml down
+
+admin-stop: ## Stop only the admin compose service.
+	@COMPOSE_BAKE="$(COMPOSE_BAKE)" docker compose -f compose.yml -f compose.admin.yml stop admin
+
+admin-logs: ## Follow admin compose logs.
+	@COMPOSE_BAKE="$(COMPOSE_BAKE)" docker compose -f compose.yml -f compose.admin.yml logs -f admin

--- a/README.md
+++ b/README.md
@@ -49,7 +49,20 @@ graph TD
 
 ## Quick Start
 
-See [quickstart](docs/user-guide.md) for a Docker-based quick start.
+Run the core stack from the repository root:
+
+```bash
+make compose DETACH=1
+make ps
+```
+
+Use `make compose` without `DETACH=1` to keep the compose stack in the foreground. After the API is healthy, create a starter namespace and repository:
+
+```bash
+make bootstrap ADMIN_PASSWORD=<admin-password>
+```
+
+See [quickstart](docs/user-guide.md) for the full Docker-based workflow and bootstrap variables.
 
 ## Contributing
 

--- a/compose.yml
+++ b/compose.yml
@@ -21,10 +21,11 @@ services:
     networks:
       - gitstore-network
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO /dev/null --tries=1 --timeout=3 http://127.0.0.1:9418/ 2>&1; test $? -ne 4"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--timeout=1", "--spider", "http://127.0.0.1:9418/health"]
+      interval: 2s
+      timeout: 2s
+      retries: 10
+      start_period: 2s
 
   api:
     image: ghcr.io/gitstore-dev/api

--- a/docs/admin/quickstart.md
+++ b/docs/admin/quickstart.md
@@ -6,20 +6,20 @@
 
 - The core stack must be running. Start it first:
   ```bash
-  docker compose up -d
+  make compose DETACH=1
   ```
 - Verify both core services are healthy:
   ```bash
-  docker compose ps
+  make ps
   # Expected: gitstore-git-service and gitstore-api both "running"
   ```
 
 ## Starting the Full Stack (Core + Admin)
 
-Use the `compose.admin.yml` override together with the base `compose.yml`:
+Use the root Make wrapper:
 
 ```bash
-docker compose -f compose.yml -f compose.admin.yml up -d
+make admin-compose DETACH=1
 ```
 
 **Expected output**:
@@ -34,7 +34,7 @@ gitstore-admin       running             0.0.0.0:3000->3000/tcp
 
 Open **http://localhost:3000** in your browser.
 
-Log in with the credentials configured in `ADMIN_PASSWORD_HASH` (default: `admin123` — change this before any real deployment).
+Log in with the admin credentials configured for `gitstore-api`.
 
 ## Managing Products
 
@@ -72,13 +72,13 @@ This creates a git commit and annotated tag in `gitstore-git-service`, which bro
 ## Stopping the Admin
 
 ```bash
-docker compose -f compose.yml -f compose.admin.yml down
+make admin-down
 ```
 
 To stop only the admin container while keeping the core stack running:
 
 ```bash
-docker compose -f compose.yml -f compose.admin.yml stop admin
+make admin-stop
 ```
 
 ## Troubleshooting
@@ -90,7 +90,7 @@ docker compose -f compose.yml -f compose.admin.yml stop admin
 **Solution**: The admin caches catalogue data. To refresh:
 1. Make git changes via CLI or AI agent
 2. Push and create a new release tag
-3. Wait for the websocket notification (check: `docker compose logs git-service`)
+3. Wait for the websocket notification (check: `make logs SERVICE=git-service`)
 4. Refresh the Admin browser tab
 
 ### Merge conflicts when publishing
@@ -108,7 +108,7 @@ docker compose -f compose.yml -f compose.admin.yml stop admin
 **Problem**: `gitstore-admin` fails to start or exits immediately.
 
 **Checklist**:
-- Is the core stack healthy? Run `docker compose ps` first.
+- Is the core stack healthy? Run `make ps` first.
 - Is `gitstore-api` reachable on port 4000? The admin has a `depends_on: api` health check.
 - Is `GITSTORE_GRAPHQL_URL` set correctly in `compose.admin.yml`? Default: `http://api:4000/graphql`.
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -23,12 +23,14 @@ GitStore is a git-backed ecommerce headless engine with two core services:
 git clone https://github.com/gitstore-dev/gitstore
 cd gitstore
 
-# Start all services with docker compose
-export COMPOSE_BAKE=true
-docker compose up --build -d
+# Start all core services
+make compose DETACH=1
 
 # Check service health
-docker compose ps
+make ps
+
+# Create a starter namespace and repository
+make bootstrap ADMIN_PASSWORD=<admin-password>
 ```
 
 **Expected Output**:
@@ -41,9 +43,9 @@ gitstore-api         running             0.0.0.0:4000->4000/tcp
 ### 2. Access Services
 
 - **GraphQL Playground**: http://localhost:4000/playground
-- **Git Repository (example)**: `http://localhost:9418/<repository_id>` — repositories are created on demand via the `CreateRepository` gRPC call; replace `<repository_id>` with the name provisioned for your catalogue.
+- **Git Repository (example)**: use the clone URL printed by `make bootstrap`. Git HTTP transport is keyed by the internal repository ID.
 
-### 4. Test GraphQL Query
+### 3. Test GraphQL Query
 
 Open http://localhost:4000/playground and run:
 
@@ -74,19 +76,16 @@ query {
 
 #### Step 1: Create and Clone a Catalogue Repository
 
-First, provision a named repository via gRPC (e.g. using `grpcurl`):
+Provision a namespace and repository through the running API:
 
 ```bash
-grpcurl -plaintext -d '{"repository_id":"catalog"}' \
-  -import-path shared/proto/gitstore/git/v1/ \
-  -proto git_service.proto localhost:50051 \
-  gitstore.git.v1.GitService.CreateRepository
+make bootstrap NAMESPACE=gitstore REPOSITORY=catalog ADMIN_PASSWORD=<admin-password>
 ```
 
-Then clone over Smart HTTP:
+Then clone over Smart HTTP using the clone URL printed by `make bootstrap`:
 
 ```bash
-git clone http://localhost:9418/catalog catalogue-work
+git clone http://localhost:9418/<repository-id> catalogue-work
 cd catalogue-work
 ```
 
@@ -377,30 +376,36 @@ query CategoryTree {
 - **Node.js**: 18+ (`node --version`)
 - **Docker**: 24+ (for local development)
 - **Git**: 2.40+
+- **Make, curl, jq**: required for root command wrappers and bootstrap targets
 
 ### Build from Source
+
+Run aggregate build and test checks from the repository root:
+
+```bash
+make build
+make test
+```
 
 #### Git Service (Rust)
 
 ```bash
-cd gitstore-git-service
-cargo build --release
-cargo test
-
-# Run standalone
-cargo run -- --port 9418 --ws-port 8080 --data-dir ./data
+# Run standalone in the foreground
+make git
 ```
 
 #### GraphQL API (Go)
 
 ```bash
-cd gitstore-api
-go mod download
-go generate ./...  # Run gqlgen code generation
-go build -o bin/api ./cmd/server
+# Run standalone in the foreground.
+# Requires gitstore-api/.env or shell env for required auth secrets.
+make api
+```
 
-# Run standalone
-./bin/api --port 4000 --git-ws ws://localhost:8080
+Run both native services together:
+
+```bash
+make dev
 ```
 
 ### Environment Variables
@@ -429,7 +434,11 @@ GITSTORE_LOG__LEVEL=info
 #### Start ScyllaDB (optional, for database-backed development)
 
 ```bash
-docker compose -f compose.yml -f compose.scylla.yml up -d scylla scylla-init
+# Scylla services only
+make scylla DETACH=1
+
+# Full core stack with Scylla
+make compose-scylla DETACH=1
 ```
 
 Scylla-backed Go tests use an externally managed ScyllaDB instance. Start
@@ -441,6 +450,36 @@ GITSTORE_TEST_SCYLLA_ADDR=127.0.0.1:9042 \
   go test -tags scylla -v -timeout 10m ./tests/contract/datastore/... ./internal/datastore/scylla/...
 ```
 
+### Bootstrap and Clean-up
+
+Bootstrap creates resources through the running GraphQL API. It is create-oriented: existing namespaces or repositories fail clearly instead of being updated.
+
+```bash
+# Login and cache a bearer token for later bootstrap commands
+make bootstrap-token ADMIN_PASSWORD=<admin-password>
+
+# Create namespace + repository
+make bootstrap ADMIN_PASSWORD=<admin-password>
+
+# Or create them separately
+make bootstrap-namespace ADMIN_PASSWORD=<admin-password>
+make bootstrap-repository ADMIN_PASSWORD=<admin-password>
+```
+
+Useful bootstrap variables include `API_URL`, `ADMIN_USERNAME`, `BOOTSTRAP_TOKEN`, `NAMESPACE`, `NAMESPACE_DISPLAY_NAME`, `NAMESPACE_TIER`, `REPOSITORY`, and `DEFAULT_BRANCH`.
+
+For native local service data only:
+
+```bash
+make git-clean-data CONFIRM=1
+```
+
+For Docker Compose services:
+
+```bash
+make down
+```
+
 ### Go Licence Headers
 
 All Go source files in this repository should include this header near the top of the file:
@@ -450,27 +489,10 @@ All Go source files in this repository should include this header near the top o
 // Copyright (c) 2026 GitStore contributors
 ```
 
-Use the checker script for enforcement:
+Run the repository license checks through Make:
 
 ```bash
-# All tracked Go files
-./scripts/check-go-license-headers.sh --all
-
-# Only staged added/modified Go files (used by pre-commit)
-./scripts/check-go-license-headers.sh --staged
-
-# Added/modified files compared to your base branch
-./scripts/check-go-license-headers.sh --diff-base origin/main
-
-# Rust files (same modes)
-./scripts/check-rust-license-headers.sh --all
-./scripts/check-rust-license-headers.sh --staged
-./scripts/check-rust-license-headers.sh --diff-base origin/main
-
-# TypeScript/JavaScript files (same modes)
-./scripts/check-js-license-headers.sh --all
-./scripts/check-js-license-headers.sh --staged
-./scripts/check-js-license-headers.sh --diff-base origin/main
+make license-check
 ```
 
 Install repository hooks once per clone:
@@ -509,44 +531,16 @@ CI also enforces this via:
 
 ## Testing
 
-> [!NOTE]
-> The sample tests below are illustrative. Some CI tests are currently placeholders and may differ from the eventual production test suite.
-
-### Contract Tests (GraphQL Schema)
+Run the standard Rust and Go test suites from the repository root:
 
 ```bash
-cd gitstore-api
-go test ./tests/contract/...
+make test
 ```
 
-**Example Test**:
-```go
-func TestProductSchema(t *testing.T) {
-    query := `{ product(by: {sku: "TEST-001"}) { id title } }`
-    resp := executeQuery(query)
-    assert.NoError(t, resp.Errors)
-    assert.Equal(t, "TEST-001", resp.Data.Product.SKU)
-}
-```
-
-### Integration Tests (User Journeys)
+Before opening a PR, run the full readiness workflow:
 
 ```bash
-cd gitstore-git-service
-cargo test --test integration
-```
-
-**Example Test**:
-```rust
-#[test]
-fn test_create_product_workflow() {
-    let repo = TestRepo::new();
-    let product = create_test_product("LAPTOP-001");
-    repo.commit_file("products/electronics/LAPTOP-001.md", product);
-    repo.push().unwrap();
-    let tag = repo.tag("v0.1.0");
-    assert_eq!(tag, "v0.1.0");
-}
+make pr-ready
 ```
 
 ---
@@ -577,7 +571,7 @@ fn test_create_product_workflow() {
 wscat -c ws://localhost:8080
 
 # Check API logs
-docker compose logs api | grep websocket
+make logs SERVICE=api
 
 # Manual cache invalidation
 # TODO returns 404

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -31,6 +31,7 @@ Both workflows use git as the source of truth, ensuring version control, auditab
 ### Prerequisites
 
 - Git installed on your system
+- Make, curl, and jq
 - Docker and Docker Compose (for running GitStore services)
 
 ### Quick Start
@@ -39,18 +40,22 @@ Demo data seeding will be provided in a future feature.
 
 1. **Start GitStore services**:
    ```bash
-   export COMPOSE_BAKE=true
-   docker compose up -d
+   make compose DETACH=1
    ```
 
-3. **Wait for services to be healthy** (10-15 seconds):
+2. **Wait for services to be healthy** (10-15 seconds):
    ```bash
-   docker compose ps
+   make ps
    ```
 
-4. **Clone the catalog repository**:
+3. **Create a namespace and catalog repository**:
    ```bash
-   git clone http://localhost:9418/catalog.git catalog-work
+   make bootstrap ADMIN_PASSWORD=<admin-password>
+   ```
+
+4. **Clone the catalog repository** using the clone URL printed by `make bootstrap`:
+   ```bash
+   git clone http://localhost:9418/<repository-id> catalog-work
    cd catalog-work
    ```
 
@@ -398,12 +403,13 @@ GitStore only reads from release tags, not from main/HEAD.
 
 **Problem**: GraphQL API returns "repository does not exist" error.
 
-**Solution**: Verify the catalog repository is initialized:
+**Solution**: Verify the repository was bootstrapped and the git service is healthy:
 ```bash
-ls -la demo-catalog/catalog.git/
+make ps
+make logs SERVICE=git-service
 ```
 
-Check Docker volume mounts in `docker-compose.yml`.
+If you are using native services, check `GIT_DATA_DIR` and recreate the starter repository with `make bootstrap`.
 
 ### Admin shows stale data or merge conflicts
 

--- a/gitstore-git-service/src/main.rs
+++ b/gitstore-git-service/src/main.rs
@@ -116,12 +116,34 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
-    tokio::signal::ctrl_c().await?;
+    shutdown_signal().await?;
     info!("Shutting down...");
 
     ws_handle.abort();
     http_handle.abort();
     grpc_handle.abort();
 
+    Ok(())
+}
+
+#[cfg(unix)]
+async fn shutdown_signal() -> Result<(), Box<dyn std::error::Error>> {
+    use tokio::signal::unix::{signal, SignalKind};
+
+    let mut interrupt = signal(SignalKind::interrupt())?;
+    let mut terminate = signal(SignalKind::terminate())?;
+
+    tokio::select! {
+        _ = interrupt.recv() => info!("Received SIGINT"),
+        _ = terminate.recv() => info!("Received SIGTERM"),
+    }
+
+    Ok(())
+}
+
+#[cfg(not(unix))]
+async fn shutdown_signal() -> Result<(), Box<dyn std::error::Error>> {
+    tokio::signal::ctrl_c().await?;
+    info!("Received Ctrl-C");
     Ok(())
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,6 +2,14 @@
 
 Utility scripts for GitStore development and demonstration.
 
+For normal repository checks, run the licence scripts through the root Make target:
+
+```bash
+make license-check
+```
+
+Use the scripts directly only when you need a narrower mode such as `--staged`.
+
 ## check-go-license-headers.sh
 
 Validates that Go files include the required AGPL header and that changed files include the current year in their copyright line.


### PR DESCRIPTION
## Summary

Adds a root `Makefile` as the canonical command interface for local native services, Docker Compose stacks, Scylla variants, bootstrap flows, admin wrappers, cleanup, and PR readiness checks.

Also updates documentation to route repository workflows through `make`, including bootstrap variables and the distinction between Scylla-only and full Scylla-backed stacks.

## Runtime Fix

The git-service healthcheck previously polled `/` every 10 seconds with shell-specific exit-code handling. It now probes the real `/health` endpoint every 2 seconds, so `api` can start sooner after `git-service` is ready.

The Rust service now handles `SIGTERM` as well as `SIGINT`, which lets Docker Compose shutdown proceed without waiting for the default kill timeout.

## Validation

- `make help`
- `make -n compose`, `make -n compose DETACH=1`
- `make -n scylla`, `make -n scylla DETACH=1`
- `make -n compose-scylla`, `make -n compose-scylla DETACH=1`
- `make -n bootstrap NAMESPACE=acme REPOSITORY=catalog`
- `make -n git-clean-data CONFIRM=1`
- `make bootstrap ADMIN_PASSWORD=not-the-password` with no API running confirms clear connection failure
- `make git-clean-data` without `CONFIRM=1` refuses to run
- `make lint`
- `make license-check`
- `cargo fmt --all -- --check`
- `cargo check --bin git-service`
- `cargo clippy --bin git-service -- -D warnings`
- `docker compose -f compose.yml config`
- `git diff --check`