### PR TITLE
feat: implement in-process git-receive-pack hook pipeline (#110)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ Auto-generated from all feature plans. Last updated: 2026-03-26
 - `go-memdb` (development / in-memory backend) / ScyllaDB 5.x+ (production backend) — via the `datastore.Datastore` interface from feature 006 (009-api-namespaces)
 - Go 1.25 (`gitstore-api`) · Rust edition 2021, MSRV 1.82 (`gitstore-git-service`) + `gqlgen v0.17.90`, `go-memdb v1.3.5`, `gocqlx/v3 v3.0.4`, `google/uuid v1.6.0` (Go) · `gix 0.83.0`, `tonic 0.14.6`, `prost 0.14.3` (Rust) (010-repo-storage-identity)
 - `go-memdb` (development) · ScyllaDB 5.x+ (production) — via `datastore.Datastore` interface (feature #006) (010-repo-storage-identity)
+- Rust edition 2021, MSRV 1.82; actual gix version is `0.84.0` (Cargo.lock canonical) + `gix 0.84.0`, `gix-ref 0.64.0` (two-phase transaction API), `tokio 1.35` (full features), `tonic 0.14`, `tracing 0.1`, `anyhow 1.0`, `async-trait 0.1` (to add) (013-receive-pack-hooks)
 
 - (001-git-backed-ecommerce)
 
@@ -52,9 +53,9 @@ Common bootstrap variables:
 : Follow standard conventions
 
 ## Recent Changes
+- 013-receive-pack-hooks: Added Rust edition 2021, MSRV 1.82; actual gix version is `0.84.0` (Cargo.lock canonical) + `gix 0.84.0`, `gix-ref 0.64.0` (two-phase transaction API), `tokio 1.35` (full features), `tonic 0.14`, `tracing 0.1`, `anyhow 1.0`, `async-trait 0.1` (to add)
 - 012-smart-http-api: Go 1.25 (`gitstore-api`) + `net/http` second server on port 5000 · Rust edition 2021, MSRV 1.82 (`gitstore-git-service`) — adds `ReceivePack` (client-streaming), `UploadPack` (server-streaming), `InfoRefs` gRPC RPCs; removes `axum`/HTTP server, `tokio_tungstenite`/`tungstenite` WebSocket deps; removes `gorilla/websocket` and `internal/websocket` from `gitstore-api`
 - 010-repo-storage-identity: Added Go 1.25 (`gitstore-api`) · Rust edition 2021, MSRV 1.82 (`gitstore-git-service`) + `gqlgen v0.17.90`, `go-memdb v1.3.5`, `gocqlx/v3 v3.0.4`, `google/uuid v1.6.0` (Go) · `gix 0.83.0`, `tonic 0.14.6`, `prost 0.14.3` (Rust)
-- 009-api-namespaces: Added Go 1.25 (`gitstore-api`) + `gqlgen v0.17.90`, `go-memdb v1.3.5`, `gocqlx/v3 v3.0.4` (ScyllaDB), `go-playground/validator/v10`, `go.uber.org/zap`, `google/uuid`
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/gitstore-git-service/Cargo.lock
+++ b/gitstore-git-service/Cargo.lock
@@ -581,6 +581,7 @@ name = "gitstore-server"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "clap",
  "config",
  "dashmap",

--- a/gitstore-git-service/Cargo.toml
+++ b/gitstore-git-service/Cargo.toml
@@ -21,6 +21,7 @@ tokio-stream = "0.1.18"
 tempfile = "3.8"
 config = "0.15.22"
 dotenvy = "0.15"
+async-trait = "0.1"
 
 [dev-dependencies]
 

--- a/gitstore-git-service/src/config.rs
+++ b/gitstore-git-service/src/config.rs
@@ -35,21 +35,22 @@ pub struct LogConfig {
     pub format: String,
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Deserialize)]
 pub struct HooksConfig {
     pub git_receive_pack: GitReceivePackHooks,
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Deserialize)]
 pub struct GitReceivePackHooks {
     pub pre_receive: HookToggle,
     pub update: HookToggle,
     pub post_receive: HookToggle,
     pub proc_receive: HookToggle,
     pub post_update: HookToggle,
+    pub reference_transaction: HookToggle,
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Deserialize)]
 pub struct HookToggle {
     pub enabled: bool,
 }
@@ -169,11 +170,12 @@ level = "info"
 format = "json"
 
 [hooks.git_receive_pack]
-pre_receive  = { enabled = false }
-update       = { enabled = false }
-post_receive = { enabled = false }
-proc_receive = { enabled = false }
-post_update  = { enabled = false }
+pre_receive           = { enabled = false }
+update                = { enabled = false }
+post_receive          = { enabled = false }
+proc_receive          = { enabled = false }
+post_update           = { enabled = false }
+reference_transaction = { enabled = false }
 
 [admission_control.validating_admission_policy]
 phase = "pre-receive"
@@ -409,5 +411,17 @@ mod tests {
             "got: {s}"
         );
         clear_env();
+    }
+
+    // T034: reference_transaction toggle defaults to false
+    #[test]
+    fn test_reference_transaction_toggle_defaults_to_false() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_env();
+        let cfg = load_config_from(None).expect("load_config failed");
+        assert!(
+            !cfg.hooks.git_receive_pack.reference_transaction.enabled,
+            "reference_transaction should default to disabled"
+        );
     }
 }

--- a/gitstore-git-service/src/git/hooks.rs
+++ b/gitstore-git-service/src/git/hooks.rs
@@ -1,82 +1,530 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (c) 2026 GitStore contributors
 
-// Git hooks handler
-
 use std::path::Path;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
-use anyhow::Result;
-use tracing::warn;
+use async_trait::async_trait;
+use tracing::{error, info, warn};
 
-/// Information about a reference update passed to receive lifecycle hooks.
-#[derive(Clone)]
+use crate::config::GitReceivePackHooks;
+
+// ---------------------------------------------------------------------------
+// Shared data type
+// ---------------------------------------------------------------------------
+
+/// A single ref update passed to all hook phases.
+#[derive(Clone, Debug)]
 pub struct RefUpdate {
     pub ref_name: String,
     pub old_oid: String,
     pub new_oid: String,
 }
 
-/// Called before any ref is updated.
-/// Non-Ok return rejects the entire push; Ok(()) allows it to proceed.
-/// Future: validate push policy via gRPC callout to gitstore-api.
-pub fn run_pre_receive(_git_dir: &Path, _updates: &[RefUpdate]) -> Result<()> {
-    Ok(())
+// ---------------------------------------------------------------------------
+// Decision types
+// ---------------------------------------------------------------------------
+
+/// Outcome of a hook phase execution.
+#[derive(Debug)]
+pub enum HookDecision {
+    Accept,
+    Reject(String),
 }
 
-/// Called once per ref being updated.
-/// Returns the indices of refs that are accepted; rejected indices are skipped.
-/// Future: per-ref policy enforcement (protected branches, signed commits) via gRPC.
-pub fn run_update_hooks(_git_dir: &Path, updates: &[RefUpdate]) -> Result<Vec<usize>> {
-    Ok((0..updates.len()).collect())
+/// Outcome returned by an `AdmissionHandler`.
+#[derive(Debug)]
+pub enum AdmissionDecision {
+    Accept,
+    Reject(String),
 }
 
-/// Called after refs are committed. Exit code is ignored.
-/// Future: trigger webhooks / event fan-out via gRPC callout to gitstore-api.
-pub fn run_post_receive(_git_dir: &Path, _updates: &[RefUpdate]) {}
-
-/// Check if update is a tag creation
-pub fn is_tag_update(ref_name: &str) -> bool {
-    ref_name.starts_with("refs/tags/")
+/// Carries the phase name and reason when a pipeline phase rejects a push.
+#[derive(Debug)]
+pub struct HookRejection {
+    pub phase: String,
+    pub reason: String,
 }
 
-/// Extract tag name from reference
-pub fn get_tag_name(ref_name: &str) -> Option<String> {
-    ref_name.strip_prefix("refs/tags/").map(|s| s.to_string())
+impl std::fmt::Display for HookRejection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "hook rejected by {}: {}", self.phase, self.reason)
+    }
 }
 
-/// Parse pre-receive hook input (from stdin)
+impl std::error::Error for HookRejection {}
+
+// ---------------------------------------------------------------------------
+// AdmissionHandler trait
+// ---------------------------------------------------------------------------
+
+/// Integration point for future admission (#105) and validation (#106) services.
+/// Implemented by any type that participates in push admission decisions.
+///
+/// Called at the phase configured by
+/// `GITSTORE_ADMISSION_CONTROL_VALIDATING_ADMISSION_POLICY_PHASE`.
+#[async_trait]
+pub trait AdmissionHandler: Send + Sync {
+    /// Return `Accept` to allow the push/ref to proceed, or `Reject(reason)` to block it.
+    /// Errors are treated as `Reject("admission handler error")`.
+    async fn admit(&self, phase: &str, updates: &[RefUpdate]) -> anyhow::Result<AdmissionDecision>;
+}
+
+/// Default no-op implementation — always accepts.
+pub struct NoopAdmissionHandler;
+
+#[async_trait]
+impl AdmissionHandler for NoopAdmissionHandler {
+    async fn admit(
+        &self,
+        _phase: &str,
+        _updates: &[RefUpdate],
+    ) -> anyhow::Result<AdmissionDecision> {
+        Ok(AdmissionDecision::Accept)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HookPipeline
+// ---------------------------------------------------------------------------
+
+const ADMISSION_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Orchestrates the in-process hook execution pipeline for a single push event.
+pub struct HookPipeline {
+    pub config: GitReceivePackHooks,
+    pub admission_phase: String,
+    pub admission_handler: Arc<dyn AdmissionHandler + Send + Sync>,
+}
+
+impl HookPipeline {
+    pub fn new(
+        config: GitReceivePackHooks,
+        admission_phase: String,
+        handler: Arc<dyn AdmissionHandler + Send + Sync>,
+    ) -> Self {
+        Self {
+            config,
+            admission_phase,
+            admission_handler: handler,
+        }
+    }
+
+    /// Run the pre-receive → proc-receive → update phases.
+    ///
+    /// Returns `Ok(accepted_indices)` where each entry is an index into `updates`
+    /// that was accepted by the update phase.
+    /// Returns `Err(HookRejection)` if pre-receive or proc-receive rejects the push.
+    pub async fn run(
+        &self,
+        git_dir: &Path,
+        updates: &[RefUpdate],
+    ) -> Result<Vec<usize>, HookRejection> {
+        // --- pre-receive (once per push, all-or-nothing) ---
+        if self.config.pre_receive.enabled {
+            let decision = self
+                .run_phase_with_admission("pre-receive", git_dir, updates, || {
+                    run_pre_receive(git_dir, updates)
+                })
+                .await;
+            if let HookDecision::Reject(reason) = decision {
+                let reason = non_empty(reason, "rejected by pre-receive");
+                warn!(
+                    phase = "pre-receive",
+                    outcome = "rejected",
+                    reason = %reason,
+                    "hook_phase_complete"
+                );
+                return Err(HookRejection {
+                    phase: "pre-receive".to_string(),
+                    reason,
+                });
+            }
+            log_phase("pre-receive", None, "accepted", None);
+        }
+
+        // --- proc-receive (once per push, all-or-nothing) ---
+        if self.config.proc_receive.enabled {
+            let decision = self
+                .run_phase_with_admission("proc-receive", git_dir, updates, || {
+                    run_proc_receive(git_dir, updates)
+                })
+                .await;
+            if let HookDecision::Reject(reason) = decision {
+                let reason = non_empty(reason, "rejected by proc-receive");
+                warn!(
+                    phase = "proc-receive",
+                    outcome = "rejected",
+                    reason = %reason,
+                    "hook_phase_complete"
+                );
+                return Err(HookRejection {
+                    phase: "proc-receive".to_string(),
+                    reason,
+                });
+            }
+            log_phase("proc-receive", None, "accepted", None);
+        }
+
+        // --- update (once per ref, per-ref semantics) ---
+        let mut accepted = Vec::new();
+        for (i, update) in updates.iter().enumerate() {
+            if !self.config.update.enabled {
+                accepted.push(i);
+                continue;
+            }
+            let single = std::slice::from_ref(update);
+            let decision = self
+                .run_phase_with_admission("update", git_dir, single, || run_update(git_dir, update))
+                .await;
+            match decision {
+                HookDecision::Accept => {
+                    log_phase("update", Some(&update.ref_name), "accepted", None);
+                    accepted.push(i);
+                }
+                HookDecision::Reject(reason) => {
+                    let reason = non_empty(reason, "rejected by update");
+                    warn!(
+                        phase = "update",
+                        ref_name = %update.ref_name,
+                        outcome = "rejected",
+                        reason = %reason,
+                        "hook_phase_complete"
+                    );
+                    // per-ref: continue processing remaining refs
+                }
+            }
+        }
+
+        Ok(accepted)
+    }
+
+    /// Called after ref lock files are acquired (gix two-phase transaction prepare step).
+    /// Returns `Ok(())` to allow the commit, or `Err(HookRejection)` to trigger rollback.
+    pub async fn run_reference_transaction_prepared(
+        &self,
+        git_dir: &Path,
+        updates: &[RefUpdate],
+    ) -> Result<(), HookRejection> {
+        if !self.config.reference_transaction.enabled {
+            return Ok(());
+        }
+        let start = Instant::now();
+        let decision = self
+            .run_phase_with_admission("reference-transaction/prepared", git_dir, updates, || {
+                HookDecision::Accept
+            })
+            .await;
+        let duration_ms = start.elapsed().as_millis() as u64;
+        match decision {
+            HookDecision::Accept => {
+                info!(
+                    phase = "reference-transaction/prepared",
+                    duration_ms,
+                    outcome = "accepted",
+                    "hook_phase_complete"
+                );
+                Ok(())
+            }
+            HookDecision::Reject(reason) => {
+                let reason = non_empty(reason, "rejected by reference-transaction");
+                warn!(
+                    phase = "reference-transaction/prepared",
+                    duration_ms,
+                    outcome = "rejected",
+                    reason = %reason,
+                    "hook_phase_complete"
+                );
+                Err(HookRejection {
+                    phase: "reference-transaction/prepared".to_string(),
+                    reason,
+                })
+            }
+        }
+    }
+
+    /// Called after refs are committed. Observation only — cannot fail.
+    pub fn run_reference_transaction_committed(&self, _git_dir: &Path, _updates: &[RefUpdate]) {
+        if self.config.reference_transaction.enabled {
+            info!(
+                phase = "reference-transaction/committed",
+                outcome = "accepted",
+                "hook_phase_complete"
+            );
+        }
+    }
+
+    /// Called on rollback. Observation only — cannot fail.
+    pub fn run_reference_transaction_aborted(&self, _git_dir: &Path, _updates: &[RefUpdate]) {
+        if self.config.reference_transaction.enabled {
+            info!(
+                phase = "reference-transaction/aborted",
+                outcome = "aborted",
+                "hook_phase_complete"
+            );
+        }
+    }
+
+    /// Called after refs are committed. Errors are logged at ERROR level and never propagated.
+    pub fn run_post_receive(&self, git_dir: &Path, updates: &[RefUpdate]) {
+        if !self.config.post_receive.enabled {
+            return;
+        }
+        let start = Instant::now();
+        run_post_receive(git_dir, updates);
+        let duration_ms = start.elapsed().as_millis() as u64;
+        info!(
+            phase = "post-receive",
+            duration_ms,
+            outcome = "accepted",
+            "hook_phase_complete"
+        );
+    }
+
+    // -- internal helpers --
+
+    /// Run `phase_fn` then, if this is the configured admission phase, call the handler
+    /// with a 5-second timeout (fail-closed). Returns the final `HookDecision`.
+    async fn run_phase_with_admission<F>(
+        &self,
+        phase: &str,
+        _git_dir: &Path,
+        updates: &[RefUpdate],
+        phase_fn: F,
+    ) -> HookDecision
+    where
+        F: FnOnce() -> HookDecision,
+    {
+        let start = Instant::now();
+        let decision = phase_fn();
+        if let HookDecision::Reject(_) = &decision {
+            return decision;
+        }
+        // Only invoke the admission handler at the configured phase.
+        if phase == self.admission_phase {
+            let result = tokio::time::timeout(
+                ADMISSION_TIMEOUT,
+                self.admission_handler.admit(phase, updates),
+            )
+            .await;
+            let duration_ms = start.elapsed().as_millis() as u64;
+            match result {
+                Ok(Ok(AdmissionDecision::Accept)) => {}
+                Ok(Ok(AdmissionDecision::Reject(reason))) => {
+                    return HookDecision::Reject(reason);
+                }
+                Ok(Err(e)) => {
+                    error!(
+                        phase,
+                        duration_ms,
+                        reason = %e,
+                        "hook_phase_error"
+                    );
+                    return HookDecision::Reject("admission handler error".to_string());
+                }
+                Err(_elapsed) => {
+                    error!(
+                        phase,
+                        duration_ms,
+                        reason = "admission service timeout",
+                        "hook_phase_error"
+                    );
+                    return HookDecision::Reject("admission service timeout".to_string());
+                }
+            }
+        }
+        decision
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Phase functions (stubs — replaced by real logic in future features)
+// ---------------------------------------------------------------------------
+
+fn run_pre_receive(_git_dir: &Path, _updates: &[RefUpdate]) -> HookDecision {
+    HookDecision::Accept
+}
+
+fn run_proc_receive(_git_dir: &Path, _updates: &[RefUpdate]) -> HookDecision {
+    HookDecision::Accept
+}
+
+fn run_update(_git_dir: &Path, _update: &RefUpdate) -> HookDecision {
+    HookDecision::Accept
+}
+
+fn run_post_receive(_git_dir: &Path, _updates: &[RefUpdate]) {
+    // fire-and-forget: future features will fan out events here
+}
+
+// ---------------------------------------------------------------------------
+// Legacy helpers (kept for tag utilities used elsewhere)
+// ---------------------------------------------------------------------------
+
+/// Parse pre-receive hook input (from stdin) — kept for compatibility.
 /// Format: <old-oid> <new-oid> <ref-name>
-pub fn parse_pre_receive_input(input: &str) -> Result<Vec<RefUpdate>> {
+pub fn parse_pre_receive_input(input: &str) -> anyhow::Result<Vec<RefUpdate>> {
     let mut updates = Vec::new();
-
     for line in input.lines() {
         let parts: Vec<&str> = line.split_whitespace().collect();
         if parts.len() != 3 {
-            warn!(line = line, "Invalid pre-receive input line");
+            tracing::warn!(line = line, "Invalid pre-receive input line");
             continue;
         }
-
         updates.push(RefUpdate {
             old_oid: parts[0].to_string(),
             new_oid: parts[1].to_string(),
             ref_name: parts[2].to_string(),
         });
     }
-
     Ok(updates)
 }
+
+pub fn is_tag_update(ref_name: &str) -> bool {
+    ref_name.starts_with("refs/tags/")
+}
+
+pub fn get_tag_name(ref_name: &str) -> Option<String> {
+    ref_name.strip_prefix("refs/tags/").map(|s| s.to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+fn non_empty(s: String, fallback: &str) -> String {
+    if s.is_empty() {
+        fallback.to_string()
+    } else {
+        s
+    }
+}
+
+fn log_phase(phase: &str, ref_name: Option<&str>, outcome: &str, reason: Option<&str>) {
+    match (ref_name, reason) {
+        (Some(r), Some(reason)) => {
+            info!(phase, ref_name = r, outcome, reason, "hook_phase_complete")
+        }
+        (Some(r), None) => info!(phase, ref_name = r, outcome, "hook_phase_complete"),
+        (None, Some(reason)) => info!(phase, outcome, reason, "hook_phase_complete"),
+        (None, None) => info!(phase, outcome, "hook_phase_complete"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+
+    // T004: HookDecision, AdmissionDecision, NoopAdmissionHandler, HookRejection
+    #[test]
+    fn test_hook_decision_reject_carries_reason() {
+        let d = HookDecision::Reject("test reason".to_string());
+        if let HookDecision::Reject(r) = d {
+            assert_eq!(r, "test reason");
+        } else {
+            panic!("expected Reject");
+        }
+    }
+
+    #[test]
+    fn test_admission_decision_reject_carries_reason() {
+        let d = AdmissionDecision::Reject("admission reason".to_string());
+        if let AdmissionDecision::Reject(r) = d {
+            assert_eq!(r, "admission reason");
+        } else {
+            panic!("expected Reject");
+        }
+    }
+
+    #[test]
+    fn test_hook_rejection_fields() {
+        let r = HookRejection {
+            phase: "pre-receive".to_string(),
+            reason: "blocked".to_string(),
+        };
+        assert_eq!(r.phase, "pre-receive");
+        assert_eq!(r.reason, "blocked");
+    }
+
+    #[tokio::test]
+    async fn test_noop_admission_handler_always_accepts() {
+        let h = NoopAdmissionHandler;
+        let updates = vec![RefUpdate {
+            ref_name: "refs/heads/main".to_string(),
+            old_oid: "0".repeat(40),
+            new_oid: "a".repeat(40),
+        }];
+        let result = h.admit("pre-receive", &updates).await.unwrap();
+        assert!(matches!(result, AdmissionDecision::Accept));
+    }
+
+    // T005: HookPipeline toggle enforcement
+    fn make_disabled_config() -> GitReceivePackHooks {
+        use crate::config::HookToggle;
+        GitReceivePackHooks {
+            pre_receive: HookToggle { enabled: false },
+            update: HookToggle { enabled: false },
+            post_receive: HookToggle { enabled: false },
+            proc_receive: HookToggle { enabled: false },
+            post_update: HookToggle { enabled: false },
+            reference_transaction: HookToggle { enabled: false },
+        }
+    }
+
+    fn make_update(ref_name: &str) -> RefUpdate {
+        RefUpdate {
+            ref_name: ref_name.to_string(),
+            old_oid: "0".repeat(40),
+            new_oid: "a".repeat(40),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_all_disabled_accepts_all_indices() {
+        let pipeline = HookPipeline::new(
+            make_disabled_config(),
+            "pre-receive".to_string(),
+            Arc::new(NoopAdmissionHandler),
+        );
+        let updates = vec![
+            make_update("refs/heads/main"),
+            make_update("refs/heads/dev"),
+        ];
+        let result = pipeline
+            .run(std::path::Path::new("/tmp"), &updates)
+            .await
+            .unwrap();
+        assert_eq!(result, vec![0, 1]);
+    }
+
+    #[tokio::test]
+    async fn test_pre_receive_only_enabled_accepts() {
+        use crate::config::HookToggle;
+        let mut cfg = make_disabled_config();
+        cfg.pre_receive = HookToggle { enabled: true };
+        let pipeline = HookPipeline::new(
+            cfg,
+            "pre-receive".to_string(),
+            Arc::new(NoopAdmissionHandler),
+        );
+        let updates = vec![make_update("refs/heads/main")];
+        let result = pipeline
+            .run(std::path::Path::new("/tmp"), &updates)
+            .await
+            .unwrap();
+        assert_eq!(result, vec![0]);
+    }
 
     #[test]
     fn test_parse_pre_receive_input() {
-        let input = "abc123 def456 refs/heads/main\n\
-                     000000 fed789 refs/tags/v1.0.0";
-
+        let input = "abc123 def456 refs/heads/main\n000000 fed789 refs/tags/v1.0.0";
         let updates = parse_pre_receive_input(input).unwrap();
-
         assert_eq!(updates.len(), 2);
         assert_eq!(updates[0].old_oid, "abc123");
         assert_eq!(updates[0].new_oid, "def456");

--- a/gitstore-git-service/src/git/pack_server.rs
+++ b/gitstore-git-service/src/git/pack_server.rs
@@ -10,7 +10,7 @@ use gix::refs::transaction::{Change, LogChange, PreviousValue, RefEdit, RefLog};
 use gix::refs::TargetRef;
 use tracing::info;
 
-use super::hooks::{run_post_receive, run_pre_receive, run_update_hooks, RefUpdate};
+use super::hooks::RefUpdate;
 
 /// In-process replacement for the four `git upload-pack` / `git receive-pack`
 /// shell-out call sites in the HTTP git server.
@@ -102,7 +102,15 @@ impl HttpPackServer {
     /// Only after the ref transaction commits successfully are the pack/index
     /// files moved into the real ODB. On any failure the temp dir is dropped and
     /// no new objects are left in the repository.
-    pub fn handle_receive_pack(&self, body: &[u8]) -> Result<Vec<u8>> {
+    ///
+    /// `pipeline` is called synchronously via `block_in_place` since this method
+    /// runs inside a `spawn_blocking` context. The HTTP path uses `NoopAdmissionHandler`
+    /// by default; real admission logic runs in the async gRPC path.
+    pub fn handle_receive_pack(
+        &self,
+        body: &[u8],
+        pipeline: &crate::git::hooks::HookPipeline,
+    ) -> Result<Vec<u8>> {
         let start = Instant::now();
         let pack_size_bytes = body.len() as u64;
 
@@ -120,7 +128,7 @@ impl HttpPackServer {
             None
         };
 
-        // Build RefUpdate list (shared with hook runners and ref transaction).
+        // Build RefUpdate list.
         let hook_updates: Vec<RefUpdate> = ref_updates
             .iter()
             .map(|(refname, old_oid, new_oid)| RefUpdate {
@@ -130,12 +138,33 @@ impl HttpPackServer {
             })
             .collect();
 
-        // pre-receive: non-zero exit rejects the entire push before any mutation.
-        run_pre_receive(&self.repo_path, &hook_updates).context("pre-receive hook")?;
+        // Run pre-receive → proc-receive → update phases via the pipeline.
+        // block_in_place lets us .await inside spawn_blocking.
+        let pipeline_result = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(pipeline.run(&self.repo_path, &hook_updates))
+        });
 
-        // update: called per-ref; collects accepted indices for the ref transaction.
-        let accepted_indices =
-            run_update_hooks(&self.repo_path, &hook_updates).context("update hooks")?;
+        let accepted_indices = match pipeline_result {
+            Ok(indices) => indices,
+            Err(rejection) => {
+                // Whole-push rejection (pre-receive or proc-receive).
+                let mut inner = Vec::new();
+                write_pkt_line(&mut inner, b"unpack ok\n")?;
+                for (refname, _, _) in &ref_updates {
+                    write_pkt_line(
+                        &mut inner,
+                        format!("ng {refname} {}\n", rejection.reason).as_bytes(),
+                    )?;
+                }
+                inner.extend_from_slice(b"0000");
+                let mut sideband_data = vec![0x01u8];
+                sideband_data.extend_from_slice(&inner);
+                let mut response = Vec::new();
+                write_pkt_line(&mut response, &sideband_data)?;
+                response.extend_from_slice(b"0000");
+                return Ok(response);
+            }
+        };
 
         // Build atomic ref transaction for accepted refs only.
         let mut ref_edits: Vec<RefEdit> = Vec::new();
@@ -147,7 +176,6 @@ impl HttpPackServer {
                 .with_context(|| format!("parse old oid {old_oid}"))?;
 
             let change = if new_id.is_null() {
-                // Delete: `git push origin :branch`
                 let expected = if old_id.is_null() {
                     PreviousValue::Any
                 } else {
@@ -184,37 +212,74 @@ impl HttpPackServer {
             });
         }
 
-        // Commit atomically — gix uses lock files; any failure rolls back
-        if !ref_edits.is_empty() {
-            repo.edit_references(ref_edits)
-                .context("atomic ref transaction")?;
-        }
-
-        // Refs committed — promote quarantined pack/index into the real ODB.
-        // If this step fails the refs already landed, so we surface the error
-        // but do not revert them (the objects are still accessible via loose ODB
-        // because write_to_directory also indexes them; this is a best-effort move).
-        if let Some(q) = quarantine {
-            promote_quarantine(&repo, q).context("promoting quarantined pack to ODB")?;
-        }
-
-        // post-receive: informational only, exit code ignored.
-        let accepted_set: std::collections::HashSet<usize> =
-            accepted_indices.iter().copied().collect();
+        // Two-phase gix ref transaction: prepare (locks acquired) → reference-transaction hook
+        // → commit or rollback.
         let accepted_updates: Vec<RefUpdate> = accepted_indices
             .iter()
-            .map(|i| RefUpdate {
-                ref_name: hook_updates[*i].ref_name.clone(),
-                old_oid: hook_updates[*i].old_oid.clone(),
-                new_oid: hook_updates[*i].new_oid.clone(),
-            })
+            .map(|i| hook_updates[*i].clone())
             .collect();
-        run_post_receive(&self.repo_path, &accepted_updates);
+
+        if !ref_edits.is_empty() {
+            let file_lock_fail = gix::lock::acquire::Fail::AfterDurationWithBackoff(
+                std::time::Duration::from_millis(100),
+            );
+            let packed_lock_fail = gix::lock::acquire::Fail::AfterDurationWithBackoff(
+                std::time::Duration::from_millis(1000),
+            );
+            let txn = repo
+                .refs
+                .transaction()
+                .prepare(ref_edits, file_lock_fail, packed_lock_fail)
+                .context("prepare ref transaction")?;
+
+            // reference-transaction/prepared veto check (sync path uses NoopAdmissionHandler).
+            let veto_result = tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current().block_on(
+                    pipeline.run_reference_transaction_prepared(&self.repo_path, &accepted_updates),
+                )
+            });
+
+            match veto_result {
+                Ok(()) => {
+                    // Promote quarantined pack before committing refs.
+                    if let Some(q) = quarantine {
+                        promote_quarantine(&repo, q)
+                            .context("promoting quarantined pack to ODB")?;
+                    }
+                    txn.commit(None).context("commit ref transaction")?;
+                    pipeline
+                        .run_reference_transaction_committed(&self.repo_path, &accepted_updates);
+                }
+                Err(rejection) => {
+                    drop(txn); // releases all lock files
+                    pipeline.run_reference_transaction_aborted(&self.repo_path, &accepted_updates);
+                    let mut inner = Vec::new();
+                    write_pkt_line(&mut inner, b"unpack ok\n")?;
+                    for (refname, _, _) in &ref_updates {
+                        write_pkt_line(
+                            &mut inner,
+                            format!("ng {refname} {}\n", rejection.reason).as_bytes(),
+                        )?;
+                    }
+                    inner.extend_from_slice(b"0000");
+                    let mut sideband_data = vec![0x01u8];
+                    sideband_data.extend_from_slice(&inner);
+                    let mut response = Vec::new();
+                    write_pkt_line(&mut response, &sideband_data)?;
+                    response.extend_from_slice(b"0000");
+                    return Ok(response);
+                }
+            }
+        } else {
+            // No ref edits: drop quarantine safely.
+            drop(quarantine);
+        }
+
+        pipeline.run_post_receive(&self.repo_path, &accepted_updates);
 
         // Build report-status response.
-        // With side-band-64k: ALL report-status pkt-lines are bundled into ONE sideband
-        // channel-1 payload, followed by a sideband flush pkt-line (0000).
-        // Format: pkt-line(\x01 <inner-pkt-lines> <inner-0000>)  then outer 0000
+        let accepted_set: std::collections::HashSet<usize> =
+            accepted_indices.iter().copied().collect();
         let mut inner = Vec::new();
         write_pkt_line(&mut inner, b"unpack ok\n")?;
         for (i, (refname, _, _)) in ref_updates.iter().enumerate() {
@@ -229,7 +294,7 @@ impl HttpPackServer {
         }
         inner.extend_from_slice(b"0000");
 
-        let mut sideband_data = vec![0x01u8]; // channel 1 = data
+        let mut sideband_data = vec![0x01u8];
         sideband_data.extend_from_slice(&inner);
 
         let mut response = Vec::new();

--- a/gitstore-git-service/src/grpc/server.rs
+++ b/gitstore-git-service/src/grpc/server.rs
@@ -893,25 +893,23 @@ impl GitService for GitServiceImpl {
             .map(|i| pipeline_updates[*i].clone())
             .collect();
 
-        // reference-transaction/prepared veto (async).
-        let repo_path_reftxn = repo_path.clone();
-        let rt_result = pipeline
-            .run_reference_transaction_prepared(&repo_path_reftxn, &accepted_updates)
-            .await;
-
-        if let Err(rejection) = rt_result {
-            pipeline.run_reference_transaction_aborted(&repo_path, &accepted_updates);
-            let all_refs: Vec<&str> = ref_updates.iter().map(|u| u.ref_name.as_str()).collect();
-            let report_status = build_rejection_status(&all_refs, &rejection.reason);
-            return Ok(Response::new(ReceivePackResponse { report_status }));
-        }
-
-        // Build ref_edits and commit transaction in blocking context.
+        // Build ref_edits, prepare the gix transaction (acquires lock files), run the
+        // reference-transaction/prepared veto *while locks are held*, then commit or rollback.
+        // All of this runs in spawn_blocking because gix::Repository is !Send.
+        // block_in_place is used inside to drive the async veto call.
         let pipeline_updates_for_txn = pipeline_updates.clone();
         let accepted_indices_clone = accepted_indices.clone();
         let accepted_updates_clone = accepted_updates.clone();
+        let accepted_updates_for_callbacks = accepted_updates.clone();
         let repo_path_commit = repo_path.clone();
-        tokio::task::spawn_blocking(move || {
+        let pipeline_clone = Arc::clone(&pipeline);
+        // Result is either Ok(rt_committed) or Err(Status); we also need to know if the
+        // reference-transaction veto fired so we can call the right observation callback.
+        enum TxnOutcome {
+            Committed,
+            RejectedByHook(String), // veto reason
+        }
+        let txn_result: Result<TxnOutcome, Status> = tokio::task::spawn_blocking(move || {
             use gix::refs::transaction::{Change, LogChange, PreviousValue, RefEdit, RefLog};
 
             let repo = gix::open(&repo_path_commit)
@@ -964,34 +962,69 @@ impl GitService for GitServiceImpl {
                 });
             }
 
-            if !ref_edits.is_empty() {
-                let file_lock_fail = gix::lock::acquire::Fail::AfterDurationWithBackoff(
-                    std::time::Duration::from_millis(100),
-                );
-                let packed_lock_fail = gix::lock::acquire::Fail::AfterDurationWithBackoff(
-                    std::time::Duration::from_millis(1000),
-                );
-                let txn = repo
-                    .refs
-                    .transaction()
-                    .prepare(ref_edits, file_lock_fail, packed_lock_fail)
-                    .map_err(|e| Status::internal(format!("prepare ref transaction: {}", e)))?;
-
-                crate::git::pack_server::promote_quarantine(&repo, quarantine)
-                    .map_err(|e| Status::internal(format!("promote quarantine: {}", e)))?;
-                txn.commit(None)
-                    .map_err(|e| Status::internal(format!("commit ref transaction: {}", e)))?;
+            if ref_edits.is_empty() {
+                return Ok(TxnOutcome::Committed);
             }
-            Ok::<_, Status>(())
+
+            let file_lock_fail = gix::lock::acquire::Fail::AfterDurationWithBackoff(
+                std::time::Duration::from_millis(100),
+            );
+            let packed_lock_fail = gix::lock::acquire::Fail::AfterDurationWithBackoff(
+                std::time::Duration::from_millis(1000),
+            );
+            // Ref lock files are acquired here — this is the "prepared" state.
+            let txn = repo
+                .refs
+                .transaction()
+                .prepare(ref_edits, file_lock_fail, packed_lock_fail)
+                .map_err(|e| Status::internal(format!("prepare ref transaction: {}", e)))?;
+
+            // Run the veto hook while locks are held (matches the prepared state semantics).
+            let veto = tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current().block_on(
+                    pipeline_clone.run_reference_transaction_prepared(
+                        &repo_path_commit,
+                        &accepted_updates_clone,
+                    ),
+                )
+            });
+
+            match veto {
+                Err(rejection) => {
+                    drop(txn); // releases all lock files
+                    Ok(TxnOutcome::RejectedByHook(rejection.reason))
+                }
+                Ok(()) => {
+                    crate::git::pack_server::promote_quarantine(&repo, quarantine)
+                        .map_err(|e| Status::internal(format!("promote quarantine: {}", e)))?;
+                    txn.commit(None)
+                        .map_err(|e| Status::internal(format!("commit ref transaction: {}", e)))?;
+                    Ok(TxnOutcome::Committed)
+                }
+            }
         })
         .await
-        .map_err(|e| Status::internal(format!("commit join: {}", e)))??;
+        .map_err(|e| Status::internal(format!("commit join: {}", e)))?;
 
-        pipeline.run_reference_transaction_committed(&repo_path, &accepted_updates_clone);
+        match txn_result? {
+            TxnOutcome::Committed => {
+                pipeline.run_reference_transaction_committed(
+                    &repo_path,
+                    &accepted_updates_for_callbacks,
+                );
+            }
+            TxnOutcome::RejectedByHook(reason) => {
+                pipeline
+                    .run_reference_transaction_aborted(&repo_path, &accepted_updates_for_callbacks);
+                let all_refs: Vec<&str> = ref_updates.iter().map(|u| u.ref_name.as_str()).collect();
+                let report_status = build_rejection_status(&all_refs, &reason);
+                return Ok(Response::new(ReceivePackResponse { report_status }));
+            }
+        }
 
         info!(repo_id = %repo_id, "receive_pack: refs committed");
 
-        pipeline.run_post_receive(&repo_path, &accepted_updates_clone);
+        pipeline.run_post_receive(&repo_path, &accepted_updates_for_callbacks);
 
         let report_status = build_report_status(
             &ref_updates,

--- a/gitstore-git-service/src/grpc/server.rs
+++ b/gitstore-git-service/src/grpc/server.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tonic::{Request, Response, Status};
 
+use crate::git::hooks::{HookPipeline, NoopAdmissionHandler, RefUpdate};
 use crate::git::repo::{create_repository, delete_repository, fanout_path, list_tags};
 use tracing::{error, info};
 
@@ -24,13 +25,35 @@ use proto::*;
 pub struct GitServiceImpl {
     pub data_root: Arc<PathBuf>,
     pub repo_locks: Arc<DashMap<String, Arc<RwLock<()>>>>,
+    pub hook_pipeline: Arc<HookPipeline>,
 }
 
 impl GitServiceImpl {
     pub fn new(data_root: PathBuf) -> Self {
+        use crate::config::{GitReceivePackHooks, HookToggle};
+        let default_hooks = GitReceivePackHooks {
+            pre_receive: HookToggle { enabled: false },
+            update: HookToggle { enabled: false },
+            post_receive: HookToggle { enabled: false },
+            proc_receive: HookToggle { enabled: false },
+            post_update: HookToggle { enabled: false },
+            reference_transaction: HookToggle { enabled: false },
+        };
+        Self::with_pipeline(
+            data_root,
+            Arc::new(HookPipeline::new(
+                default_hooks,
+                "pre-receive".to_string(),
+                Arc::new(NoopAdmissionHandler),
+            )),
+        )
+    }
+
+    pub fn with_pipeline(data_root: PathBuf, hook_pipeline: Arc<HookPipeline>) -> Self {
         Self {
             data_root: Arc::new(data_root),
             repo_locks: Arc::new(DashMap::new()),
+            hook_pipeline,
         }
     }
 }
@@ -822,103 +845,165 @@ impl GitService for GitServiceImpl {
         info!(repo_id = %repo_id, "receive_pack: pack staged in quarantine");
 
         // Build ref_updates from ref_commands
-        let ref_updates: Vec<crate::git::hooks::RefUpdate> = ref_commands
+        let ref_updates: Vec<RefUpdate> = ref_commands
             .iter()
-            .map(|c| crate::git::hooks::RefUpdate {
+            .map(|c| RefUpdate {
                 ref_name: c.ref_name.clone(),
                 old_oid: c.old_oid.clone(),
                 new_oid: c.new_oid.clone(),
             })
             .collect();
 
-        let repo =
-            gix::open(&repo_path).map_err(|e| Status::internal(format!("open repo: {}", e)))?;
-
-        crate::git::hooks::run_pre_receive(&repo_path, &ref_updates)
-            .map_err(|e| Status::internal(format!("pre-receive: {}", e)))?;
-
-        let mut validated_updates: Vec<crate::git::hooks::RefUpdate> = Vec::new();
-        let mut rejected: Vec<String> = Vec::new();
-        for update in &ref_updates {
-            let is_non_ff = validate_ref_command(&repo, &update.ref_name, &update.old_oid)
-                .map_err(|e| Status::internal(e.to_string()))?;
-            if is_non_ff {
-                rejected.push(update.ref_name.clone());
-            } else {
-                validated_updates.push(update.clone());
+        // Non-fast-forward validation in blocking context (gix::Repository is !Send).
+        let ref_updates_clone = ref_updates.clone();
+        let repo_path_nff = repo_path.clone();
+        let (nff_rejected, pipeline_updates) = tokio::task::spawn_blocking(move || {
+            let repo = gix::open(&repo_path_nff)
+                .map_err(|e| Status::internal(format!("open repo for nff: {}", e)))?;
+            let mut rejected = Vec::new();
+            let mut valid = Vec::new();
+            for update in &ref_updates_clone {
+                let is_non_ff = validate_ref_command(&repo, &update.ref_name, &update.old_oid)
+                    .map_err(|e| Status::internal(e.to_string()))?;
+                if is_non_ff {
+                    rejected.push(update.ref_name.clone());
+                } else {
+                    valid.push(update.clone());
+                }
             }
+            Ok::<_, Status>((rejected, valid))
+        })
+        .await
+        .map_err(|e| Status::internal(format!("nff join: {}", e)))??;
+
+        // Run hook pipeline async (pre-receive → proc-receive → update).
+        let pipeline = Arc::clone(&self.hook_pipeline);
+        let repo_path_pipeline = repo_path.clone();
+        let accepted_indices = match pipeline.run(&repo_path_pipeline, &pipeline_updates).await {
+            Ok(indices) => indices,
+            Err(rejection) => {
+                let all_refs: Vec<&str> = ref_updates.iter().map(|u| u.ref_name.as_str()).collect();
+                let report_status = build_rejection_status(&all_refs, &rejection.reason);
+                return Ok(Response::new(ReceivePackResponse { report_status }));
+            }
+        };
+
+        let accepted_updates: Vec<RefUpdate> = accepted_indices
+            .iter()
+            .map(|i| pipeline_updates[*i].clone())
+            .collect();
+
+        // reference-transaction/prepared veto (async).
+        let repo_path_reftxn = repo_path.clone();
+        let rt_result = pipeline
+            .run_reference_transaction_prepared(&repo_path_reftxn, &accepted_updates)
+            .await;
+
+        if let Err(rejection) = rt_result {
+            pipeline.run_reference_transaction_aborted(&repo_path, &accepted_updates);
+            let all_refs: Vec<&str> = ref_updates.iter().map(|u| u.ref_name.as_str()).collect();
+            let report_status = build_rejection_status(&all_refs, &rejection.reason);
+            return Ok(Response::new(ReceivePackResponse { report_status }));
         }
 
-        let accepted_indices = crate::git::hooks::run_update_hooks(&repo_path, &validated_updates)
-            .map_err(|e| Status::internal(format!("update hooks: {}", e)))?;
+        // Build ref_edits and commit transaction in blocking context.
+        let pipeline_updates_for_txn = pipeline_updates.clone();
+        let accepted_indices_clone = accepted_indices.clone();
+        let accepted_updates_clone = accepted_updates.clone();
+        let repo_path_commit = repo_path.clone();
+        tokio::task::spawn_blocking(move || {
+            use gix::refs::transaction::{Change, LogChange, PreviousValue, RefEdit, RefLog};
 
-        use gix::refs::transaction::{Change, LogChange, PreviousValue, RefEdit, RefLog};
-        let mut ref_edits: Vec<RefEdit> = Vec::new();
-        for i in &accepted_indices {
-            let u = &validated_updates[*i];
-            let new_id = gix::ObjectId::from_hex(u.new_oid.as_bytes())
-                .map_err(|e| Status::invalid_argument(format!("parse new oid: {}", e)))?;
-            let old_id = gix::ObjectId::from_hex(u.old_oid.as_bytes())
-                .map_err(|e| Status::invalid_argument(format!("parse old oid: {}", e)))?;
+            let repo = gix::open(&repo_path_commit)
+                .map_err(|e| Status::internal(format!("open repo for commit: {}", e)))?;
 
-            let change = if new_id.is_null() {
-                let expected = if old_id.is_null() {
-                    PreviousValue::Any
+            let mut ref_edits: Vec<RefEdit> = Vec::new();
+            for i in &accepted_indices_clone {
+                let u = &pipeline_updates_for_txn[*i];
+                let new_id = gix::ObjectId::from_hex(u.new_oid.as_bytes())
+                    .map_err(|e| Status::invalid_argument(format!("parse new oid: {}", e)))?;
+                let old_id = gix::ObjectId::from_hex(u.old_oid.as_bytes())
+                    .map_err(|e| Status::invalid_argument(format!("parse old oid: {}", e)))?;
+
+                let change = if new_id.is_null() {
+                    let expected = if old_id.is_null() {
+                        PreviousValue::Any
+                    } else {
+                        PreviousValue::MustExistAndMatch(gix::refs::Target::Object(old_id))
+                    };
+                    Change::Delete {
+                        expected,
+                        log: RefLog::AndReference,
+                    }
                 } else {
-                    PreviousValue::MustExistAndMatch(gix::refs::Target::Object(old_id))
+                    let previous_value = if old_id.is_null() {
+                        PreviousValue::MustNotExist
+                    } else {
+                        PreviousValue::MustExistAndMatch(gix::refs::Target::Object(old_id))
+                    };
+                    Change::Update {
+                        log: LogChange {
+                            mode: RefLog::AndReference,
+                            force_create_reflog: false,
+                            message: "push".into(),
+                        },
+                        expected: previous_value,
+                        new: gix::refs::Target::Object(new_id),
+                    }
                 };
-                Change::Delete {
-                    expected,
-                    log: RefLog::AndReference,
-                }
-            } else {
-                let previous_value = if old_id.is_null() {
-                    PreviousValue::MustNotExist
-                } else {
-                    PreviousValue::MustExistAndMatch(gix::refs::Target::Object(old_id))
-                };
-                Change::Update {
-                    log: LogChange {
-                        mode: RefLog::AndReference,
-                        force_create_reflog: false,
-                        message: "push".into(),
-                    },
-                    expected: previous_value,
-                    new: gix::refs::Target::Object(new_id),
-                }
-            };
-            ref_edits.push(RefEdit {
-                change,
-                name: u
-                    .ref_name
-                    .as_str()
-                    .try_into()
-                    .map_err(|e: gix::refs::name::Error| {
-                        Status::invalid_argument(format!("parse refname: {}", e))
-                    })?,
-                deref: false,
-            });
-        }
+                ref_edits.push(RefEdit {
+                    change,
+                    name: u
+                        .ref_name
+                        .as_str()
+                        .try_into()
+                        .map_err(|e: gix::refs::name::Error| {
+                            Status::invalid_argument(format!("parse refname: {}", e))
+                        })?,
+                    deref: false,
+                });
+            }
 
-        // Promote pack objects first so refs never point to missing objects.
-        crate::git::pack_server::promote_quarantine(&repo, quarantine)
-            .map_err(|e| Status::internal(format!("promote quarantine: {}", e)))?;
+            if !ref_edits.is_empty() {
+                let file_lock_fail = gix::lock::acquire::Fail::AfterDurationWithBackoff(
+                    std::time::Duration::from_millis(100),
+                );
+                let packed_lock_fail = gix::lock::acquire::Fail::AfterDurationWithBackoff(
+                    std::time::Duration::from_millis(1000),
+                );
+                let txn = repo
+                    .refs
+                    .transaction()
+                    .prepare(ref_edits, file_lock_fail, packed_lock_fail)
+                    .map_err(|e| Status::internal(format!("prepare ref transaction: {}", e)))?;
 
-        if !ref_edits.is_empty() {
-            repo.edit_references(ref_edits)
-                .map_err(|e| Status::internal(format!("ref transaction: {}", e)))?;
-        }
+                crate::git::pack_server::promote_quarantine(&repo, quarantine)
+                    .map_err(|e| Status::internal(format!("promote quarantine: {}", e)))?;
+                txn.commit(None)
+                    .map_err(|e| Status::internal(format!("commit ref transaction: {}", e)))?;
+            }
+            Ok::<_, Status>(())
+        })
+        .await
+        .map_err(|e| Status::internal(format!("commit join: {}", e)))??;
 
-        info!(repo_id = %repo_id, "receive_pack: quarantine promoted, refs committed");
+        pipeline.run_reference_transaction_committed(&repo_path, &accepted_updates_clone);
 
-        crate::git::hooks::run_post_receive(&repo_path, &validated_updates);
+        info!(repo_id = %repo_id, "receive_pack: refs committed");
 
-        let report_status = build_report_status(&ref_updates, &accepted_indices, &rejected);
+        pipeline.run_post_receive(&repo_path, &accepted_updates_clone);
+
+        let report_status = build_report_status(
+            &ref_updates,
+            &pipeline_updates,
+            &accepted_indices,
+            &nff_rejected,
+        );
 
         info!(
             repo_id = %repo_id,
             refs_accepted = accepted_indices.len(),
-            refs_rejected = rejected.len(),
+            refs_rejected = nff_rejected.len(),
             "receive_pack: complete"
         );
 
@@ -1070,25 +1155,50 @@ fn validate_ref_command(
     }
 }
 
+/// Build a report-status payload where every ref is rejected with the same reason.
+fn build_rejection_status(all_ref_names: &[&str], reason: &str) -> Vec<u8> {
+    let mut inner = Vec::new();
+    let _ = write_pkt_line_buf(&mut inner, b"unpack ok\n");
+    for ref_name in all_ref_names {
+        let _ = write_pkt_line_buf(&mut inner, format!("ng {ref_name} {reason}\n").as_bytes());
+    }
+    inner.extend_from_slice(b"0000");
+    let mut sideband_data = vec![0x01u8];
+    sideband_data.extend_from_slice(&inner);
+    let mut response = Vec::new();
+    let _ = write_pkt_line_buf(&mut response, &sideband_data);
+    response.extend_from_slice(b"0000");
+    response
+}
+
 /// Build a report-status pkt-line payload.
+///
+/// `all_updates` — original full list of requested ref updates (for reporting).
+/// `pipeline_updates` — subset that passed nff validation (passed to hook pipeline).
+/// `accepted_indices` — indices into `pipeline_updates` that were accepted.
+/// `nff_rejected` — ref names rejected as non-fast-forward before the pipeline.
 fn build_report_status(
-    all_updates: &[crate::git::hooks::RefUpdate],
+    all_updates: &[RefUpdate],
+    pipeline_updates: &[RefUpdate],
     accepted_indices: &[usize],
-    rejected_refs: &[String],
+    nff_rejected: &[String],
 ) -> Vec<u8> {
     use std::collections::HashSet;
-    let accepted_set: HashSet<usize> = accepted_indices.iter().copied().collect();
-    let rejected_set: HashSet<&str> = rejected_refs.iter().map(|s| s.as_str()).collect();
+    let accepted_names: HashSet<&str> = accepted_indices
+        .iter()
+        .map(|i| pipeline_updates[*i].ref_name.as_str())
+        .collect();
+    let nff_set: HashSet<&str> = nff_rejected.iter().map(|s| s.as_str()).collect();
 
     let mut inner = Vec::new();
     let _ = write_pkt_line_buf(&mut inner, b"unpack ok\n");
-    for (i, u) in all_updates.iter().enumerate() {
-        if rejected_set.contains(u.ref_name.as_str()) {
+    for u in all_updates {
+        if nff_set.contains(u.ref_name.as_str()) {
             let _ = write_pkt_line_buf(
                 &mut inner,
                 format!("ng {} non-fast-forward\n", u.ref_name).as_bytes(),
             );
-        } else if accepted_set.contains(&i) {
+        } else if accepted_names.contains(u.ref_name.as_str()) {
             let _ = write_pkt_line_buf(&mut inner, format!("ok {}\n", u.ref_name).as_bytes());
         } else {
             let _ = write_pkt_line_buf(

--- a/gitstore-git-service/src/main.rs
+++ b/gitstore-git-service/src/main.rs
@@ -8,6 +8,9 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use tracing::{error, info};
 
+use std::sync::Arc;
+
+use gitstore::git::hooks::{HookPipeline, NoopAdmissionHandler};
 use gitstore::grpc::server::{proto::git_service_server::GitServiceServer, GitServiceImpl};
 
 #[derive(Parser, Debug)]
@@ -58,7 +61,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Start gRPC server
     let grpc_addr: SocketAddr = format!("0.0.0.0:{}", cfg.grpc.port).parse()?;
-    let grpc_service = GitServiceImpl::new(data_path.clone());
+    let hook_pipeline = Arc::new(HookPipeline::new(
+        cfg.hooks.git_receive_pack.clone(),
+        cfg.admission_control
+            .validating_admission_policy
+            .phase
+            .clone(),
+        Arc::new(NoopAdmissionHandler),
+    ));
+    let grpc_service = GitServiceImpl::with_pipeline(data_path.clone(), hook_pipeline);
     info!(
         grpc_port = cfg.grpc.port,
         "gRPC server starting on {}", grpc_addr

--- a/gitstore-git-service/tests/integration/helpers.rs
+++ b/gitstore-git-service/tests/integration/helpers.rs
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use gitstore::git::hooks::{AdmissionDecision, AdmissionHandler, RefUpdate};
+
+/// Create a bare git repository at `dir` and return its path.
+pub fn make_bare_repo(dir: &Path) -> PathBuf {
+    let repo_path = dir.join("repo.git");
+    gix::init_bare(&repo_path).expect("init_bare");
+    repo_path
+}
+
+/// Commit a single file into a bare repo, creating `refs/heads/main` if needed.
+/// Returns the new commit OID as a hex string.
+pub fn make_commit(repo_path: &Path, msg: &str) -> String {
+    let repo = gix::open(repo_path).expect("open repo");
+
+    let sig = gix::actor::Signature {
+        name: "test".into(),
+        email: "test@example.com".into(),
+        time: gix::date::Time::now_local_or_utc(),
+    };
+
+    let blob_oid: gix::ObjectId = repo
+        .write_blob(msg.as_bytes())
+        .expect("write_blob")
+        .detach();
+
+    let parent = repo.head_commit().ok().map(|c| c.id().detach());
+    let parent_tree_id = parent
+        .and_then(|id| repo.find_object(id).ok())
+        .and_then(|obj| obj.try_into_commit().ok())
+        .and_then(|c| c.tree_id().ok())
+        .map(|id| id.detach())
+        .unwrap_or_else(|| gix::ObjectId::empty_tree(gix::hash::Kind::Sha1));
+
+    let new_tree = repo
+        .edit_tree(parent_tree_id)
+        .expect("edit_tree")
+        .upsert("file.txt", gix::object::tree::EntryKind::Blob, blob_oid)
+        .expect("upsert")
+        .write()
+        .expect("write tree")
+        .detach();
+
+    let parents: Vec<gix::ObjectId> = parent.into_iter().collect();
+
+    let mut time_buf = gix::date::parse::TimeBuf::default();
+    let sig_ref = sig.to_ref(&mut time_buf);
+
+    let commit_id = repo
+        .commit_as(sig_ref, sig_ref, "HEAD", msg, new_tree, parents)
+        .expect("commit_as")
+        .detach();
+
+    // Ensure refs/heads/main exists
+    use gix::refs::transaction::{Change, LogChange, PreviousValue, RefEdit, RefLog};
+    use gix::refs::Target;
+    repo.edit_reference(RefEdit {
+        change: Change::Update {
+            log: LogChange {
+                mode: RefLog::AndReference,
+                force_create_reflog: false,
+                message: "update".into(),
+            },
+            expected: PreviousValue::Any,
+            new: Target::Symbolic("refs/heads/main".try_into().unwrap()),
+        },
+        name: "HEAD".try_into().unwrap(),
+        deref: false,
+    })
+    .ok();
+    repo.edit_reference(RefEdit {
+        change: Change::Update {
+            log: LogChange {
+                mode: RefLog::AndReference,
+                force_create_reflog: false,
+                message: "commit".into(),
+            },
+            expected: PreviousValue::Any,
+            new: Target::Object(commit_id),
+        },
+        name: "refs/heads/main".try_into().unwrap(),
+        deref: false,
+    })
+    .expect("update main ref");
+
+    commit_id.to_string()
+}
+
+pub fn zero_oid() -> &'static str {
+    "0000000000000000000000000000000000000000"
+}
+
+// ---------------------------------------------------------------------------
+// Test doubles for AdmissionHandler
+// ---------------------------------------------------------------------------
+
+/// Always rejects with the configured reason.
+pub struct RejectingAdmissionHandler(pub String);
+
+#[async_trait]
+impl AdmissionHandler for RejectingAdmissionHandler {
+    async fn admit(
+        &self,
+        _phase: &str,
+        _updates: &[RefUpdate],
+    ) -> anyhow::Result<AdmissionDecision> {
+        Ok(AdmissionDecision::Reject(self.0.clone()))
+    }
+}
+
+/// Rejects refs whose index (within the provided slice) is in the given set.
+pub struct PerRefRejectingHandler(pub std::collections::HashSet<usize>);
+
+#[async_trait]
+impl AdmissionHandler for PerRefRejectingHandler {
+    async fn admit(
+        &self,
+        _phase: &str,
+        updates: &[RefUpdate],
+    ) -> anyhow::Result<AdmissionDecision> {
+        // When called per-ref (single update), identify position by ref_name tag
+        // The handler is called once per ref, so updates.len() == 1 in update phase.
+        // We use the ref_name suffix "idx:<n>" to identify the position.
+        for u in updates {
+            if let Some(rest) = u.ref_name.strip_prefix("refs/test/idx/") {
+                if let Ok(idx) = rest.parse::<usize>() {
+                    if self.0.contains(&idx) {
+                        return Ok(AdmissionDecision::Reject(format!(
+                            "rejected ref at index {idx}"
+                        )));
+                    }
+                }
+            }
+        }
+        Ok(AdmissionDecision::Accept)
+    }
+}
+
+/// Sleeps longer than the pipeline timeout before returning, to trigger fail-closed.
+pub struct SlowAdmissionHandler;
+
+#[async_trait]
+impl AdmissionHandler for SlowAdmissionHandler {
+    async fn admit(
+        &self,
+        _phase: &str,
+        _updates: &[RefUpdate],
+    ) -> anyhow::Result<AdmissionDecision> {
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        Ok(AdmissionDecision::Accept)
+    }
+}
+
+/// Counts how many times admit() is called.
+pub struct CountingAdmissionHandler(pub Arc<AtomicUsize>);
+
+impl CountingAdmissionHandler {
+    pub fn new() -> (Self, Arc<AtomicUsize>) {
+        let counter = Arc::new(AtomicUsize::new(0));
+        (Self(Arc::clone(&counter)), counter)
+    }
+}
+
+#[async_trait]
+impl AdmissionHandler for CountingAdmissionHandler {
+    async fn admit(
+        &self,
+        _phase: &str,
+        _updates: &[RefUpdate],
+    ) -> anyhow::Result<AdmissionDecision> {
+        self.0.fetch_add(1, Ordering::SeqCst);
+        Ok(AdmissionDecision::Accept)
+    }
+}

--- a/gitstore-git-service/tests/integration/hook_pipeline.rs
+++ b/gitstore-git-service/tests/integration/hook_pipeline.rs
@@ -1,0 +1,390 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use tempfile::TempDir;
+
+use gitstore::config::{GitReceivePackHooks, HookToggle};
+use gitstore::git::hooks::{HookPipeline, NoopAdmissionHandler, RefUpdate};
+
+use super::helpers::{
+    make_bare_repo, make_commit, zero_oid, CountingAdmissionHandler, PerRefRejectingHandler,
+    RejectingAdmissionHandler, SlowAdmissionHandler,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn all_disabled() -> GitReceivePackHooks {
+    GitReceivePackHooks {
+        pre_receive: HookToggle { enabled: false },
+        update: HookToggle { enabled: false },
+        post_receive: HookToggle { enabled: false },
+        proc_receive: HookToggle { enabled: false },
+        post_update: HookToggle { enabled: false },
+        reference_transaction: HookToggle { enabled: false },
+    }
+}
+
+fn all_enabled() -> GitReceivePackHooks {
+    GitReceivePackHooks {
+        pre_receive: HookToggle { enabled: true },
+        update: HookToggle { enabled: true },
+        post_receive: HookToggle { enabled: true },
+        proc_receive: HookToggle { enabled: true },
+        post_update: HookToggle { enabled: false }, // legacy, excluded from scope
+        reference_transaction: HookToggle { enabled: true },
+    }
+}
+
+fn noop_pipeline(config: GitReceivePackHooks) -> HookPipeline {
+    HookPipeline::new(
+        config,
+        "pre-receive".to_string(),
+        Arc::new(NoopAdmissionHandler),
+    )
+}
+
+fn make_update(ref_name: &str, old_oid: &str, new_oid: &str) -> RefUpdate {
+    RefUpdate {
+        ref_name: ref_name.to_string(),
+        old_oid: old_oid.to_string(),
+        new_oid: new_oid.to_string(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// T010 / US1: Happy path — push accepted, phase order (with all phases enabled)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_push_accepted_all_phases_enabled() {
+    let dir = TempDir::new().unwrap();
+    let repo_path = make_bare_repo(dir.path());
+    let old_oid = make_commit(&repo_path, "initial");
+    let new_oid = make_commit(&repo_path, "second");
+
+    let pipeline = noop_pipeline(all_enabled());
+    let update = make_update("refs/heads/main", &old_oid, &new_oid);
+
+    let result = pipeline
+        .run(&repo_path, std::slice::from_ref(&update))
+        .await
+        .unwrap();
+    assert_eq!(result, vec![0], "index 0 should be accepted");
+
+    let rt_result = pipeline
+        .run_reference_transaction_prepared(&repo_path, std::slice::from_ref(&update))
+        .await;
+    assert!(
+        rt_result.is_ok(),
+        "reference-transaction/prepared should accept"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T011 / US1: Per-phase log events emitted (structural check via pipeline execution)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_pipeline_run_returns_all_accepted_with_noop() {
+    let dir = TempDir::new().unwrap();
+    let repo_path = make_bare_repo(dir.path());
+    let oid = make_commit(&repo_path, "init");
+
+    let pipeline = noop_pipeline(all_enabled());
+    let update = make_update("refs/heads/main", zero_oid(), &oid);
+
+    let accepted = pipeline.run(&repo_path, &[update]).await.unwrap();
+    assert_eq!(accepted, vec![0]);
+}
+
+// ---------------------------------------------------------------------------
+// T020 / US2: pre-receive rejection aborts entire push
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_push_rejected_pre_receive() {
+    let dir = TempDir::new().unwrap();
+    let repo_path = make_bare_repo(dir.path());
+    let oid1 = make_commit(&repo_path, "init");
+    let oid2 = make_commit(&repo_path, "second");
+
+    let mut cfg = all_disabled();
+    cfg.pre_receive = HookToggle { enabled: true };
+    let pipeline = HookPipeline::new(
+        cfg,
+        "pre-receive".to_string(),
+        Arc::new(RejectingAdmissionHandler("blocked by policy".to_string())),
+    );
+
+    let updates = vec![
+        make_update("refs/heads/main", &oid1, &oid2),
+        make_update("refs/heads/dev", zero_oid(), &oid1),
+    ];
+    let err = pipeline.run(&repo_path, &updates).await.unwrap_err();
+    assert_eq!(err.phase, "pre-receive");
+    assert_eq!(err.reason, "blocked by policy");
+}
+
+// ---------------------------------------------------------------------------
+// T021 / US2: update per-ref rejection — one ref blocked, others proceed
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_push_rejected_update_one_ref() {
+    let dir = TempDir::new().unwrap();
+    let repo_path = make_bare_repo(dir.path());
+    let oid = make_commit(&repo_path, "init");
+
+    let mut cfg = all_disabled();
+    cfg.update = HookToggle { enabled: true };
+
+    // PerRefRejectingHandler rejects refs named refs/test/idx/1
+    let mut reject_set = HashSet::new();
+    reject_set.insert(1usize);
+    let pipeline = HookPipeline::new(
+        cfg,
+        "update".to_string(),
+        Arc::new(PerRefRejectingHandler(reject_set)),
+    );
+
+    let updates = vec![
+        make_update("refs/test/idx/0", zero_oid(), &oid),
+        make_update("refs/test/idx/1", zero_oid(), &oid),
+        make_update("refs/test/idx/2", zero_oid(), &oid),
+    ];
+    let accepted = pipeline.run(&repo_path, &updates).await.unwrap();
+    assert_eq!(accepted, vec![0, 2], "only idx/1 should be rejected");
+}
+
+// ---------------------------------------------------------------------------
+// T022 / US2: proc-receive rejection aborts push
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_push_rejected_proc_receive() {
+    let dir = TempDir::new().unwrap();
+    let repo_path = make_bare_repo(dir.path());
+    let oid = make_commit(&repo_path, "init");
+
+    let mut cfg = all_disabled();
+    cfg.proc_receive = HookToggle { enabled: true };
+    let pipeline = HookPipeline::new(
+        cfg,
+        "proc-receive".to_string(),
+        Arc::new(RejectingAdmissionHandler("proc blocked".to_string())),
+    );
+
+    let update = make_update("refs/heads/main", zero_oid(), &oid);
+    let err = pipeline.run(&repo_path, &[update]).await.unwrap_err();
+    assert_eq!(err.phase, "proc-receive");
+    assert_eq!(err.reason, "proc blocked");
+}
+
+// ---------------------------------------------------------------------------
+// T023 / US2: reference-transaction/prepared veto
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_reference_transaction_veto() {
+    let dir = TempDir::new().unwrap();
+    let repo_path = make_bare_repo(dir.path());
+    let oid = make_commit(&repo_path, "init");
+
+    let mut cfg = all_disabled();
+    cfg.reference_transaction = HookToggle { enabled: true };
+    let pipeline = HookPipeline::new(
+        cfg,
+        "reference-transaction/prepared".to_string(),
+        Arc::new(RejectingAdmissionHandler("txn blocked".to_string())),
+    );
+
+    let update = make_update("refs/heads/main", zero_oid(), &oid);
+    let err = pipeline
+        .run_reference_transaction_prepared(&repo_path, &[update])
+        .await
+        .unwrap_err();
+    assert_eq!(err.phase, "reference-transaction/prepared");
+    assert_eq!(err.reason, "txn blocked");
+}
+
+// ---------------------------------------------------------------------------
+// T029 / US3: all phases disabled — all refs accepted, no log overhead
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_all_phases_disabled() {
+    let dir = TempDir::new().unwrap();
+    let repo_path = make_bare_repo(dir.path());
+    let oid = make_commit(&repo_path, "init");
+
+    let pipeline = noop_pipeline(all_disabled());
+    let update = make_update("refs/heads/main", zero_oid(), &oid);
+
+    let accepted = pipeline.run(&repo_path, &[update]).await.unwrap();
+    assert_eq!(accepted, vec![0]);
+}
+
+// ---------------------------------------------------------------------------
+// T030 / US3: only pre-receive enabled
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_only_pre_receive_enabled() {
+    let dir = TempDir::new().unwrap();
+    let repo_path = make_bare_repo(dir.path());
+    let oid = make_commit(&repo_path, "init");
+
+    let mut cfg = all_disabled();
+    cfg.pre_receive = HookToggle { enabled: true };
+    let pipeline = noop_pipeline(cfg);
+
+    let update = make_update("refs/heads/main", zero_oid(), &oid);
+    let accepted = pipeline.run(&repo_path, &[update]).await.unwrap();
+    assert_eq!(accepted, vec![0]);
+}
+
+// ---------------------------------------------------------------------------
+// T031 / US3: reference-transaction disabled — prepared returns Ok immediately
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_reference_transaction_disabled() {
+    let dir = TempDir::new().unwrap();
+    let repo_path = make_bare_repo(dir.path());
+    let oid = make_commit(&repo_path, "init");
+
+    let pipeline = noop_pipeline(all_disabled());
+    let update = make_update("refs/heads/main", zero_oid(), &oid);
+
+    let result = pipeline
+        .run_reference_transaction_prepared(&repo_path, &[update])
+        .await;
+    assert!(result.is_ok());
+}
+
+// ---------------------------------------------------------------------------
+// T035 / US4: admission accept at configured phase
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_admission_accept() {
+    let dir = TempDir::new().unwrap();
+    let repo_path = make_bare_repo(dir.path());
+    let oid = make_commit(&repo_path, "init");
+
+    let mut cfg = all_disabled();
+    cfg.pre_receive = HookToggle { enabled: true };
+    let pipeline = HookPipeline::new(
+        cfg,
+        "pre-receive".to_string(),
+        Arc::new(NoopAdmissionHandler),
+    );
+
+    let update = make_update("refs/heads/main", zero_oid(), &oid);
+    let accepted = pipeline.run(&repo_path, &[update]).await.unwrap();
+    assert_eq!(accepted, vec![0]);
+}
+
+// ---------------------------------------------------------------------------
+// T036 / US4: admission reject with reason
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_admission_reject_with_reason() {
+    let dir = TempDir::new().unwrap();
+    let repo_path = make_bare_repo(dir.path());
+    let oid = make_commit(&repo_path, "init");
+
+    let mut cfg = all_disabled();
+    cfg.update = HookToggle { enabled: true };
+    let pipeline = HookPipeline::new(
+        cfg,
+        "update".to_string(),
+        Arc::new(RejectingAdmissionHandler("policy violation".to_string())),
+    );
+
+    let update = make_update("refs/heads/main", zero_oid(), &oid);
+    // update is per-ref, rejection causes that ref to be marked ng (not a pipeline Err)
+    // All refs are rejected so accepted set is empty.
+    let accepted = pipeline.run(&repo_path, &[update]).await.unwrap();
+    assert!(
+        accepted.is_empty(),
+        "all refs should be rejected by update admission"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T037 / US4: admission timeout → fail-closed
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_admission_timeout_fail_closed() {
+    let dir = TempDir::new().unwrap();
+    let repo_path = make_bare_repo(dir.path());
+    let oid = make_commit(&repo_path, "init");
+
+    let mut cfg = all_disabled();
+    cfg.pre_receive = HookToggle { enabled: true };
+    let pipeline = HookPipeline::new(
+        cfg,
+        "pre-receive".to_string(),
+        Arc::new(SlowAdmissionHandler),
+    );
+
+    let update = make_update("refs/heads/main", zero_oid(), &oid);
+    let start = std::time::Instant::now();
+    let err = pipeline.run(&repo_path, &[update]).await.unwrap_err();
+    let elapsed = start.elapsed();
+
+    assert_eq!(err.phase, "pre-receive");
+    assert_eq!(err.reason, "admission service timeout");
+    // Should complete well under 10 seconds (the slow handler sleeps 10s)
+    assert!(
+        elapsed.as_secs() < 8,
+        "pipeline should have timed out at 5s, took {:?}",
+        elapsed
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T038 / US4: admission called only at configured phase
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_admission_only_called_at_configured_phase() {
+    let dir = TempDir::new().unwrap();
+    let repo_path = make_bare_repo(dir.path());
+    let oid1 = make_commit(&repo_path, "init");
+    let oid2 = make_commit(&repo_path, "second");
+
+    // Enable both pre-receive and update; route admission to update only.
+    let mut cfg = all_disabled();
+    cfg.pre_receive = HookToggle { enabled: true };
+    cfg.update = HookToggle { enabled: true };
+
+    let (counter_handler, counter) = CountingAdmissionHandler::new();
+    let pipeline = HookPipeline::new(
+        cfg,
+        "update".to_string(), // admission only at update
+        Arc::new(counter_handler),
+    );
+
+    let updates = vec![
+        make_update("refs/heads/main", &oid1, &oid2),
+        make_update("refs/heads/dev", zero_oid(), &oid1),
+    ];
+    let accepted = pipeline.run(&repo_path, &updates).await.unwrap();
+    assert_eq!(accepted, vec![0, 1]);
+
+    // Admission called once per ref in update phase = 2 times; pre-receive = 0
+    let call_count = counter.load(std::sync::atomic::Ordering::SeqCst);
+    assert_eq!(
+        call_count, 2,
+        "should be called once per ref in update phase"
+    );
+}

--- a/gitstore-git-service/tests/integration/mod.rs
+++ b/gitstore-git-service/tests/integration/mod.rs
@@ -3,6 +3,9 @@
 
 // Integration tests: full repository lifecycle without service restart (SC-008)
 
+pub mod helpers;
+pub mod hook_pipeline;
+
 use gitstore::grpc::server::{proto, GitServiceImpl};
 use proto::git_service_server::GitService;
 use tempfile::TempDir;

--- a/specs/013-receive-pack-hooks/checklists/requirements.md
+++ b/specs/013-receive-pack-hooks/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: In-Process git-receive-pack Hook Pipeline
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-01
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All items pass. Spec is ready for `/speckit.clarify` or `/speckit.plan`.

--- a/specs/013-receive-pack-hooks/contracts/hook-pipeline.md
+++ b/specs/013-receive-pack-hooks/contracts/hook-pipeline.md
@@ -1,0 +1,138 @@
+# Contract: Hook Pipeline Public Interface
+
+**Service**: `gitstore-git-service` (Rust)  
+**Feature**: `013-receive-pack-hooks`  
+**Date**: 2026-06-01
+
+## AdmissionHandler Trait Contract
+
+This trait is the stable integration point for future admission (#105) and validation (#106) services. Any type that implements this trait can be injected into the hook pipeline.
+
+```rust
+/// Implemented by any service that participates in push admission.
+/// Called at the phase assigned by GITSTORE_ADMISSION_CONTROL_VALIDATING_ADMISSION_POLICY_PHASE.
+#[async_trait]
+pub trait AdmissionHandler: Send + Sync {
+    /// Called once per push for per-push phases (pre-receive, proc-receive, post-receive).
+    /// Called once per ref for per-ref phases (update).
+    ///
+    /// Returns:
+    ///   Ok(Accept)          — push/ref proceeds
+    ///   Ok(Reject(reason))  — push/ref rejected; reason shown to Git client verbatim
+    ///   Err(_)              — treated as Reject("admission handler error")
+    async fn admit(
+        &self,
+        phase: &str,           // canonical phase name (see Phase Names below)
+        updates: &[RefUpdate], // all updates for per-push phases; single update for per-ref phases
+    ) -> anyhow::Result<AdmissionDecision>;
+}
+```
+
+### Phase Names (canonical strings)
+
+| Phase                              | Cardinality | Called when…                           |
+|------------------------------------|-------------|----------------------------------------|
+| `"pre-receive"`                    | once/push   | Before any ref is updated              |
+| `"proc-receive"`                   | once/push   | After pre-receive, before update       |
+| `"update"`                         | once/ref    | For each ref in the push independently |
+| `"reference-transaction/prepared"` | once/push   | Ref locks acquired, not yet committed  |
+| `"post-receive"`                   | once/push   | After refs committed (fire-and-forget) |
+
+### AdmissionDecision
+
+```rust
+pub enum AdmissionDecision {
+    Accept,
+    Reject(String), // non-empty reason shown verbatim to the Git client
+}
+```
+
+### Timeout Contract
+
+The pipeline enforces a **5-second hard timeout** on every `admit()` call. An elapsed timeout is treated as `Reject("admission service timeout")`. Implementations MUST NOT assume they will receive a cancellation signal — the future is simply dropped.
+
+### NoopAdmissionHandler (default)
+
+```rust
+pub struct NoopAdmissionHandler;
+
+#[async_trait]
+impl AdmissionHandler for NoopAdmissionHandler {
+    async fn admit(&self, _phase: &str, _updates: &[RefUpdate]) -> anyhow::Result<AdmissionDecision> {
+        Ok(AdmissionDecision::Accept)
+    }
+}
+```
+
+This is the default when no admission service is wired up.
+
+---
+
+## HookPipeline Public API
+
+```rust
+pub struct HookPipeline {
+    pub config: HooksConfig,
+    pub admission_phase: String,
+    pub admission_handler: Arc<dyn AdmissionHandler + Send + Sync>,
+}
+
+impl HookPipeline {
+    pub fn new(config: HooksConfig, admission_phase: String, handler: Arc<dyn AdmissionHandler + Send + Sync>) -> Self;
+
+    /// Run the full pipeline for a push event.
+    /// Returns Ok(Vec<usize>) — indices of accepted ref updates.
+    /// Returns Err(HookRejection) — push aborted; rejection reason for client.
+    pub async fn run(
+        &self,
+        git_dir: &Path,
+        updates: &[RefUpdate],
+        // reference-transaction is driven separately via the prepare/commit/rollback callbacks
+    ) -> Result<Vec<usize>, HookRejection>;
+
+    /// Called after pack is promoted and ref edits are prepared (locks held).
+    /// Returns Ok(()) to allow commit, Err(HookRejection) to rollback.
+    pub async fn run_reference_transaction_prepared(
+        &self,
+        git_dir: &Path,
+        updates: &[RefUpdate],
+    ) -> Result<(), HookRejection>;
+
+    /// Called after commit completes (observation only, cannot fail).
+    pub fn run_reference_transaction_committed(&self, git_dir: &Path, updates: &[RefUpdate]);
+
+    /// Called on rollback (observation only, cannot fail).
+    pub fn run_reference_transaction_aborted(&self, git_dir: &Path, updates: &[RefUpdate]);
+
+    /// Called after refs committed. Errors logged at ERROR, never propagated.
+    pub fn run_post_receive(&self, git_dir: &Path, updates: &[RefUpdate]);
+}
+
+pub struct HookRejection {
+    pub phase: String,
+    pub reason: String,
+}
+```
+
+---
+
+## Structured Log Contract
+
+Every phase execution MUST produce a `tracing` event with these fields:
+
+```
+INFO  hook_phase_complete  phase="pre-receive"  duration_ms=2  outcome="accepted"
+WARN  hook_phase_complete  phase="update"  ref_name="refs/heads/main"  duration_ms=1  outcome="rejected"  reason="non-fast-forward"
+ERROR hook_phase_error     phase="post-receive"  duration_ms=5001  reason="admission service timeout"
+```
+
+Log level rules:
+- `INFO` — phase executed and accepted
+- `WARN` — phase executed and rejected (pre-receive, update, proc-receive, reference-transaction/prepared)
+- `ERROR` — post-receive / post-update failure (fire-and-forget error)
+
+---
+
+## Backward Compatibility
+
+All hook phases default to `enabled = false` in `gitstore.toml`. No existing push behaviour changes unless an operator explicitly enables a phase. This contract makes no stability promises (alpha software).

--- a/specs/013-receive-pack-hooks/data-model.md
+++ b/specs/013-receive-pack-hooks/data-model.md
@@ -1,0 +1,158 @@
+# Data Model: In-Process git-receive-pack Hook Pipeline
+
+**Branch**: `013-receive-pack-hooks` | **Date**: 2026-06-01
+
+## Entities
+
+### RefUpdate
+
+Represents a single ref being created, updated, or deleted as part of a push event.
+
+| Field    | Type   | Constraints                                      |
+|----------|--------|--------------------------------------------------|
+| ref_name | String | Non-empty; valid Git ref name (`refs/heads/…`)   |
+| old_oid  | String | 40-hex SHA-1; all-zeros = ref does not exist yet |
+| new_oid  | String | 40-hex SHA-1; all-zeros = deletion               |
+
+Already exists in `git/hooks.rs`. No new fields needed.
+
+---
+
+### HookDecision
+
+The outcome returned by each hook phase.
+
+```
+HookDecision
+  ├── Accept
+  └── Reject(reason: String)   // reason surfaces verbatim to Git client
+```
+
+New type to be added to `git/hooks.rs`. Replaces the current `Result<()>` / `Vec<usize>` ad-hoc return convention.
+
+---
+
+### AdmissionDecision
+
+Returned by an `AdmissionHandler` implementation.
+
+```
+AdmissionDecision
+  ├── Accept
+  └── Reject(reason: String)
+```
+
+New type in `git/hooks.rs`. Semantically identical to `HookDecision`; kept separate so the admission contract is explicit and independently evolvable.
+
+---
+
+### AdmissionHandler (trait)
+
+An async, dyn-compatible trait that external admission and validation services (future: #105, #106) implement.
+
+```rust
+#[async_trait]
+pub trait AdmissionHandler: Send + Sync {
+    async fn admit(
+        &self,
+        phase: &str,           // "pre-receive" | "update" | "proc-receive" | "reference-transaction"
+        updates: &[RefUpdate],
+    ) -> anyhow::Result<AdmissionDecision>;
+}
+```
+
+Stored as `Arc<dyn AdmissionHandler + Send + Sync>` in `HttpPackServer` and passed into the gRPC `receive_pack` handler.
+
+**Built-in implementations:**
+- `NoopAdmissionHandler` — always returns `Accept`; used when no admission service is configured (default).
+
+---
+
+### HookPipeline
+
+Encapsulates phase execution, config-toggle enforcement, and per-phase logging. New type in `git/hooks.rs`.
+
+| Field              | Type                               | Description                                    |
+|--------------------|------------------------------------|------------------------------------------------|
+| config             | `HooksConfig` (copy/clone)         | Phase enabled/disabled toggles                 |
+| admission_phase    | `String`                           | Which phase routes to the admission handler    |
+| admission_handler  | `Arc<dyn AdmissionHandler>`        | The admission/validation service callout       |
+
+---
+
+### PhaseLog (structured log event — not a persisted struct)
+
+Emitted via `tracing::info!` / `tracing::warn!` for each phase execution.
+
+| Field       | Type | Notes                                         |
+|-------------|------|-----------------------------------------------|
+| phase       | &str | "pre-receive", "update", "proc-receive", etc. |
+| ref_name    | &str | Present only for per-ref phases (update)      |
+| duration_ms | u64  | Elapsed milliseconds for this phase call      |
+| outcome     | &str | "accepted" or "rejected"                      |
+| reason      | &str | Present only when outcome = "rejected"        |
+
+---
+
+## State Transitions
+
+### Push Event Lifecycle
+
+```
+push received
+    │
+    ▼
+[pack staged in quarantine]
+    │
+    ▼
+pre-receive phase ──(Reject)──► abort; return ng to client; drop quarantine
+    │ Accept
+    ▼
+proc-receive phase ──(Reject)──► abort; return ng; drop quarantine
+    │ Accept
+    ▼
+update phase (per ref) ──(Reject)──► mark ref as ng; continue other refs
+    │ at least one Accept
+    ▼
+reference-transaction: prepared
+    │
+    ├──(Reject)──► rollback all lock files; return ng to all refs; drop quarantine
+    │
+    │ Accept
+    ▼
+[promote quarantine pack → ODB]
+    │
+    ▼
+reference-transaction: committed  (observation only)
+    │
+    ▼
+post-receive phase  (fire-and-forget; failures logged at ERROR, not returned)
+    │
+    ▼
+return report-status to client
+```
+
+### reference-transaction Sub-states
+
+```
+prepared  ──Accept──►  committed  (refs written)
+          ──Reject──►  aborted    (lock files dropped)
+          ──error ──►  aborted    (Drop impl releases locks)
+```
+
+---
+
+## Validation Rules
+
+- `ref_name` must start with `refs/` (enforced upstream by gix parse, not re-validated in hook layer).
+- `old_oid` and `new_oid` must be exactly 40 hex characters or the all-zeros string.
+- A `HookDecision::Reject` reason string MUST be non-empty; the pipeline substitutes `"rejected by hook"` if empty.
+- Post-receive is only invoked with the accepted ref updates subset (those that passed update + reference-transaction).
+
+---
+
+## Config Entities (existing, no changes)
+
+`HooksConfig` / `GitReceivePackHooks` / `HookToggle` — all exist in `config.rs`. The pipeline reads these by reference; no new config keys are introduced in this feature.
+
+`AdmissionControlConfig.validating_admission_policy.phase` — the string that `HookPipeline.admission_phase` is initialised from at startup.

--- a/specs/013-receive-pack-hooks/plan.md
+++ b/specs/013-receive-pack-hooks/plan.md
@@ -1,0 +1,209 @@
+# Implementation Plan: In-Process git-receive-pack Hook Pipeline
+
+**Branch**: `013-receive-pack-hooks` | **Date**: 2026-06-01 | **Spec**: [spec.md](spec.md)  
+**Input**: Feature specification from `specs/013-receive-pack-hooks/spec.md`
+
+## Summary
+
+Implement a fully in-process hook execution pipeline for `git-receive-pack` in `gitstore-git-service` (Rust). The pipeline executes enabled hook phases — pre-receive, proc-receive, update (per-ref), reference-transaction (three-state: prepared/committed/aborted), and post-receive — in the correct order, enforcing all-or-nothing semantics for pre-receive and per-ref semantics for update, while providing a typed `AdmissionHandler` trait as the integration point for future admission (#105) and validation (#106) services. All hook phases default to disabled; the pipeline emits structured per-phase log events and enforces a 5-second timeout on admission callouts.
+
+## Technical Context
+
+**Language/Version**: Rust edition 2021, MSRV 1.82; actual gix version is `0.84.0` (Cargo.lock canonical)  
+**Primary Dependencies**: `gix 0.84.0`, `gix-ref 0.64.0` (two-phase transaction API), `tokio 1.35` (full features), `tonic 0.14`, `tracing 0.1`, `anyhow 1.0`, `async-trait 0.1` (to add)  
+**Storage**: Bare Git repositories on local filesystem (unchanged)  
+**Testing**: `cargo test` (unit + integration); integration tests use `tempfile` for bare repo fixtures  
+**Target Platform**: Linux server (Docker) + macOS dev  
+**Project Type**: gRPC service library + binary  
+**Performance Goals**: ≤ 50 ms pipeline overhead for no-op phases (SC-005); 5 s admission timeout (FR-009a)  
+**Constraints**: No external `git` binary invocation (FR-011); all phase logic in-process  
+**Scale/Scope**: Single push at a time per repository (per-repo RwLock already in place)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle                         | Status | Notes                                                                                                                    |
+|-----------------------------------|--------|--------------------------------------------------------------------------------------------------------------------------|
+| I. Test-First                     | ✅ PASS | Tasks will write failing tests before implementation for each phase function and the pipeline orchestrator               |
+| II. API-First                     | ✅ PASS | `AdmissionHandler` trait and `HookPipeline` public API defined in `contracts/hook-pipeline.md` before any implementation |
+| III. Clear Contracts & Versioning | ✅ PASS | Contract defined; alpha — no semver stability promise needed                                                             |
+| IV. Observability                 | ✅ PASS | FR-013 mandates structured per-phase log events; `PhaseLog` contract defined                                             |
+| V. User Story Driven              | ✅ PASS | All work maps to US1–US4 in spec; tasks will carry [US1]/[US2] labels                                                    |
+| VI. Incremental Delivery          | ✅ PASS | P1 stories (accept/reject) deliverable independently of P2 (config toggles, admission routing)                           |
+| VII. Simplicity                   | ✅ PASS | No new config keys; `NoopAdmissionHandler` default; `async-trait` only new dep                                           |
+
+**Post-Design Re-check** (after Phase 1):
+
+| Item                                          | Result                                                                                                                                                                         |
+|-----------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `HookPipeline` struct — justified complexity? | Yes: encapsulates phase ordering, toggle enforcement, admission routing, timeouts in one place; alternative (scattered if-guards at call sites) is harder to test and maintain |
+| Two-phase gix transaction — added complexity? | Low: replaces one `edit_references()` call with `prepare()` + `commit()` on `repo.refs`; no new abstractions                                                                   |
+| `async-trait` dependency                      | Minimal: single dep, established in ecosystem; no speculative use                                                                                                              |
+
+No constitution violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/013-receive-pack-hooks/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── hook-pipeline.md # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code Changes
+
+```text
+gitstore-git-service/
+├── Cargo.toml                         # add async-trait = "0.1"
+└── src/
+    ├── git/
+    │   ├── hooks.rs                   # REPLACE: HookDecision, AdmissionDecision,
+    │   │                              #   AdmissionHandler trait, NoopAdmissionHandler,
+    │   │                              #   HookPipeline struct, all phase functions
+    │   ├── pack_server.rs             # MODIFY: wire HookPipeline into handle_receive_pack;
+    │   │                              #   replace edit_references() with two-phase txn
+    │   └── mod.rs                     # no changes expected
+    └── grpc/
+        └── server.rs                  # MODIFY: wire HookPipeline into receive_pack RPC;
+                                       #   replace edit_references() with two-phase txn;
+                                       #   add async admission call with timeout
+
+tests/                                 # NEW directory at crate root (or gitstore-git-service/tests/)
+└── integration/
+    ├── hook_pipeline_test.rs          # integration tests (US1–US4)
+    └── helpers.rs                     # shared bare-repo fixture helpers
+```
+
+**Structure Decision**: Single Rust crate (`gitstore-git-service`). All changes are within the existing crate. Integration tests live in `tests/` at the crate root (Rust convention for integration tests outside `src/`). Unit tests remain co-located in `hooks.rs`.
+
+## Complexity Tracking
+
+No constitution violations requiring justification.
+
+---
+
+## Phase 0: Research Complete
+
+All unknowns resolved. See [research.md](research.md).
+
+Key findings:
+1. `gix 0.84.0` exposes `repo.refs.transaction().prepare().commit()` — two-phase ref transaction available natively via `gix_ref::file::Store`.
+2. `async-trait = "0.1"` needed for dyn-compatible async `AdmissionHandler` trait.
+3. `tokio::time::timeout(Duration::from_secs(5), ...)` — standard pattern, tokio 1.35 full features already present.
+4. `receive_pack` gRPC handler is a real `async fn` — timeout wraps the admission `.await` directly.
+5. Config toggles and `AdmissionControlConfig` already exist in `config.rs` — no new config keys needed.
+
+---
+
+## Phase 1: Design & Contracts Complete
+
+### Data Model
+
+See [data-model.md](data-model.md).
+
+New types:
+- `HookDecision` (enum: Accept | Reject(String))
+- `AdmissionDecision` (enum: Accept | Reject(String))
+- `AdmissionHandler` (async trait, dyn-compatible)
+- `NoopAdmissionHandler` (default no-op implementation)
+- `HookPipeline` (struct: config + admission_phase + admission_handler)
+- `HookRejection` (struct: phase + reason — error type for pipeline abort)
+
+Modified types:
+- `RefUpdate` — existing, no changes
+- `HooksConfig` / `GitReceivePackHooks` / `HookToggle` — existing, no changes
+
+### Phase Execution Contract
+
+```
+pre-receive (once/push, all-or-nothing)
+  └─► [admission check if phase == admission_phase]
+  └─► HookDecision::Reject → HookRejection → abort entire push
+
+proc-receive (once/push, all-or-nothing)
+  └─► [admission check if phase == admission_phase]
+  └─► HookDecision::Reject → HookRejection → abort entire push
+
+update (once/ref, per-ref semantics)
+  └─► [admission check if phase == admission_phase]
+  └─► HookDecision::Reject for ref N → mark N as ng; continue other refs
+
+reference-transaction/prepared  (once/push, veto allowed — via gix_ref two-phase txn)
+  └─► [admission check if phase == admission_phase]
+  └─► HookDecision::Reject → txn.rollback() → HookRejection
+
+[promote quarantine + txn.commit()]
+
+reference-transaction/committed (once/push, observation only)
+
+post-receive (once/push, fire-and-forget)
+  └─► errors logged at ERROR level, never returned to caller
+```
+
+### Interfaces (contracts)
+
+See [contracts/hook-pipeline.md](contracts/hook-pipeline.md).
+
+Public surface:
+- `AdmissionHandler` trait — stable integration point for #105/#106
+- `HookPipeline::new()` + `HookPipeline::run()` — pipeline entry point
+- `HookPipeline::run_reference_transaction_prepared/committed/aborted()` — ref-transaction callbacks
+- `HookPipeline::run_post_receive()` — fire-and-forget post-push notification
+
+### Quickstart
+
+See [quickstart.md](quickstart.md).
+
+---
+
+## Implementation Sequence (input to /speckit.tasks)
+
+The following ordered phases feed directly into task generation:
+
+### Setup
+1. Add `async-trait = "0.1"` to `gitstore-git-service/Cargo.toml`
+2. Create `gitstore-git-service/tests/integration/` directory with placeholder `helpers.rs`
+
+### Foundational — Core Types (blocks all user stories)
+3. [US1/US2] Write failing unit tests for `HookDecision`, `AdmissionDecision`, `AdmissionHandler` trait, `NoopAdmissionHandler`
+4. [US1/US2] Implement `HookDecision`, `AdmissionDecision`, `AdmissionHandler`, `NoopAdmissionHandler`, `HookRejection` in `hooks.rs`
+5. [US1/US2] Write failing unit tests for `HookPipeline::new()` and toggle enforcement (disabled phase = no-op)
+6. [US1/US2] Implement `HookPipeline` struct with config wiring
+
+### User Story 1 — Happy Path Push
+7. [US1] Write failing integration test: single-ref push accepted, phase order verified in logs
+8. [US1] Implement `HookPipeline::run()` — pre-receive → proc-receive → update → reference-transaction/prepared; write phase log events
+9. [US1] Modify `pack_server.rs` and `grpc/server.rs` to drive two-phase gix transaction via `repo.refs.transaction().prepare()/commit()`
+10. [US1] Wire `HookPipeline` into `handle_receive_pack` and `receive_pack` RPC
+11. [US1] Implement `run_reference_transaction_committed()` and `run_post_receive()` (fire-and-forget)
+12. [US1] Verify integration test passes
+
+### User Story 2 — Push Rejection
+13. [US2] Write failing integration tests: pre-receive rejection (all refs blocked), update rejection (one ref blocked), proc-receive rejection
+14. [US2] Implement rejection propagation: pre-receive/proc-receive abort full push; update marks single ref ng
+15. [US2] Wire rejection reason into `report-status` ng lines for client visibility
+16. [US2] Implement `run_reference_transaction_prepared()` with veto (rollback path)
+17. [US2] Verify rejection integration tests pass
+
+### User Story 3 — Config Toggle Enforcement
+18. [US3] Write failing integration tests: each phase disabled individually; all disabled
+19. [US3] Verify toggle checks short-circuit each phase in `HookPipeline::run()`
+20. [US3] Verify US3 integration tests pass
+
+### User Story 4 — Admission Routing
+21. [US4] Write failing integration tests: stub handler accept/reject/timeout wired to configured phase
+22. [US4] Implement `tokio::time::timeout(5s, handler.admit(...))` in `HookPipeline` async phase calls
+23. [US4] Implement admission routing: only call handler when `phase == admission_phase`
+24. [US4] Verify US4 integration tests pass
+
+### Polish
+25. Verify all `cargo test` pass including config tests
+26. Verify `make pr-ready` passes (lint, licence-check, build)

--- a/specs/013-receive-pack-hooks/quickstart.md
+++ b/specs/013-receive-pack-hooks/quickstart.md
@@ -1,0 +1,108 @@
+# Quickstart: Testing the Hook Pipeline
+
+**Branch**: `013-receive-pack-hooks` | **Date**: 2026-06-01
+
+This guide shows how to exercise the hook pipeline locally once the feature is implemented.
+
+## Prerequisites
+
+- gitstore-git-service built and running (`make git` or `make dev`)
+- A repository exists (see `make bootstrap`)
+- A Git client with the smart HTTP URL for the repository
+
+## Enable a Hook Phase
+
+By default, all hook phases are disabled. To enable, set via `gitstore.toml` or environment variables.
+
+**Enable pre-receive and post-receive via env (double-underscore separator):**
+
+```bash
+GITSTORE_HOOKS__GIT_RECEIVE_PACK__PRE_RECEIVE__ENABLED=true \
+GITSTORE_HOOKS__GIT_RECEIVE_PACK__POST_RECEIVE__ENABLED=true \
+make git
+```
+
+Or in `gitstore.toml`:
+
+```toml
+[hooks.git_receive_pack]
+pre_receive  = { enabled = true }
+update       = { enabled = true }
+post_receive = { enabled = true }
+proc_receive = { enabled = false }
+post_update  = { enabled = false }
+```
+
+## Test a Push
+
+```bash
+# Clone the repository
+git clone http://localhost:5000/gitstore/catalog.git
+
+# Make a commit
+cd catalog
+echo "test" >> README.md
+git add README.md
+git commit -m "test: hook pipeline"
+
+# Push (should succeed with all phases accepting)
+git push origin main
+```
+
+Expected output when all phases accept:
+```
+Enumerating objects: 5, done.
+Counting objects: 100% (5/5), done.
+Writing objects: 100% (3/3), 300 bytes | 300.00 KiB/s, done.
+To http://localhost:5000/gitstore/catalog.git
+   abc1234..def5678  main -> main
+```
+
+## Observe Hook Phase Logs
+
+With `log.format = "json"` (default), each phase produces a structured log line:
+
+```json lines
+{"level":"INFO","target":"gitstore_git_service","hook_phase_complete":{"phase":"pre-receive","duration_ms":1,"outcome":"accepted"}}
+{"level":"INFO","target":"gitstore_git_service","hook_phase_complete":{"phase":"update","ref_name":"refs/heads/main","duration_ms":0,"outcome":"accepted"}}
+{"level":"INFO","target":"gitstore_git_service","hook_phase_complete":{"phase":"post-receive","duration_ms":0,"outcome":"accepted"}}
+```
+
+## Test a Rejection
+
+The default `NoopAdmissionHandler` always accepts. To exercise rejection, wire a test handler in integration tests (see `tests/integration/` after implementation). The integration test suite covers:
+
+- `test_push_accepted_all_phases_enabled` — happy path, phase order verified
+- `test_push_rejected_pre_receive` — pre-receive rejects, zero refs updated
+- `test_push_rejected_update_one_ref` — update rejects one ref, others proceed
+- `test_push_all_phases_disabled` — no hook overhead
+- `test_admission_routing_phase` — admission handler wired to configured phase
+
+## Wiring a Custom Admission Handler
+
+For future use by #105 and #106, implement the `AdmissionHandler` trait:
+
+```rust
+use gitstore_git_service::git::hooks::{AdmissionDecision, AdmissionHandler, RefUpdate};
+use async_trait::async_trait;
+
+pub struct MyAdmissionService { /* gRPC channel etc. */ }
+
+#[async_trait]
+impl AdmissionHandler for MyAdmissionService {
+    async fn admit(&self, phase: &str, updates: &[RefUpdate]) -> anyhow::Result<AdmissionDecision> {
+        // call your service here; 5-second timeout enforced by the pipeline
+        Ok(AdmissionDecision::Accept)
+    }
+}
+```
+
+Pass it when constructing `HookPipeline`:
+
+```rust
+let pipeline = HookPipeline::new(
+    config.hooks.git_receive_pack.clone(),
+    config.admission_control.validating_admission_policy.phase.clone(),
+    Arc::new(MyAdmissionService::new(channel)),
+);
+```

--- a/specs/013-receive-pack-hooks/research.md
+++ b/specs/013-receive-pack-hooks/research.md
@@ -1,0 +1,92 @@
+# Research: In-Process git-receive-pack Hook Pipeline
+
+**Branch**: `013-receive-pack-hooks` | **Date**: 2026-06-01
+
+## Decision 1 — gix Two-Phase Reference Transaction
+
+**Decision**: Use `gix_ref::file::Store::transaction()` directly (low-level API) to split `prepare()` from `commit()`, giving a natural "prepared" veto point for the reference-transaction hook phase.
+
+**Rationale**: The high-level `Repository::edit_references()` / `edit_references_as()` fuses prepare and commit in one call with no hook injection point. The low-level `gix_ref::file::Store` (accessible via `repo.refs`) exposes the two-phase API:
+
+```
+let txn = repo.refs.transaction()
+    .prepare(edits, file_lock_fail, packed_lock_fail)?;  // ← "prepared" state, locks held
+// run reference-transaction hook here — veto by drop(txn), allow by txn.commit(committer)?
+```
+
+- `prepare()` — acquires `.lock` files for every ref, validates old-value constraints, writes new values into lock files. After this call, all lock files are held but nothing is committed.
+- `commit()` — renames lock files into place (atomic).
+- `rollback()` / `Drop` — releases all lock files with no write (aborted state).
+
+**Alternatives considered**: Patching gix to add a callback (too invasive, external dep); using `edit_references()` and faking the prepared state (incorrect — objects would be staged but refs rolled back manually, race-prone); skipping reference-transaction veto entirely and making it observation-only (rejected — spec requires FR-008 veto in prepared state).
+
+**Note**: Actual gix version in Cargo.toml is `0.84.0` (not 0.83.0 stated in CLAUDE.md — the lock file is canonical).
+
+---
+
+## Decision 2 — AdmissionHandler Trait Design
+
+**Decision**: Add `async-trait = "0.1"` to `gitstore-git-service` Cargo.toml and define:
+
+```rust
+#[async_trait]
+pub trait AdmissionHandler: Send + Sync {
+    async fn admit(&self, phase: &str, updates: &[RefUpdate]) -> anyhow::Result<AdmissionDecision>;
+}
+```
+
+with `AdmissionDecision::Accept` / `AdmissionDecision::Reject(String)`.
+
+**Rationale**: The codebase is on Rust edition 2021 with MSRV 1.82. RPITIT (`async fn` in traits, stable Rust 1.75+) is not dyn-compatible without additional machinery. Since `Arc<dyn AdmissionHandler>` is required so the handler can be passed into both `HttpPackServer` and the gRPC `receive_pack` handler, `#[async_trait]` is the cleanest path — it desugars to `Pin<Box<dyn Future<...> + Send>>` which is dyn-compatible. The codebase already uses `#[tonic::async_trait]` (a re-export), so the pattern is established.
+
+**Alternatives considered**: Manual `BoxFuture` return type (works but verbose, no ergonomic benefit over async-trait); RPITIT with `dyn-async-trait` shim (extra dep, less standard); synchronous trait (forces blocking inside async context, defeats tokio::time::timeout usage).
+
+---
+
+## Decision 3 — 5-Second Admission Timeout
+
+**Decision**: Use `tokio::time::timeout(Duration::from_secs(5), handler.admit(...).await)` in the async `receive_pack` gRPC handler. Timeout → treat as `Reject("admission service timeout")`.
+
+**Rationale**: tokio 1.35 with `features = ["full"]` already includes `tokio::time`. The `receive_pack` RPC is a real `async fn` (not inside `spawn_blocking`), so the timeout wraps the admission await directly without thread-pool contention. Hardcoded 5 s for alpha; a configurable value is deferred.
+
+**Alternatives considered**: `spawn_blocking` with `std::thread` timeout (works but wastes a blocking thread slot for async network I/O); no timeout (violates FR-009a); configurable timeout in this feature (deferred to a follow-on — config keys already exist in `AdmissionControlConfig`).
+
+---
+
+## Decision 4 — Config Toggle Wiring
+
+**Decision**: Pass `&HooksConfig` (from `AppConfig`) into both `HttpPackServer` and the gRPC `receive_pack` handler. Each phase call site checks the relevant `HookToggle::enabled` before invoking the phase function.
+
+**Rationale**: `HooksConfig` and all five `HookToggle` fields already exist in `config.rs` (all disabled by default). No new config keys are needed (assumption confirmed). Passing config by reference keeps `HttpPackServer` lightweight; the gRPC handler already has `AppConfig` accessible via a shared `Arc<AppConfig>` pattern to be established in this feature.
+
+**Alternatives considered**: Global config singleton (not idiomatic Rust); per-toggle method on `HttpPackServer` (too granular); reading config inside each hook function (breaks single-responsibility).
+
+---
+
+## Decision 5 — Structured Phase Logging
+
+**Decision**: Emit a `tracing::info!` span per phase execution with fields: `phase`, `ref_name` (if per-ref), `duration_ms`, `outcome` ("accepted" | "rejected"), and `reason` (if rejected).
+
+**Rationale**: The codebase already uses `tracing` for all observability (FR-004 via `emit_span` in `pack_server.rs`). Adding per-phase events follows the same pattern. Using `tracing::info!` (not `debug!`) for accepted phases and `tracing::warn!` for rejections ensures operators see hook activity in production `level = "info"` logs without noise.
+
+**Alternatives considered**: Metrics-only (no log lines for accepted phases — insufficient for debugging rejection chains); `tracing::Span` with enter/exit (heavier, no benefit here); separate audit log (out of scope for alpha).
+
+---
+
+## Decision 6 — proc-receive Placement and Semantics
+
+**Decision**: Execute proc-receive after pre-receive and before update, per Git documentation. The stub implementation passes all ref updates through unmodified (no rewriting), providing the invocation point required by the spec without implementing ref rewriting logic (deferred to #105/#106).
+
+**Rationale**: The FR-007 requirement is for the invocation point with ability to rewrite ref targets, not that rewriting is exercised now. The admission handler trait covers the "routing contract" for proc-receive. The order pre-receive → proc-receive → update matches the Git source and the spec FR-001 ordering.
+
+**Alternatives considered**: proc-receive after update (incorrect per Git spec); proc-receive as part of update (conflates per-push and per-ref semantics).
+
+---
+
+## Decision 7 — HTTP vs gRPC call site duplication
+
+**Decision**: Both `HttpPackServer::handle_receive_pack` (sync, called from blocking context) and `grpc/server.rs::receive_pack` (async) share the same synchronous phase functions for pre-receive, update, proc-receive, post-receive. The reference-transaction phase and admission handler calls are async and live only in the gRPC path for now; the HTTP path calls a blocking wrapper.
+
+**Rationale**: `handle_receive_pack` runs inside `spawn_blocking` (see gRPC server usage). Adding async admission calls there would require a `block_on` trampoline, which is anti-pattern with tokio. For this feature, the HTTP path's admission handler is a no-op `NoopAdmissionHandler`; the real async handler is only wired in the gRPC path. The HTTP path is a secondary code path (Smart HTTP proxied via gitstore-api which calls gRPC).
+
+**Alternatives considered**: Fully async `HttpPackServer` (large refactor, out of scope); duplicating all logic (maintenance burden).

--- a/specs/013-receive-pack-hooks/spec.md
+++ b/specs/013-receive-pack-hooks/spec.md
@@ -1,0 +1,145 @@
+# Feature Specification: In-Process git-receive-pack Hook Pipeline
+
+**Feature Branch**: `013-receive-pack-hooks`  
+**Created**: 2026-06-01  
+**Status**: Closed  
+**Input**: User description: "Implement GH#110 — Implement in-process git-receive-pack hook pipeline"
+
+## Clarifications
+
+### Session 2026-06-01
+
+- Q: Should `update` hook rejection abort the entire push or only the rejected ref? → A: Per-ref for `update` (only the rejected ref is blocked); all-or-nothing only for `pre-receive`.
+- Q: Should post-receive / post-update failures surface to the Git client or be fire-and-forget? → A: Fire-and-forget — failures logged at ERROR level, never returned to the client (matches standard Git semantics).
+- Q: Does reference-transaction support veto (push abort) or is it observation-only? → A: Full three-state (prepared/committed/aborted); veto allowed in `prepared` state only.
+- Q: What observability signals should the hook pipeline emit? → A: Structured log entry per phase (phase name, ref, duration ms, accept/reject outcome).
+- Q: What timeout applies to admission service calls, and what happens on timeout? → A: Fixed 5-second timeout per call; timeout is treated as rejection (fail-closed).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Push Accepted Through Enabled Hook Phases (Priority: P1)
+
+A developer pushes commits to a repository hosted on GitStore. The push passes through all enabled hook phases (pre-receive, update, proc-receive, reference-transaction, post-receive) in the correct order before the refs are updated. The developer receives confirmation that the push succeeded.
+
+**Why this priority**: This is the foundational happy-path scenario. Without a working hook pipeline that accepts valid pushes, none of the dependent admission or validation features (#105, #106) can function. It is the minimal viable behaviour.
+
+**Independent Test**: Can be fully tested by running `git push` against a repository with all hook phases enabled and verifying that refs are updated and the client sees a success response.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repository with all hook phases enabled, **When** a developer pushes a new commit, **Then** each enabled phase executes in order (pre-receive → update → proc-receive → reference-transaction → post-receive) and the push succeeds with the refs updated.
+2. **Given** a repository where only `pre-receive` and `post-receive` phases are enabled, **When** a developer pushes, **Then** only those two phases run and the push still succeeds.
+3. **Given** a successful push, **When** post-receive runs, **Then** the hook receives the full list of updated refs as input.
+
+---
+
+### User Story 2 - Push Rejected by a Hook Phase (Priority: P1)
+
+A developer attempts to push commits that violate a policy enforced in the pre-receive or update phase. The push is rejected atomically — no refs are updated — and the developer sees a clear, actionable error message explaining why the push was denied.
+
+**Why this priority**: Rejection with a human-readable reason is the core value proposition of the hook pipeline. Without atomic rejection, downstream admission control (#105, #106) cannot safely block invalid pushes.
+
+**Independent Test**: Can be fully tested by enabling the pre-receive phase with a rejection rule and verifying that `git push` returns a non-zero exit code with the error text visible in the client output, and that the remote refs remain unchanged.
+
+**Acceptance Scenarios**:
+
+1. **Given** the pre-receive phase is enabled and configured to reject, **When** a developer pushes, **Then** the push is aborted, no refs are updated, and the client receives a descriptive rejection message.
+2. **Given** the update phase rejects one ref in a multi-ref push, **When** a developer pushes multiple branches simultaneously, **Then** only the rejected ref is blocked (best-effort atomicity) and accepted refs are updated.
+3. **Given** the proc-receive phase rejects a push, **When** a developer pushes, **Then** refs are not updated and the client sees the rejection reason.
+
+---
+
+### User Story 3 - Selectively Disable Hook Phases via Configuration (Priority: P2)
+
+An operator configures GitStore to skip specific hook phases (e.g., disable `proc-receive` and `post-update`) for a deployment. Pushes complete without executing the disabled phases, and the system behaves identically to a deployment where those phases were never implemented.
+
+**Why this priority**: Operators need granular control to roll out hook phases incrementally or disable them for performance-sensitive paths without modifying code. This is required to preserve backward compatibility with existing deployments.
+
+**Independent Test**: Can be fully tested by toggling each phase toggle independently, pushing to the repository, and verifying through observable behaviour (logs, response timing, ref state) that only the enabled phases ran.
+
+**Acceptance Scenarios**:
+
+1. **Given** `GITSTORE_HOOKS_GIT_RECEIVE_PACK_PRE_RECEIVE_ENABLED=false`, **When** a developer pushes, **Then** the pre-receive phase is skipped and the push completes without any pre-receive logic running.
+2. **Given** all hook phases disabled, **When** a developer pushes, **Then** the push succeeds immediately with no hook overhead.
+3. **Given** `GITSTORE_HOOKS_GIT_RECEIVE_PACK_PROC_RECEIVE_ENABLED=true` and all others disabled, **When** a developer pushes, **Then** only proc-receive executes.
+
+---
+
+### User Story 4 - Hook Pipeline Provides Routing Points for Admission Services (Priority: P2)
+
+A GitStore operator has configured an external validation or admission policy service (future: #105, #106). The hook pipeline calls out to that service at the appropriate phase and forwards the push context (ref name, old OID, new OID). The service's accept/reject decision is propagated back to the Git client.
+
+**Why this priority**: This is the extensibility contract that makes the entire hook system valuable beyond simple logging. It enables #105 and #106 without requiring further changes to the push flow.
+
+**Independent Test**: Can be fully tested by wiring a stub admission service and verifying that the stub's decision (accept or reject) controls the push outcome.
+
+**Acceptance Scenarios**:
+
+1. **Given** an admission phase is configured and the stub service returns "accept", **When** a developer pushes, **Then** the push succeeds.
+2. **Given** an admission phase is configured and the stub service returns "reject" with a reason, **When** a developer pushes, **Then** the push is rejected and the client sees the reason from the service.
+3. **Given** the admission service is unreachable, **When** a developer pushes, **Then** the push is rejected with a service-unavailable error (fail-closed by default).
+
+---
+
+### Edge Cases
+
+- What happens when a hook phase times out mid-execution? The push is rejected and the client receives a timeout error; no partial ref update occurs.
+- What happens when a push updates 50+ refs simultaneously? All refs pass through each hook phase; performance degrades gracefully rather than failing.
+- What happens when the same ref is pushed twice concurrently? Hook phases execute for each push independently; ref-transaction semantics prevent double-update races.
+- What happens when a post-receive hook fails? The push is already committed (refs updated); the failure is logged but does not roll back the push (post-* hooks are best-effort).
+- What happens when a push contains a branch deletion (new OID = zero)? Hook phases receive the zero OID as the new value and must treat it as a deletion event.
+- What happens when no refs are included in the push? The hook pipeline is not invoked; the client receives an empty-update response.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST execute enabled hook phases in the following order for each push: pre-receive → proc-receive → update (per ref) → reference-transaction → post-receive.
+- **FR-002**: The system MUST skip any hook phase whose configuration toggle is set to disabled, without error or observable side effect.
+- **FR-003a**: The system MUST abort the push and leave all refs unchanged if the pre-receive phase returns a rejection (all-or-nothing semantics).
+- **FR-003b**: The system MUST block only the rejected ref if the update phase returns a rejection for that ref; other refs in the same push MUST proceed normally (per-ref semantics).
+- **FR-004**: The system MUST surface the rejection reason from a hook phase as a human-readable message visible to the Git client.
+- **FR-005**: The system MUST execute the update phase once per ref being pushed (each ref is an independent invocation).
+- **FR-006**: The system MUST execute pre-receive and post-receive phases exactly once per push, regardless of how many refs are being updated.
+- **FR-007**: The system MUST execute proc-receive in the appropriate position in the pipeline when enabled, with the ability to rewrite ref targets.
+- **FR-008**: The system MUST invoke the reference-transaction phase in three states per push: `prepared` (ref locks acquired — veto allowed, push aborted if rejected), `committed` (refs written — observation only), and `aborted` (rollback — observation only). Rejection is only honoured in the `prepared` state.
+- **FR-009**: The system MUST provide hook invocation points that accept a routing contract so that future admission and validation services (#105, #106) can be integrated without modifying the pipeline ordering.
+- **FR-009a**: Each admission phase call MUST time out after 5 seconds; a timeout MUST be treated as a rejection (fail-closed). No client push may be stalled indefinitely by an unresponsive admission service.
+- **FR-010**: The system MUST respect the `GITSTORE_ADMISSION_CONTROL_VALIDATING_ADMISSION_POLICY_PHASE` configuration to determine which phase admission policy evaluation is routed to.
+- **FR-011**: The system MUST NOT invoke any external `git` binary when executing hook phases; all phase logic MUST run in-process.
+- **FR-012**: Post-receive and post-update failures MUST be recorded as structured ERROR-level log entries but MUST NOT cause the push to be reported as failed to the client (fire-and-forget semantics matching standard Git behavior).
+- **FR-013**: The system MUST emit a structured log entry for each hook phase execution containing at minimum: phase name, ref name (where applicable), duration in milliseconds, and outcome (accepted/rejected with reason).
+
+### Key Entities
+
+- **Push Event**: A single `git push` operation; carries one or more ref updates (each with ref name, old OID, new OID) and the pack data.
+- **Ref Update**: A single ref being created, updated, or deleted as part of a push event; the unit of input to the `update` phase.
+- **Hook Phase**: A named, ordered stage in the push pipeline (pre-receive, proc-receive, update, reference-transaction, post-receive); each has an enabled/disabled toggle.
+- **Hook Decision**: The outcome of a hook phase execution — either "accept" (push proceeds) or "reject" (push aborted with reason).
+- **Admission Phase Assignment**: The configuration value that maps the admission policy evaluation to a specific hook phase.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of pushes through an enabled hook pipeline execute phases in the documented order, verifiable by integration test assertions on phase execution sequence.
+- **SC-002**: A push rejected by any pre-receive or update phase results in zero ref updates on the server side in all tested scenarios.
+- **SC-003**: Rejection messages from hook phases appear verbatim in the `git push` client output for 100% of rejection test cases.
+- **SC-004**: Disabling a hook phase via configuration results in that phase never executing, confirmed across all integration test runs.
+- **SC-005**: The hook pipeline adds no more than 50 ms of latency to a push that exercises all enabled phases with no-op phase logic (measured in integration tests without network round-trips to external services).
+- **SC-006**: Integration tests cover at minimum: single-ref accepted push, single-ref rejected push (pre-receive), single-ref rejected push (update), multi-ref push with one rejection, all-phases-disabled push, and admission routing phase confirmation.
+
+## Assumptions
+
+- The in-process hook pipeline replaces only the hook execution mechanism; the Git pack protocol, ref negotiation, and object storage remain as implemented in feature #009 (remove git shell-outs).
+- Admission and validation logic bodies (the actual policies) are out of scope; this feature provides the invocation points only (#105 and #106 implement the logic).
+- The fail-closed behaviour for unreachable admission services (FR-009) is the safe default; operators who require fail-open must configure it explicitly (tracked separately).
+- Phase configuration toggles already exist in the codebase (from feature #005); this feature preserves their semantics without introducing new configuration keys.
+- The `post-update` (legacy) phase is explicitly excluded from scope per the issue.
+- `push-to-checkout` is in scope as a phase invocation point but its checkout logic is minimal (update the working tree on non-bare repos); GitStore uses bare repositories so this phase is a no-op by default.
+
+## Dependencies
+
+- **Requires**: Feature #009 (remove git shell-outs) — the in-process push flow must be in place before hooks can be injected.
+- **Supports**: Feature #105 (validation logic), Feature #106 (admission policy evaluation), Feature #107.
+- **Related**: Issue #139 (release-tag notification, excluded from this scope).

--- a/specs/013-receive-pack-hooks/tasks.md
+++ b/specs/013-receive-pack-hooks/tasks.md
@@ -1,0 +1,337 @@
+---
+description: "Task list for In-Process git-receive-pack Hook Pipeline"
+---
+
+# Tasks: In-Process git-receive-pack Hook Pipeline
+
+**Input**: Design documents from `/specs/013-receive-pack-hooks/`  
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/ ✅, quickstart.md ✅
+
+**Tests**: Test-First Development (Constitution Principle I — NON-NEGOTIABLE). Tests MUST be written before implementation and verified to FAIL before implementation begins.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: Which user story this task belongs to (US1–US4)
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Add the new dependency and create the integration test scaffold. No implementation yet.
+
+- [x] T001 Add `async-trait = "0.1"` to `gitstore-git-service/Cargo.toml` under `[dependencies]`
+- [x] T002 Create `gitstore-git-service/tests/integration/` directory; add empty `mod.rs` placeholder so `cargo test` discovers the module
+- [x] T003 [P] Create `gitstore-git-service/tests/integration/helpers.rs` — bare-repo fixture helpers: `make_bare_repo(dir) -> PathBuf`, `make_commit(repo_path, msg) -> String` (returns commit OID), `zero_oid() -> &'static str`
+
+**Checkpoint**: `cargo build` succeeds with the new dependency; `cargo test` runs without errors.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core types and `HookPipeline` struct that ALL user stories depend on. No phase logic yet — just the scaffolding.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+### Tests for Foundation (write first, verify FAIL)
+
+- [x] T004 Write unit tests in `gitstore-git-service/src/git/hooks.rs` verifying:
+  - `HookDecision::Reject("reason")` carries the reason string
+  - `AdmissionDecision::Reject("reason")` carries the reason string
+  - `NoopAdmissionHandler::admit()` always returns `Ok(Accept)`
+  - `HookRejection` has accessible `phase` and `reason` fields
+
+- [x] T005 Write unit tests in `gitstore-git-service/src/git/hooks.rs` verifying `HookPipeline` toggle enforcement:
+  - Pipeline with all toggles disabled runs `run()` and returns all indices as accepted with zero phase invocations (assert no panic, no admission call)
+  - Pipeline with only `pre_receive.enabled = true` invokes noop pre-receive and returns accepted
+
+### Implementation
+
+- [x] T006 Replace existing ad-hoc types in `gitstore-git-service/src/git/hooks.rs` with:
+  - `pub enum HookDecision { Accept, Reject(String) }`
+  - `pub enum AdmissionDecision { Accept, Reject(String) }`
+  - `pub struct HookRejection { pub phase: String, pub reason: String }`
+  - `#[async_trait] pub trait AdmissionHandler: Send + Sync { async fn admit(...) }`
+  - `pub struct NoopAdmissionHandler;` + `impl AdmissionHandler for NoopAdmissionHandler`
+  - Add `use async_trait::async_trait;` import
+
+- [x] T007 Add `pub struct HookPipeline` to `gitstore-git-service/src/git/hooks.rs` with fields: `config: GitReceivePackHooks`, `admission_phase: String`, `admission_handler: Arc<dyn AdmissionHandler + Send + Sync>`; add `HookPipeline::new()` constructor; add stub `async fn run()` returning `Ok((0..updates.len()).collect())` (all accepted, no phase logic yet — will be filled in per story)
+
+- [x] T008 Update existing `run_pre_receive`, `run_update_hooks`, `run_post_receive` signatures in `gitstore-git-service/src/git/hooks.rs` to return `HookDecision` / `Vec<(usize, HookDecision)>` respectively, keeping bodies as no-op (always accept) so existing call sites still compile
+
+- [x] T009 Update call sites in `gitstore-git-service/src/git/pack_server.rs` and `gitstore-git-service/src/grpc/server.rs` to handle the new return types without changing behaviour — ensure `cargo test` still passes after this change
+
+**Checkpoint**: `cargo test` passes. All foundation unit tests pass (T004, T005). Hook types exist and compile.
+
+---
+
+## Phase 3: User Story 1 — Push Accepted Through Enabled Hook Phases (Priority: P1) 🎯 MVP
+
+**Goal**: A push with all hook phases enabled executes pre-receive → proc-receive → update → reference-transaction/prepared → committed → post-receive in order, refs are updated, client receives success.
+
+**Independent Test**: `cargo test` with integration test `test_push_accepted_all_phases_enabled` passes; log output contains one event per phase in the correct order.
+
+### Tests for User Story 1 (write first, verify FAIL)
+
+- [x] T010 [US1] Write integration test `test_push_accepted_all_phases_enabled` in `gitstore-git-service/tests/integration/hook_pipeline_test.rs`:
+  - Create a bare repo with one commit using helpers from T003
+  - Construct a `HookPipeline` with all phases enabled and `NoopAdmissionHandler`
+  - Build a `RefUpdate` advancing `refs/heads/main` to a new commit OID
+  - Call `pipeline.run(git_dir, &[update])` and assert `Ok(vec![0])` (index 0 accepted)
+  - Assert `pipeline.run_reference_transaction_prepared(git_dir, &[update])` returns `Ok(())`
+  - Verify test FAILS before implementation
+
+- [x] T011 [US1] Write unit test in `gitstore-git-service/src/git/hooks.rs` asserting per-phase structured log events are emitted (use `tracing_test` or capture span fields manually): pre-receive log contains `phase="pre-receive"`, `outcome="accepted"`, `duration_ms` field present
+
+### Implementation for User Story 1
+
+- [x] T012 [US1] Implement `HookPipeline::run()` in `gitstore-git-service/src/git/hooks.rs`:
+  - Check `config.pre_receive.enabled`; if enabled call `run_pre_receive` and call admission handler if `admission_phase == "pre-receive"` (with `tokio::time::timeout(5s, ...)`); on `Reject` return `Err(HookRejection { phase: "pre-receive", reason })`
+  - Check `config.proc_receive.enabled`; if enabled call `run_proc_receive` stub + admission routing for `"proc-receive"`; on `Reject` return `Err(HookRejection)`
+  - For each ref update: check `config.update.enabled`; call `run_update` + admission routing for `"update"`; collect accepted indices (per-ref semantics — rejections mark that ref ng, others continue)
+  - Emit structured `tracing::info!` / `tracing::warn!` per phase with `phase`, `duration_ms`, `outcome` fields (and `ref_name` for update, `reason` for reject)
+  - Return `Ok(accepted_indices)`
+
+- [x] T013 [US1] Add `pub fn run_proc_receive(git_dir: &Path, updates: &[RefUpdate]) -> HookDecision` stub (always `Accept`) in `gitstore-git-service/src/git/hooks.rs`
+
+- [x] T014 [US1] Implement `HookPipeline::run_reference_transaction_prepared()` in `gitstore-git-service/src/git/hooks.rs`:
+  - Check `config` for reference-transaction toggle (add `reference_transaction: HookToggle` field to `GitReceivePackHooks` in `gitstore-git-service/src/config.rs` with default `enabled = false`)
+  - If enabled: call admission handler if `admission_phase == "reference-transaction/prepared"` (with 5s timeout); on `Reject` return `Err(HookRejection { phase: "reference-transaction/prepared", reason })`
+  - Emit structured log event; return `Ok(())`
+
+- [x] T015 [US1] Add `pub fn run_reference_transaction_committed()` and `pub fn run_reference_transaction_aborted()` stubs in `gitstore-git-service/src/git/hooks.rs` — both emit a structured `tracing::info!` event and return `()`
+
+- [x] T016 [US1] Implement `HookPipeline::run_post_receive()` in `gitstore-git-service/src/git/hooks.rs`:
+  - Check `config.post_receive.enabled`; if enabled call `run_post_receive` stub
+  - Catch any error with `if let Err(e) = ...`; log at `tracing::error!` with `phase="post-receive"` and `reason`; never propagate
+
+- [x] T017 [US1] Replace `repo.edit_references()` in `gitstore-git-service/src/git/pack_server.rs` with the two-phase gix transaction:
+  - Build `ref_edits` as before
+  - Call `let txn = repo.refs.transaction().prepare(ref_edits, lock_fail_mode, packed_lock_fail)?;`
+  - Call `pipeline.run_reference_transaction_prepared(git_dir, accepted_updates).await?` (or blocking equivalent in this sync context — see Decision 7 in research.md: use a `NoopAdmissionHandler` here, admission only in gRPC path)
+  - On Ok: call `txn.commit(committer)?` then `run_reference_transaction_committed()`
+  - On Err: call `txn.rollback()` (or drop) then `run_reference_transaction_aborted()`; propagate error
+
+- [x] T018 [US1] Replace `repo.edit_references()` in `gitstore-git-service/src/grpc/server.rs::receive_pack` with the two-phase gix transaction using the same pattern as T017; wire `HookPipeline` (constructed from `AppConfig` passed as `Arc<AppConfig>` into `GitServiceImpl`) into the `receive_pack` RPC flow:
+  - Add `hook_pipeline: Arc<HookPipeline>` field to `GitServiceImpl`; update `GitServiceImpl::new()` to accept and store it
+  - In `receive_pack`: call `pipeline.run(git_dir, &ref_updates).await` to get accepted indices; build ref edits from accepted indices only; run two-phase transaction; call `pipeline.run_post_receive()`
+
+- [x] T019 [US1] Update `gitstore-git-service/src/main.rs` to construct `HookPipeline` from loaded `AppConfig` and pass it into `GitServiceImpl::new()`
+
+**Checkpoint**: `cargo test` passes including T010 and T011. A real `git push` via `make dev` succeeds with per-phase log events visible.
+
+---
+
+## Phase 4: User Story 2 — Push Rejected by a Hook Phase (Priority: P1)
+
+**Goal**: A push that violates a pre-receive or update policy is rejected — pre-receive blocks all refs (all-or-nothing); update blocks only the rejected ref (per-ref). Client sees rejection reason.
+
+**Independent Test**: `cargo test` with integration tests `test_push_rejected_pre_receive`, `test_push_rejected_update_one_ref`, `test_push_rejected_proc_receive` all pass; rejected refs appear in report-status `ng` lines with the reason.
+
+### Tests for User Story 2 (write first, verify FAIL)
+
+- [x] T020 [US2] Write integration test `test_push_rejected_pre_receive` in `gitstore-git-service/tests/integration/hook_pipeline_test.rs`:
+  - Create a `RejectingAdmissionHandler("blocked by policy")` test double that always returns `Reject`
+  - Construct `HookPipeline` with `pre_receive.enabled = true`, `admission_phase = "pre-receive"`, wired to `RejectingAdmissionHandler`
+  - Call `pipeline.run(git_dir, &[update1, update2])` and assert `Err(HookRejection { phase: "pre-receive", .. })`
+  - Verify test FAILS before implementation
+
+- [x] T021 [US2] Write integration test `test_push_rejected_update_one_ref` in `gitstore-git-service/tests/integration/hook_pipeline_test.rs`:
+  - Construct `HookPipeline` with `update.enabled = true`; use `PerRefRejectingHandler` that rejects ref index 1 only
+  - Call `pipeline.run(git_dir, &[update0, update1, update2])` and assert `Ok(vec![0, 2])` (index 1 rejected, others accepted)
+  - Verify test FAILS before implementation
+
+- [x] T022 [P] [US2] Write integration test `test_push_rejected_proc_receive` in `gitstore-git-service/tests/integration/hook_pipeline_test.rs`: proc-receive rejection returns `Err(HookRejection { phase: "proc-receive", .. })`
+
+- [x] T023 [P] [US2] Write integration test `test_reference_transaction_veto` in `gitstore-git-service/tests/integration/hook_pipeline_test.rs`:
+  - `run_reference_transaction_prepared()` with rejecting handler returns `Err(HookRejection { phase: "reference-transaction/prepared", .. })`
+
+### Implementation for User Story 2
+
+- [x] T024 [US2] Wire `RejectingAdmissionHandler` test double into `gitstore-git-service/tests/integration/helpers.rs` (or inline in test file): a struct implementing `AdmissionHandler` that returns `Reject(reason)` for all calls; also add `PerRefRejectingHandler(HashSet<usize>)` that rejects specific ref indices
+
+- [x] T025 [US2] Verify `HookPipeline::run()` pre-receive rejection path returns `Err(HookRejection)` carrying the exact reason string from the admission handler (should already work from T012; confirm with T020 passing)
+
+- [x] T026 [US2] Verify `HookPipeline::run()` update per-ref rejection correctly excludes only the rejected ref index from the accepted set and continues processing remaining refs (confirm with T021 passing)
+
+- [x] T027 [US2] Update `report-status` building in `gitstore-git-service/src/grpc/server.rs::receive_pack` and `gitstore-git-service/src/git/pack_server.rs::handle_receive_pack` to:
+  - On `Err(HookRejection)` from `pipeline.run()`: emit `ng <all-refs> <reason>` for all requested refs (pre-receive / proc-receive rejection blocks entire push)
+  - On `Ok(accepted_indices)`: emit `ng <ref> <reason>` for rejected refs using the rejection reason captured during the update phase iteration; emit `ok <ref>` for accepted refs
+
+- [x] T028 [US2] Verify `HookPipeline::run_reference_transaction_prepared()` rejection causes `txn.rollback()` to be called (lock files dropped) and no refs are written — confirm via T023
+
+**Checkpoint**: `cargo test` passes including T020–T023. Rejection reasons appear verbatim in client `git push` output.
+
+---
+
+## Phase 5: User Story 3 — Selectively Disable Hook Phases via Configuration (Priority: P2)
+
+**Goal**: Each hook phase can be independently disabled via config toggle; disabled phases are skipped with zero overhead and zero log output.
+
+**Independent Test**: `cargo test` with integration tests `test_all_phases_disabled`, `test_single_phase_enabled` pass; log capture confirms no hook events emitted for disabled phases.
+
+### Tests for User Story 3 (write first, verify FAIL)
+
+- [x] T029 [US3] Write integration test `test_all_phases_disabled` in `gitstore-git-service/tests/integration/hook_pipeline_test.rs`:
+  - Construct `HookPipeline` with all toggles `enabled = false`
+  - Assert `pipeline.run(git_dir, &[update])` returns `Ok(vec![0])` and no `hook_phase_complete` log events are emitted
+  - Verify test FAILS before T030 if phase logging is unconditional
+
+- [x] T030 [P] [US3] Write integration test `test_only_pre_receive_enabled` in `gitstore-git-service/tests/integration/hook_pipeline_test.rs`:
+  - Enable only `pre_receive`; assert noop pre-receive runs (one log event) and update/proc-receive/post-receive emit no log events
+
+- [x] T031 [P] [US3] Write integration test `test_reference_transaction_disabled` in `gitstore-git-service/tests/integration/hook_pipeline_test.rs`:
+  - `reference_transaction.enabled = false`; assert `run_reference_transaction_prepared()` returns `Ok(())` immediately with no log event
+
+### Implementation for User Story 3
+
+- [x] T032 [US3] Audit `HookPipeline::run()` and `run_reference_transaction_prepared()` in `gitstore-git-service/src/git/hooks.rs` — confirm each phase arm is guarded by `if self.config.<phase>.enabled { ... }` and emits no log event when disabled; fix any missing guards (should largely be in place from Phase 3 implementation)
+
+- [x] T033 [US3] Add `reference_transaction: HookToggle` to `GitReceivePackHooks` in `gitstore-git-service/src/config.rs` with default `{ enabled = false }` in `default_toml()` (may already exist from T014 — verify and add if missing)
+
+- [x] T034 [US3] Verify existing config tests in `gitstore-git-service/src/config.rs` still pass after adding the new toggle; add a test asserting `reference_transaction.enabled` defaults to `false`
+
+**Checkpoint**: `cargo test` passes including T029–T031. Toggling any single phase on/off has no effect on other phases.
+
+---
+
+## Phase 6: User Story 4 — Hook Pipeline Provides Routing Points for Admission Services (Priority: P2)
+
+**Goal**: A configurable admission handler is called at the phase specified by `GITSTORE_ADMISSION_CONTROL_VALIDATING_ADMISSION_POLICY_PHASE`; its accept/reject decision controls the push outcome; calls time out in 5 seconds (fail-closed).
+
+**Independent Test**: `cargo test` with integration tests `test_admission_accept`, `test_admission_reject`, `test_admission_timeout_fail_closed` all pass.
+
+### Tests for User Story 4 (write first, verify FAIL)
+
+- [x] T035 [US4] Write integration test `test_admission_accept` in `gitstore-git-service/tests/integration/hook_pipeline_test.rs`:
+  - Wire `NoopAdmissionHandler` to `admission_phase = "pre-receive"`, enable pre-receive
+  - Assert push accepted
+
+- [x] T036 [US4] Write integration test `test_admission_reject_with_reason` in `gitstore-git-service/tests/integration/hook_pipeline_test.rs`:
+  - Wire `RejectingAdmissionHandler("policy violation")` to `admission_phase = "update"`, enable update
+  - Assert `pipeline.run()` returns `Ok` but with empty accepted indices (all refs rejected via update) and rejection reason `"policy violation"` captured
+
+- [x] T037 [US4] Write integration test `test_admission_timeout_fail_closed` in `gitstore-git-service/tests/integration/hook_pipeline_test.rs`:
+  - Create `SlowAdmissionHandler` that sleeps 10 seconds before returning
+  - Wire to `admission_phase = "pre-receive"`, enable pre-receive
+  - Assert `pipeline.run()` returns `Err(HookRejection { reason: "admission service timeout", .. })` within ~6 seconds
+  - Verify test FAILS before T038
+
+- [x] T038 [P] [US4] Write integration test `test_admission_only_called_at_configured_phase` in `gitstore-git-service/tests/integration/hook_pipeline_test.rs`:
+  - Wire counting handler to `admission_phase = "update"`, enable pre-receive + update
+  - Assert handler is called exactly N times (once per ref) for update phase, and zero times for pre-receive phase
+
+### Implementation for User Story 4
+
+- [x] T039 [US4] Add `SlowAdmissionHandler` test double to `gitstore-git-service/tests/integration/helpers.rs`: implements `AdmissionHandler`, sleeps `tokio::time::sleep(Duration::from_secs(10)).await` before returning `Ok(Accept)`
+
+- [x] T040 [US4] Verify `HookPipeline::run()` wraps every admission `handler.admit()` call with `tokio::time::timeout(Duration::from_secs(5), ...)` and maps `Err(Elapsed)` to `HookRejection { reason: "admission service timeout".to_string(), .. }` — confirm via T037 passing
+
+- [x] T041 [US4] Verify admission routing guard `if phase_name == self.admission_phase { ... }` is correctly placed at each phase call site in `gitstore-git-service/src/git/hooks.rs` — handler must NOT be called at phases other than the configured one; confirm via T038 passing
+
+- [x] T042 [US4] Add `CountingAdmissionHandler` test double to `gitstore-git-service/tests/integration/helpers.rs`: wraps an `Arc<AtomicUsize>` call counter, always returns `Accept`
+
+**Checkpoint**: `cargo test` passes including T035–T038. Admission handler is called exactly at the configured phase with the 5-second timeout enforced.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation, documentation, PR readiness.
+
+- [x] T043 [P] Run `cargo clippy -- -D warnings` in `gitstore-git-service/` and fix any lint warnings introduced by this feature
+- [x] T044 [P] Run `cargo test` for the full `gitstore-git-service` crate and confirm all pre-existing tests still pass (no regressions in config, gRPC, pack_server tests)
+- [x] T045 Update `docs/` per CLAUDE.md guideline: add a section describing the hook pipeline, config toggles, and admission handler integration point
+- [x] T046 Run `make pr-ready` from repo root and fix any failures (lint, license-check, build across all modules)
+- [x] T047 Walk through `specs/013-receive-pack-hooks/quickstart.md` steps against a running `make dev` instance to verify the happy path, phase log events, and toggle behaviour
+
+**Checkpoint**: `make pr-ready` passes. quickstart.md validated end-to-end.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 — **BLOCKS all user stories**
+- **US1 (Phase 3)**: Depends on Phase 2 — first P1 story, enables MVP
+- **US2 (Phase 4)**: Depends on Phase 2 — second P1 story; depends on US1 types being present (HookRejection, run_reference_transaction_prepared) but independently testable
+- **US3 (Phase 5)**: Depends on Phase 2 — can start after Phase 2 in parallel with US1/US2; toggle enforcement is a property of the existing pipeline structure
+- **US4 (Phase 6)**: Depends on Phase 3 (admission handler wiring lives in HookPipeline::run() from T012) — must follow US1
+- **Polish (Phase 7)**: Depends on all desired user stories complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: No story dependencies — enables the pipeline scaffold
+- **US2 (P1)**: Requires US1 types (`HookRejection`, `run_reference_transaction_prepared`) — tightly related, treat as sequential with US1
+- **US3 (P2)**: No story dependencies beyond Foundational — toggle enforcement is a guard on the existing pipeline; can develop in parallel with US1/US2
+- **US4 (P2)**: Requires US1 (admission call sites exist in `HookPipeline::run()`) — must follow US1
+
+### Within Each User Story
+
+1. Write tests → verify they FAIL
+2. Implement → verify tests PASS
+3. Fix any regressions in existing tests
+4. Checkpoint before moving to next phase
+
+### Parallel Opportunities
+
+- T002 + T003 (Phase 1) — parallel: different files
+- T004 + T005 (Phase 2 tests) — parallel: same file but non-conflicting test functions
+- T020 + T021 + T022 + T023 (Phase 4 tests) — all parallel: non-conflicting test functions in integration test file
+- T029 + T030 + T031 (Phase 5 tests) — parallel: non-conflicting test functions
+- T035 + T036 + T037 + T038 (Phase 6 tests) — parallel: non-conflicting test functions
+- T043 + T044 (Phase 7) — parallel: different commands, read-only
+
+---
+
+## Parallel Example: User Story 2 Tests
+
+```bash
+# All US2 tests can be written in parallel (different test functions, same file):
+Task T020: "Write test_push_rejected_pre_receive"
+Task T021: "Write test_push_rejected_update_one_ref"
+Task T022: "Write test_push_rejected_proc_receive"
+Task T023: "Write test_reference_transaction_veto"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Stories 1 + 2 — both P1)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational — **BLOCKS everything**
+3. Complete Phase 3: US1 (happy path push, phase ordering, structured logs)
+4. Complete Phase 4: US2 (rejection, per-ref semantics, client-visible reason)
+5. **STOP and VALIDATE**: `make dev` + `git push` with rejecting handler; verify log output and client error message
+6. Deploy/demo if ready — this is the complete P1 hook pipeline
+
+### Full Delivery (all four stories)
+
+1. Phases 1–4 (MVP above)
+2. Phase 5: US3 (config toggle enforcement)
+3. Phase 6: US4 (admission routing + timeout)
+4. Phase 7: Polish
+
+### Parallel Team Strategy
+
+With two developers after Phase 2 completes:
+- **Developer A**: US1 (Phase 3) → US2 (Phase 4) — critical path P1
+- **Developer B**: US3 (Phase 5) — config toggles, fully independent of US1/US2 implementation details
+
+---
+
+## Notes
+
+- `[P]` tasks = different files or non-conflicting test functions — safe to run in parallel
+- Each user story is independently completable and testable via its integration tests
+- Constitution Principle I: every test task MUST be verified to FAIL before the corresponding implementation task begins
+- The `reference_transaction` toggle (T014, T033) may already exist from Phase 3 implementation — check before adding to avoid duplication
+- `GitServiceImpl` constructor change (T018, T019) touches `main.rs` and test fixture helpers — coordinate to avoid conflict if working in parallel
+- Commit after each checkpoint using Conventional Commits (`feat:`, `test:`, `refactor:`)


### PR DESCRIPTION
## Summary

- Implements `HookPipeline` in `gitstore-git-service` with in-process execution of pre-receive, proc-receive, update (per-ref), reference-transaction (three-state: prepared/committed/aborted), and post-receive hook phases
- Adds `AdmissionHandler` async trait as the integration point for future admission (#105) and validation (#106) services — `NoopAdmissionHandler` is the default (all phases disabled, no behaviour change)
- Replaces `repo.edit_references()` with the two-phase `gix_ref` transaction (`prepare()`→`commit()`/`rollback()`) to support reference-transaction veto at the "prepared" state
- Enforces 5-second hard timeout on admission service calls (fail-closed)

## Test plan

- [x] `cargo test` — 77 tests pass (60 unit + 17 integration)
- [x] 15 new integration tests cover all 4 user stories: happy-path push, pre-receive/update/proc-receive rejection, per-ref vs all-or-nothing semantics, config toggle enforcement, admission routing, timeout fail-closed
- [x] `make pr-ready` — build, lint, license-check all pass

## Related

Closes #110  
Provides invocation points for #105, #106, #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)