### PR TITLE
feat(collection): Collection resource contract with label-selector membership

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,8 @@ Auto-generated from all feature plans. Last updated: 2026-03-26
 - GitHub Actions YAML + Go 1.25 (test runner) + Docker Compose, `compose.scylla.yml` (already committed), ScyllaDB 5.4 (020-pre-receive-validation-e2e)
 - memdb (default, no infra) and ScyllaDB 5.4 (via Docker overlay) (020-pre-receive-validation-e2e)
 - Go 1.25 (`gitstore-api`); Rust edition 2021 MSRV 1.82 (`gitstore-git-service`) + `gqlgen v0.17.90`, `go-playground/validator/v10 v10.30.3`, `github.com/adrg/frontmatter v0.2.0`, `gopkg.in/yaml.v3`, `go.uber.org/zap`, `google/uuid`, `gocqlx/v3 v3.0.4` (ScyllaDB prod), `go-memdb v1.3.5` (dev) (021-category-taxonomy)
+- Go 1.25 (`gitstore-api`); Rust edition 2021 MSRV 1.82 (`gitstore-git-service` — no changes needed) + `gqlgen v0.17.90`, `go-memdb v1.3.5` (dev), `gocqlx/v3 v3.0.4` + `gocql` (ScyllaDB prod), `go-playground/validator/v10`, `go.uber.org/zap`, `github.com/adrg/frontmatter v0.2.0`, `gopkg.in/yaml.v3` (022-collection-resource-contract)
+- ScyllaDB 5.x+ (prod) via three-table pattern; `go-memdb` (dev/test) (022-collection-resource-contract)
 
 - (001-git-backed-ecommerce)
 
@@ -57,9 +59,9 @@ Common bootstrap variables:
 : Follow standard conventions
 
 ## Recent Changes
+- 022-collection-resource-contract: Added Go 1.25 (`gitstore-api`); Rust edition 2021 MSRV 1.82 (`gitstore-git-service` — no changes needed) + `gqlgen v0.17.90`, `go-memdb v1.3.5` (dev), `gocqlx/v3 v3.0.4` + `gocql` (ScyllaDB prod), `go-playground/validator/v10`, `go.uber.org/zap`, `github.com/adrg/frontmatter v0.2.0`, `gopkg.in/yaml.v3`
 - 021-category-taxonomy: Replaced legacy `Category` entity with Kubernetes-style `CategoryTaxonomy` backed by git push pipeline. Added `ParseResource` multi-kind validator dispatcher, intra-push DFS cycle detection, materialized `AncestorPath` hierarchy, `CategoryObjectMeta`/`CategorySpec`/`status` GraphQL envelope, E2E integration tests. Removed legacy `slug`/`displayOrder` fields from `Category` type. Completed `ObjectMeta` with full system-managed fields. Closes GH#40, GH#82.
 - 020-pre-receive-validation-e2e: Added GitHub Actions YAML + Go 1.25 (test runner) + Docker Compose, `compose.scylla.yml` (already committed), ScyllaDB 5.4
-- 019-fix-upload-pack: Added Rust edition 2021, MSRV 1.82 (`gitstore-git-service`) + `gix 0.84.0`, `gix-pack 0.71.0`, `tokio 1.35`, `anyhow 1.0`, `tracing 0.1`
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/gitstore-api/internal/catalog/collection.go
+++ b/gitstore-api/internal/catalog/collection.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package catalog
+
+// CollectionResource is the top-level envelope parsed from a Collection
+// Markdown file's YAML frontmatter. Only author-writable fields are present here.
+type CollectionResource struct {
+	APIVersion string         `yaml:"apiVersion" validate:"required,eq=catalog.gitstore.dev/v1beta1"`
+	Kind       string         `yaml:"kind"       validate:"required,eq=Collection"`
+	Metadata   ObjectMeta     `yaml:"metadata"   validate:"required"`
+	Spec       CollectionSpec `yaml:"spec"`
+}
+
+// CollectionSpec is the author-controlled declarative specification for a collection.
+type CollectionSpec struct {
+	Title     string            `yaml:"title"     validate:"required"`
+	Selector  *LabelSelector    `yaml:"selector"`
+	TargetRef *ObjectReference  `yaml:"targetRef"`
+	Media     []MediaDefinition `yaml:"media"     validate:"omitempty,dive"`
+}
+
+// LabelSelector selects resources by label constraints.
+// matchLabels and matchExpressions are combined with logical AND.
+// An empty or absent selector matches nothing.
+type LabelSelector struct {
+	MatchLabels      map[string]string          `yaml:"matchLabels"`
+	MatchExpressions []LabelSelectorRequirement `yaml:"matchExpressions" validate:"omitempty,dive"`
+}
+
+// LabelSelectorRequirement is a single set-based label constraint.
+type LabelSelectorRequirement struct {
+	Key      string   `yaml:"key"      validate:"required"`
+	Operator string   `yaml:"operator" validate:"required,oneof=In NotIn Exists DoesNotExist"`
+	Values   []string `yaml:"values"`
+}

--- a/gitstore-api/internal/catalog/selector.go
+++ b/gitstore-api/internal/catalog/selector.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package catalog
+
+// MatchesLabels reports whether the given labels satisfy the selector.
+// An empty or nil selector always returns false (matches nothing).
+func MatchesLabels(selector *LabelSelector, labels map[string]string) bool {
+	if selector == nil {
+		return false
+	}
+	if len(selector.MatchLabels) == 0 && len(selector.MatchExpressions) == 0 {
+		return false
+	}
+	for k, v := range selector.MatchLabels {
+		if labels[k] != v {
+			return false
+		}
+	}
+	for _, req := range selector.MatchExpressions {
+		switch req.Operator {
+		case "In":
+			val, ok := labels[req.Key]
+			if !ok {
+				return false
+			}
+			if !containsString(req.Values, val) {
+				return false
+			}
+		case "NotIn":
+			val, ok := labels[req.Key]
+			if ok && containsString(req.Values, val) {
+				return false
+			}
+		case "Exists":
+			if _, ok := labels[req.Key]; !ok {
+				return false
+			}
+		case "DoesNotExist":
+			if _, ok := labels[req.Key]; ok {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func containsString(ss []string, s string) bool {
+	for _, v := range ss {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}

--- a/gitstore-api/internal/catalog/selector_test.go
+++ b/gitstore-api/internal/catalog/selector_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package catalog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchesLabels_NilSelector_ReturnsFalse(t *testing.T) {
+	assert.False(t, MatchesLabels(nil, map[string]string{"k": "v"}))
+}
+
+func TestMatchesLabels_EmptySelector_ReturnsFalse(t *testing.T) {
+	assert.False(t, MatchesLabels(&LabelSelector{}, map[string]string{"k": "v"}))
+}
+
+func TestMatchesLabels_MatchLabels_AllMatch(t *testing.T) {
+	sel := &LabelSelector{MatchLabels: map[string]string{"brand": "apple", "type": "laptop"}}
+	labels := map[string]string{"brand": "apple", "type": "laptop", "extra": "ignored"}
+	assert.True(t, MatchesLabels(sel, labels))
+}
+
+func TestMatchesLabels_MatchLabels_OneMismatch_ReturnsFalse(t *testing.T) {
+	sel := &LabelSelector{MatchLabels: map[string]string{"brand": "apple", "type": "laptop"}}
+	labels := map[string]string{"brand": "apple", "type": "desktop"}
+	assert.False(t, MatchesLabels(sel, labels))
+}
+
+func TestMatchesLabels_MatchLabels_MissingKey_ReturnsFalse(t *testing.T) {
+	sel := &LabelSelector{MatchLabels: map[string]string{"brand": "apple"}}
+	assert.False(t, MatchesLabels(sel, map[string]string{}))
+}
+
+func TestMatchesLabels_In_Match(t *testing.T) {
+	sel := &LabelSelector{MatchExpressions: []LabelSelectorRequirement{
+		{Key: "type", Operator: "In", Values: []string{"laptop", "notebook"}},
+	}}
+	assert.True(t, MatchesLabels(sel, map[string]string{"type": "laptop"}))
+}
+
+func TestMatchesLabels_In_NoMatch(t *testing.T) {
+	sel := &LabelSelector{MatchExpressions: []LabelSelectorRequirement{
+		{Key: "type", Operator: "In", Values: []string{"laptop", "notebook"}},
+	}}
+	assert.False(t, MatchesLabels(sel, map[string]string{"type": "desktop"}))
+}
+
+func TestMatchesLabels_In_MissingKey_ReturnsFalse(t *testing.T) {
+	sel := &LabelSelector{MatchExpressions: []LabelSelectorRequirement{
+		{Key: "type", Operator: "In", Values: []string{"laptop"}},
+	}}
+	assert.False(t, MatchesLabels(sel, map[string]string{}))
+}
+
+func TestMatchesLabels_NotIn_KeyAbsent_ReturnsTrue(t *testing.T) {
+	sel := &LabelSelector{MatchExpressions: []LabelSelectorRequirement{
+		{Key: "type", Operator: "NotIn", Values: []string{"desktop"}},
+	}}
+	assert.True(t, MatchesLabels(sel, map[string]string{"brand": "apple"}))
+}
+
+func TestMatchesLabels_NotIn_ValueInList_ReturnsFalse(t *testing.T) {
+	sel := &LabelSelector{MatchExpressions: []LabelSelectorRequirement{
+		{Key: "type", Operator: "NotIn", Values: []string{"desktop"}},
+	}}
+	assert.False(t, MatchesLabels(sel, map[string]string{"type": "desktop"}))
+}
+
+func TestMatchesLabels_NotIn_ValueNotInList_ReturnsTrue(t *testing.T) {
+	sel := &LabelSelector{MatchExpressions: []LabelSelectorRequirement{
+		{Key: "type", Operator: "NotIn", Values: []string{"desktop"}},
+	}}
+	assert.True(t, MatchesLabels(sel, map[string]string{"type": "laptop"}))
+}
+
+func TestMatchesLabels_Exists_KeyPresent_ReturnsTrue(t *testing.T) {
+	sel := &LabelSelector{MatchExpressions: []LabelSelectorRequirement{
+		{Key: "brand", Operator: "Exists"},
+	}}
+	assert.True(t, MatchesLabels(sel, map[string]string{"brand": "anything"}))
+}
+
+func TestMatchesLabels_Exists_KeyAbsent_ReturnsFalse(t *testing.T) {
+	sel := &LabelSelector{MatchExpressions: []LabelSelectorRequirement{
+		{Key: "brand", Operator: "Exists"},
+	}}
+	assert.False(t, MatchesLabels(sel, map[string]string{"other": "val"}))
+}
+
+func TestMatchesLabels_DoesNotExist_KeyAbsent_ReturnsTrue(t *testing.T) {
+	sel := &LabelSelector{MatchExpressions: []LabelSelectorRequirement{
+		{Key: "discontinued", Operator: "DoesNotExist"},
+	}}
+	assert.True(t, MatchesLabels(sel, map[string]string{"brand": "apple"}))
+}
+
+func TestMatchesLabels_DoesNotExist_KeyPresent_ReturnsFalse(t *testing.T) {
+	sel := &LabelSelector{MatchExpressions: []LabelSelectorRequirement{
+		{Key: "discontinued", Operator: "DoesNotExist"},
+	}}
+	assert.False(t, MatchesLabels(sel, map[string]string{"discontinued": "true"}))
+}
+
+func TestMatchesLabels_CombinedMatchLabelsAndExpressions(t *testing.T) {
+	sel := &LabelSelector{
+		MatchLabels: map[string]string{"brand": "apple"},
+		MatchExpressions: []LabelSelectorRequirement{
+			{Key: "type", Operator: "In", Values: []string{"laptop", "notebook"}},
+			{Key: "discontinued", Operator: "DoesNotExist"},
+		},
+	}
+	// All constraints satisfied
+	assert.True(t, MatchesLabels(sel, map[string]string{"brand": "apple", "type": "laptop"}))
+	// matchLabels fails
+	assert.False(t, MatchesLabels(sel, map[string]string{"brand": "samsung", "type": "laptop"}))
+	// In expression fails
+	assert.False(t, MatchesLabels(sel, map[string]string{"brand": "apple", "type": "desktop"}))
+	// DoesNotExist fails
+	assert.False(t, MatchesLabels(sel, map[string]string{"brand": "apple", "type": "laptop", "discontinued": "true"}))
+}

--- a/gitstore-api/internal/cataloggrpc/server.go
+++ b/gitstore-api/internal/cataloggrpc/server.go
@@ -282,8 +282,11 @@ func (s *Server) AdmitResources(
 		s.admitCategoryTaxonomyWithContext(ctx, e.parsed.CategoryTaxonomy, e.body, req, repoNamespace, revision, now, inPushAncestorPaths, cycleMembers[name])
 	}
 	for _, e := range entries {
-		if e.parsed.Kind == "Product" {
+		switch e.parsed.Kind {
+		case "Product":
 			s.admitProduct(ctx, e.parsed.Product, e.body, req, repoNamespace, revision, now)
+		case "Collection":
+			s.admitCollection(ctx, e.parsed.Collection, e.body, req, repoNamespace, revision, now)
 		}
 	}
 
@@ -432,6 +435,73 @@ func (s *Server) admitProduct(
 		existing.Status = admissionAcceptedStatus(gen, revision, now)
 		if uerr := s.store.UpdateProduct(ctx, existing); uerr != nil {
 			s.log.Error("admit_resources: update product failed",
+				zap.String("name", resource.Metadata.Name), zap.Error(uerr))
+		}
+	}
+}
+
+func (s *Server) admitCollection(
+	ctx context.Context,
+	resource *catalog.CollectionResource,
+	body []byte,
+	req *catalogv1.AdmitResourcesRequest,
+	repoNamespace string,
+	revision string,
+	now time.Time,
+) {
+	specJSON, err := json.Marshal(resource.Spec)
+	if err != nil {
+		s.log.Error("admit_resources: marshal collection spec failed",
+			zap.String("name", resource.Metadata.Name), zap.Error(err))
+		return
+	}
+
+	namespace := resource.Metadata.Namespace
+	if namespace == "" {
+		namespace = repoNamespace
+	}
+
+	existing, getErr := s.store.GetCollectionByName(ctx, namespace, resource.Metadata.Name)
+
+	if getErr != nil || existing == nil {
+		c := &datastore.Collection{
+			UID:               uuid.Must(uuid.NewV7()).String(),
+			Namespace:         namespace,
+			Name:              resource.Metadata.Name,
+			APIVersion:        resource.APIVersion,
+			Kind:              resource.Kind,
+			Labels:            resource.Metadata.Labels,
+			Annotations:       resource.Metadata.Annotations,
+			Generation:        1,
+			ResourceVersion:   "1",
+			CreationTimestamp: now,
+			Revision:          revision,
+			GitCommitSHA:      req.CommitSha,
+			GitRef:            req.RefName,
+			Spec:              specJSON,
+			Body:              string(body),
+		}
+		c.Status = admissionAcceptedStatus(1, revision, now)
+		if cerr := s.store.CreateCollection(ctx, c); cerr != nil {
+			s.log.Error("admit_resources: create collection failed",
+				zap.String("name", resource.Metadata.Name), zap.Error(cerr))
+		}
+	} else {
+		gen := existing.Generation + 1
+		existing.APIVersion = resource.APIVersion
+		existing.Kind = resource.Kind
+		existing.Labels = resource.Metadata.Labels
+		existing.Annotations = resource.Metadata.Annotations
+		existing.Generation = gen
+		existing.ResourceVersion = fmt.Sprintf("%d", gen)
+		existing.Revision = revision
+		existing.GitCommitSHA = req.CommitSha
+		existing.GitRef = req.RefName
+		existing.Spec = specJSON
+		existing.Body = string(body)
+		existing.Status = admissionAcceptedStatus(gen, revision, now)
+		if uerr := s.store.UpdateCollection(ctx, existing); uerr != nil {
+			s.log.Error("admit_resources: update collection failed",
 				zap.String("name", resource.Metadata.Name), zap.Error(uerr))
 		}
 	}

--- a/gitstore-api/internal/datastore/datastore.go
+++ b/gitstore-api/internal/datastore/datastore.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"errors"
 	"time"
+
+	"github.com/gitstore-dev/gitstore/api/internal/catalog"
 )
 
 // Sentinel errors returned by all backends.
@@ -75,11 +77,11 @@ type Datastore interface {
 
 	// Collection operations
 	CreateCollection(ctx context.Context, c *Collection) error
-	GetCollection(ctx context.Context, id string) (*Collection, error)
-	GetCollectionBySlug(ctx context.Context, slug string) (*Collection, error)
-	ListCollections(ctx context.Context, page PageParams) (*PageResult[Collection], error)
+	GetCollection(ctx context.Context, uid string) (*Collection, error)
+	GetCollectionByName(ctx context.Context, namespace, name string) (*Collection, error)
+	ListCollections(ctx context.Context, namespace string, page PageParams) (*PageResult[Collection], error)
 	UpdateCollection(ctx context.Context, c *Collection) error
-	DeleteCollection(ctx context.Context, id string) error
+	ListProductsByLabelSelector(ctx context.Context, namespace string, selector catalog.LabelSelector) ([]*Product, error)
 
 	// Namespace operations
 	CreateNamespace(ctx context.Context, ns *Namespace) error

--- a/gitstore-api/internal/datastore/entities.go
+++ b/gitstore-api/internal/datastore/entities.go
@@ -110,16 +110,39 @@ type CategoryTaxonomy struct {
 	Status json.RawMessage
 }
 
-// Collection represents a flat grouping of products.
+// Collection is the git-backed Kubernetes-style collection resource.
+// Membership is determined at query time via label selector evaluation,
+// not by a stored product list.
 type Collection struct {
-	ID           string
-	Name         string
-	Slug         string
-	DisplayOrder int
-	ProductIDs   []string
-	CreatedAt    time.Time
-	UpdatedAt    time.Time
-	Body         string
+	// Identity (primary key: Namespace + Name)
+	UID       string
+	Namespace string
+	Name      string
+
+	// Resource envelope
+	APIVersion string
+	Kind       string
+
+	// Versioning
+	Generation        int64
+	ResourceVersion   string
+	CreationTimestamp time.Time
+	Revision          string // e.g. "main@sha1:abc123"
+
+	// Author-supplied classification
+	Labels      map[string]string
+	Annotations map[string]string
+
+	// Git provenance
+	GitCommitSHA string
+	GitRef       string
+
+	// Spec and body
+	Spec json.RawMessage // JSON-encoded CollectionSpec
+	Body string          // Markdown description
+
+	// Status — system-only JSON blob
+	Status json.RawMessage
 }
 
 // Repository represents a git repository with a stable internal identity.

--- a/gitstore-api/internal/datastore/instrumented.go
+++ b/gitstore-api/internal/datastore/instrumented.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/gitstore-dev/gitstore/api/internal/catalog"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 )
@@ -139,23 +140,23 @@ func (d *InstrumentedDatastore) CreateCollection(ctx context.Context, c *Collect
 	return err
 }
 
-func (d *InstrumentedDatastore) GetCollection(ctx context.Context, id string) (*Collection, error) {
+func (d *InstrumentedDatastore) GetCollection(ctx context.Context, uid string) (*Collection, error) {
 	start := time.Now()
-	v, err := d.next.GetCollection(ctx, id)
+	v, err := d.next.GetCollection(ctx, uid)
 	d.observe("GetCollection", start, err)
 	return v, err
 }
 
-func (d *InstrumentedDatastore) GetCollectionBySlug(ctx context.Context, slug string) (*Collection, error) {
+func (d *InstrumentedDatastore) GetCollectionByName(ctx context.Context, namespace, name string) (*Collection, error) {
 	start := time.Now()
-	v, err := d.next.GetCollectionBySlug(ctx, slug)
-	d.observe("GetCollectionBySlug", start, err)
+	v, err := d.next.GetCollectionByName(ctx, namespace, name)
+	d.observe("GetCollectionByName", start, err)
 	return v, err
 }
 
-func (d *InstrumentedDatastore) ListCollections(ctx context.Context, params PageParams) (*PageResult[Collection], error) {
+func (d *InstrumentedDatastore) ListCollections(ctx context.Context, namespace string, params PageParams) (*PageResult[Collection], error) {
 	start := time.Now()
-	v, err := d.next.ListCollections(ctx, params)
+	v, err := d.next.ListCollections(ctx, namespace, params)
 	d.observe("ListCollections", start, err)
 	return v, err
 }
@@ -167,11 +168,11 @@ func (d *InstrumentedDatastore) UpdateCollection(ctx context.Context, c *Collect
 	return err
 }
 
-func (d *InstrumentedDatastore) DeleteCollection(ctx context.Context, id string) error {
+func (d *InstrumentedDatastore) ListProductsByLabelSelector(ctx context.Context, namespace string, selector catalog.LabelSelector) ([]*Product, error) {
 	start := time.Now()
-	err := d.next.DeleteCollection(ctx, id)
-	d.observe("DeleteCollection", start, err)
-	return err
+	v, err := d.next.ListProductsByLabelSelector(ctx, namespace, selector)
+	d.observe("ListProductsByLabelSelector", start, err)
+	return v, err
 }
 
 // ── Namespace ─────────────────────────────────────────────────────────────

--- a/gitstore-api/internal/datastore/instrumented_test.go
+++ b/gitstore-api/internal/datastore/instrumented_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/gitstore-dev/gitstore/api/internal/catalog"
 	"github.com/gitstore-dev/gitstore/api/internal/datastore"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
@@ -61,17 +62,17 @@ func (s *stubDatastore) CreateCollection(_ context.Context, _ *datastore.Collect
 func (s *stubDatastore) GetCollection(_ context.Context, _ string) (*datastore.Collection, error) {
 	return nil, s.getProductErr
 }
-func (s *stubDatastore) GetCollectionBySlug(_ context.Context, _ string) (*datastore.Collection, error) {
+func (s *stubDatastore) GetCollectionByName(_ context.Context, _, _ string) (*datastore.Collection, error) {
 	return nil, s.getProductErr
 }
-func (s *stubDatastore) ListCollections(_ context.Context, _ datastore.PageParams) (*datastore.PageResult[datastore.Collection], error) {
+func (s *stubDatastore) ListCollections(_ context.Context, _ string, _ datastore.PageParams) (*datastore.PageResult[datastore.Collection], error) {
 	return nil, s.getProductErr
 }
 func (s *stubDatastore) UpdateCollection(_ context.Context, _ *datastore.Collection) error {
 	return s.getProductErr
 }
-func (s *stubDatastore) DeleteCollection(_ context.Context, _ string) error {
-	return s.getProductErr
+func (s *stubDatastore) ListProductsByLabelSelector(_ context.Context, _ string, _ catalog.LabelSelector) ([]*datastore.Product, error) {
+	return nil, s.getProductErr
 }
 func (s *stubDatastore) CreateNamespace(_ context.Context, _ *datastore.Namespace) error {
 	return s.getProductErr

--- a/gitstore-api/internal/datastore/memdb/backend.go
+++ b/gitstore-api/internal/datastore/memdb/backend.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gitstore-dev/gitstore/api/internal/catalog"
 	"github.com/gitstore-dev/gitstore/api/internal/datastore"
 	gomemdb "github.com/hashicorp/go-memdb"
 )
@@ -346,13 +347,9 @@ func (m *memdbDatastore) UpdateCategoryTaxonomy(_ context.Context, c *datastore.
 
 func (m *memdbDatastore) CreateCollection(_ context.Context, c *datastore.Collection) error {
 	txn := m.db.Txn(true)
-	if raw, _ := txn.First("collection", "id", c.ID); raw != nil {
+	if raw, _ := txn.First("collection", "name_namespace", c.Namespace, c.Name); raw != nil {
 		txn.Abort()
-		return fmt.Errorf("%w: collection id %s", datastore.ErrAlreadyExists, c.ID)
-	}
-	if raw, _ := txn.First("collection", "slug", c.Slug); raw != nil {
-		txn.Abort()
-		return fmt.Errorf("%w: collection slug %s", datastore.ErrAlreadyExists, c.Slug)
+		return fmt.Errorf("%w: collection %s/%s", datastore.ErrAlreadyExists, c.Namespace, c.Name)
 	}
 	if err := txn.Insert("collection", c); err != nil {
 		txn.Abort()
@@ -362,30 +359,30 @@ func (m *memdbDatastore) CreateCollection(_ context.Context, c *datastore.Collec
 	return nil
 }
 
-func (m *memdbDatastore) GetCollection(_ context.Context, id string) (*datastore.Collection, error) {
+func (m *memdbDatastore) GetCollection(_ context.Context, uid string) (*datastore.Collection, error) {
 	txn := m.db.Txn(false)
 	defer txn.Abort()
-	raw, err := txn.First("collection", "id", id)
+	raw, err := txn.First("collection", "id", uid)
 	if err != nil || raw == nil {
 		return nil, notFoundOrErr(err)
 	}
 	return raw.(*datastore.Collection), nil
 }
 
-func (m *memdbDatastore) GetCollectionBySlug(_ context.Context, slug string) (*datastore.Collection, error) {
+func (m *memdbDatastore) GetCollectionByName(_ context.Context, namespace, name string) (*datastore.Collection, error) {
 	txn := m.db.Txn(false)
 	defer txn.Abort()
-	raw, err := txn.First("collection", "slug", slug)
+	raw, err := txn.First("collection", "name_namespace", namespace, name)
 	if err != nil || raw == nil {
 		return nil, notFoundOrErr(err)
 	}
 	return raw.(*datastore.Collection), nil
 }
 
-func (m *memdbDatastore) ListCollections(_ context.Context, page datastore.PageParams) (*datastore.PageResult[datastore.Collection], error) {
+func (m *memdbDatastore) ListCollections(_ context.Context, namespace string, page datastore.PageParams) (*datastore.PageResult[datastore.Collection], error) {
 	txn := m.db.Txn(false)
 	defer txn.Abort()
-	it, err := txn.Get("collection", "id")
+	it, err := txn.Get("collection", "namespace", namespace)
 	if err != nil {
 		return nil, fmt.Errorf("memdb: list collections: %w", err)
 	}
@@ -394,15 +391,15 @@ func (m *memdbDatastore) ListCollections(_ context.Context, page datastore.PageP
 		all = append(all, obj.(*datastore.Collection))
 	}
 	return paginateSlice(all, page, func(c *datastore.Collection) (time.Time, string) {
-		return c.CreatedAt, c.ID
+		return c.CreationTimestamp, c.UID
 	}), nil
 }
 
 func (m *memdbDatastore) UpdateCollection(_ context.Context, c *datastore.Collection) error {
 	txn := m.db.Txn(true)
-	if raw, _ := txn.First("collection", "id", c.ID); raw == nil {
+	if raw, _ := txn.First("collection", "name_namespace", c.Namespace, c.Name); raw == nil {
 		txn.Abort()
-		return fmt.Errorf("%w: collection id %s", datastore.ErrNotFound, c.ID)
+		return fmt.Errorf("%w: collection %s/%s", datastore.ErrNotFound, c.Namespace, c.Name)
 	}
 	if err := txn.Insert("collection", c); err != nil {
 		txn.Abort()
@@ -412,19 +409,21 @@ func (m *memdbDatastore) UpdateCollection(_ context.Context, c *datastore.Collec
 	return nil
 }
 
-func (m *memdbDatastore) DeleteCollection(_ context.Context, id string) error {
-	txn := m.db.Txn(true)
-	raw, _ := txn.First("collection", "id", id)
-	if raw == nil {
-		txn.Abort()
-		return fmt.Errorf("%w: collection id %s", datastore.ErrNotFound, id)
+func (m *memdbDatastore) ListProductsByLabelSelector(_ context.Context, namespace string, selector catalog.LabelSelector) ([]*datastore.Product, error) {
+	txn := m.db.Txn(false)
+	defer txn.Abort()
+	it, err := txn.Get("product", "namespace", namespace)
+	if err != nil {
+		return nil, fmt.Errorf("memdb: list products by selector: %w", err)
 	}
-	if err := txn.Delete("collection", raw); err != nil {
-		txn.Abort()
-		return fmt.Errorf("memdb: delete collection: %w", err)
+	var result []*datastore.Product
+	for obj := it.Next(); obj != nil; obj = it.Next() {
+		p := obj.(*datastore.Product)
+		if catalog.MatchesLabels(&selector, p.Labels) {
+			result = append(result, p)
+		}
 	}
-	txn.Commit()
-	return nil
+	return result, nil
 }
 
 // ── Namespace ─────────────────────────────────────────────────────────────────

--- a/gitstore-api/internal/datastore/memdb/backend_test.go
+++ b/gitstore-api/internal/datastore/memdb/backend_test.go
@@ -48,11 +48,11 @@ func categoryTaxonomyFixture(uid, name string) *datastore.CategoryTaxonomy {
 
 func collectionFixture(uid, namespace, name string) *datastore.Collection {
 	return &datastore.Collection{
-		UID:       uid,
-		Namespace: namespace,
-		Name:      name,
+		UID:        uid,
+		Namespace:  namespace,
+		Name:       name,
 		APIVersion: "catalog.gitstore.dev/v1beta1",
-		Kind:      "Collection",
+		Kind:       "Collection",
 	}
 }
 

--- a/gitstore-api/internal/datastore/memdb/backend_test.go
+++ b/gitstore-api/internal/datastore/memdb/backend_test.go
@@ -46,13 +46,13 @@ func categoryTaxonomyFixture(uid, name string) *datastore.CategoryTaxonomy {
 	}
 }
 
-func collectionFixture(id, slug string) *datastore.Collection {
+func collectionFixture(uid, namespace, name string) *datastore.Collection {
 	return &datastore.Collection{
-		ID:        id,
-		Name:      "Test Collection",
-		Slug:      slug,
-		CreatedAt: time.Now(),
-		UpdatedAt: time.Now(),
+		UID:       uid,
+		Namespace: namespace,
+		Name:      name,
+		APIVersion: "catalog.gitstore.dev/v1beta1",
+		Kind:      "Collection",
 	}
 }
 
@@ -235,12 +235,13 @@ func TestMemdb_UpdateCategoryTaxonomy_NotFound(t *testing.T) {
 func TestMemdb_CreateAndGetCollection(t *testing.T) {
 	ds := newBackend(t)
 	ctx := context.Background()
-	c := collectionFixture("c0000000-0000-0000-0000-000000000001", "col-slug")
+	c := collectionFixture("c0000000-0000-0000-0000-000000000001", "my-store", "summer-sale")
 	require.NoError(t, ds.CreateCollection(ctx, c))
 
-	got, err := ds.GetCollection(ctx, c.ID)
+	got, err := ds.GetCollection(ctx, c.UID)
 	require.NoError(t, err)
-	assert.Equal(t, c.Slug, got.Slug)
+	assert.Equal(t, c.UID, got.UID)
+	assert.Equal(t, c.Name, got.Name)
 }
 
 func TestMemdb_GetCollection_NotFound(t *testing.T) {
@@ -249,20 +250,20 @@ func TestMemdb_GetCollection_NotFound(t *testing.T) {
 	require.ErrorIs(t, err, datastore.ErrNotFound)
 }
 
-func TestMemdb_GetCollectionBySlug(t *testing.T) {
+func TestMemdb_GetCollectionByName(t *testing.T) {
 	ds := newBackend(t)
 	ctx := context.Background()
-	c := collectionFixture("c0000000-0000-0000-0000-000000000002", "col-slug-lkp")
+	c := collectionFixture("c0000000-0000-0000-0000-000000000002", "my-store", "winter-sale")
 	require.NoError(t, ds.CreateCollection(ctx, c))
 
-	got, err := ds.GetCollectionBySlug(ctx, "col-slug-lkp")
+	got, err := ds.GetCollectionByName(ctx, "my-store", "winter-sale")
 	require.NoError(t, err)
-	assert.Equal(t, c.ID, got.ID)
+	assert.Equal(t, c.UID, got.UID)
 }
 
-func TestMemdb_GetCollectionBySlug_NotFound(t *testing.T) {
+func TestMemdb_GetCollectionByName_NotFound(t *testing.T) {
 	ds := newBackend(t)
-	_, err := ds.GetCollectionBySlug(context.Background(), "not-there")
+	_, err := ds.GetCollectionByName(context.Background(), "my-store", "not-there")
 	require.ErrorIs(t, err, datastore.ErrNotFound)
 }
 

--- a/gitstore-api/internal/datastore/memdb/schema.go
+++ b/gitstore-api/internal/datastore/memdb/schema.go
@@ -78,12 +78,22 @@ var schema = &memdb.DBSchema{
 				"id": {
 					Name:    "id",
 					Unique:  true,
-					Indexer: &memdb.UUIDFieldIndex{Field: "ID"},
+					Indexer: &memdb.UUIDFieldIndex{Field: "UID"},
 				},
-				"slug": {
-					Name:    "slug",
-					Unique:  true,
-					Indexer: &memdb.StringFieldIndex{Field: "Slug", Lowercase: true},
+				"name_namespace": {
+					Name:   "name_namespace",
+					Unique: true,
+					Indexer: &memdb.CompoundIndex{
+						Indexes: []memdb.Indexer{
+							&memdb.StringFieldIndex{Field: "Namespace"},
+							&memdb.StringFieldIndex{Field: "Name"},
+						},
+					},
+				},
+				"namespace": {
+					Name:    "namespace",
+					Unique:  false,
+					Indexer: &memdb.StringFieldIndex{Field: "Namespace"},
 				},
 			},
 		},

--- a/gitstore-api/internal/datastore/scylla/backend.go
+++ b/gitstore-api/internal/datastore/scylla/backend.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gitstore-dev/gitstore/api/internal/catalog"
 	"github.com/gitstore-dev/gitstore/api/internal/config"
 	"github.com/gitstore-dev/gitstore/api/internal/datastore"
 	"github.com/gocql/gocql"
@@ -33,6 +34,8 @@ type scyllaDatastore struct {
 	categoryTaxonomyByNameTable *table.Table
 	categoryTaxonomyByUIDTable  *table.Table
 	collectionTable             *table.Table
+	collectionByNameTable       *table.Table
+	collectionByUIDTable        *table.Table
 	namespaceTable              *table.Table
 	repositoryTable             *table.Table
 	namespaceMappingTable       *table.Table
@@ -113,15 +116,35 @@ type categoryTaxonomyUIDRow struct {
 }
 
 type collectionRow struct {
-	Bucket       string     `db:"bucket"`
-	CreatedAt    time.Time  `db:"created_at"`
-	ID           gocql.UUID `db:"id"`
-	Name         string     `db:"name"`
-	Slug         string     `db:"slug"`
-	DisplayOrder int        `db:"display_order"`
-	ProductIDs   []string   `db:"product_ids"`
-	UpdatedAt    time.Time  `db:"updated_at"`
-	Body         string     `db:"body"`
+	Namespace         string            `db:"namespace"`
+	CreationTimestamp time.Time         `db:"creation_timestamp"`
+	UID               gocql.UUID        `db:"uid"`
+	Name              string            `db:"name"`
+	APIVersion        string            `db:"api_version"`
+	Kind              string            `db:"kind"`
+	Generation        int64             `db:"generation"`
+	ResourceVersion   string            `db:"resource_version"`
+	Revision          string            `db:"revision"`
+	Labels            map[string]string `db:"labels"`
+	Annotations       map[string]string `db:"annotations"`
+	GitCommitSHA      string            `db:"git_commit_sha"`
+	GitRef            string            `db:"git_ref"`
+	Spec              string            `db:"spec"`
+	Body              string            `db:"body"`
+	Status            string            `db:"status"`
+}
+
+type collectionNameRow struct {
+	Namespace         string     `db:"namespace"`
+	Name              string     `db:"name"`
+	UID               gocql.UUID `db:"uid"`
+	CreationTimestamp time.Time  `db:"creation_timestamp"`
+}
+
+type collectionUIDRow struct {
+	UID               gocql.UUID `db:"uid"`
+	Namespace         string     `db:"namespace"`
+	CreationTimestamp time.Time  `db:"creation_timestamp"`
 }
 
 type namespaceRow struct {
@@ -180,6 +203,8 @@ func New(cfg config.ScyllaConfig, log *zap.Logger) (datastore.Datastore, error) 
 		categoryTaxonomyByNameTable: CategoryTaxonomyByName,
 		categoryTaxonomyByUIDTable:  CategoryTaxonomyByUID,
 		collectionTable:             Collection,
+		collectionByNameTable:       CollectionByName,
+		collectionByUIDTable:        CollectionByUID,
 		namespaceTable:              Namespace,
 		repositoryTable:             Repository,
 		namespaceMappingTable:       NamespaceMapping,
@@ -503,65 +528,80 @@ func (s *scyllaDatastore) UpdateCategoryTaxonomy(ctx context.Context, c *datasto
 // ── Collection ────────────────────────────────────────────────────────────────
 
 func (s *scyllaDatastore) CreateCollection(ctx context.Context, c *datastore.Collection) error {
-	if _, err := s.GetCollection(ctx, c.ID); err == nil {
-		return fmt.Errorf("%w: collection id %s", datastore.ErrAlreadyExists, c.ID)
+	if _, err := s.GetCollection(ctx, c.UID); err == nil {
+		return fmt.Errorf("%w: collection uid %s", datastore.ErrAlreadyExists, c.UID)
 	}
-	if existing, err := s.GetCollectionBySlug(ctx, c.Slug); err == nil && existing.ID != c.ID {
-		return fmt.Errorf("%w: collection slug %s", datastore.ErrAlreadyExists, c.Slug)
+	if _, err := s.GetCollectionByName(ctx, c.Namespace, c.Name); err == nil {
+		return fmt.Errorf("%w: collection %s/%s", datastore.ErrAlreadyExists, c.Namespace, c.Name)
 	}
-	now := time.Now().UTC().Truncate(time.Millisecond)
-	if c.CreatedAt.IsZero() {
-		c.CreatedAt = now
-	}
-	if c.UpdatedAt.IsZero() {
-		c.UpdatedAt = now
+	if c.CreationTimestamp.IsZero() {
+		c.CreationTimestamp = time.Now().UTC().Truncate(time.Millisecond)
 	}
 	row := toCollectionRow(c)
-	stmt, names := s.collectionTable.Insert()
-	if err := s.session.Query(stmt, names).BindStruct(row).ExecRelease(); err != nil {
+
+	insNS, _ := s.collectionTable.Insert()
+	insName, _ := s.collectionByNameTable.Insert()
+	insUID, _ := s.collectionByUIDTable.Insert()
+
+	b := s.session.Batch(gocql.LoggedBatch).WithContext(ctx)
+	b.Query(insNS, row.Namespace, row.CreationTimestamp, row.UID, row.Name, row.APIVersion, row.Kind,
+		row.Generation, row.ResourceVersion, row.Revision, row.Labels, row.Annotations,
+		row.GitCommitSHA, row.GitRef, row.Spec, row.Body, row.Status)
+	b.Query(insName, row.Namespace, row.Name, row.UID, row.CreationTimestamp)
+	b.Query(insUID, row.UID, row.Namespace, row.CreationTimestamp)
+	if err := s.session.ExecuteBatch(b); err != nil {
 		return fmt.Errorf("scylla: create collection: %w", err)
 	}
 	return nil
 }
 
-func (s *scyllaDatastore) GetCollection(_ context.Context, id string) (*datastore.Collection, error) {
-	uid, err := gocql.ParseUUID(id)
+func (s *scyllaDatastore) GetCollection(_ context.Context, uid string) (*datastore.Collection, error) {
+	parsedUID, err := gocql.ParseUUID(uid)
 	if err != nil {
-		return nil, fmt.Errorf("%w: invalid collection id %s", datastore.ErrNotFound, id)
+		return nil, fmt.Errorf("%w: invalid collection uid %s", datastore.ErrNotFound, uid)
 	}
-	stmt, names := qb.Select("collections").
-		Columns(s.collectionTable.Metadata().Columns...).
-		Where(qb.Eq("id")).
-		Limit(1).
-		ToCql()
-	var row collectionRow
-	if err := s.session.Query(stmt, names).BindMap(qb.M{"id": uid}).GetRelease(&row); err != nil {
+	getUID, names := s.collectionByUIDTable.Get()
+	var uidRow collectionUIDRow
+	if err := s.session.Query(getUID, names).BindMap(qb.M{"uid": parsedUID}).GetRelease(&uidRow); err != nil {
 		if errors.Is(err, gocql.ErrNotFound) {
-			return nil, fmt.Errorf("%w: collection id %s", datastore.ErrNotFound, id)
+			return nil, fmt.Errorf("%w: collection uid %s", datastore.ErrNotFound, uid)
 		}
-		return nil, fmt.Errorf("scylla: get collection: %w", err)
+		return nil, fmt.Errorf("scylla: get collection (uid lookup): %w", err)
+	}
+	return s.getCollectionByKey(uidRow.Namespace, uidRow.CreationTimestamp, uidRow.UID)
+}
+
+func (s *scyllaDatastore) GetCollectionByName(_ context.Context, namespace, name string) (*datastore.Collection, error) {
+	getName, nameNames := s.collectionByNameTable.Get()
+	var nameRow collectionNameRow
+	if err := s.session.Query(getName, nameNames).BindMap(qb.M{"namespace": namespace, "name": name}).GetRelease(&nameRow); err != nil {
+		if errors.Is(err, gocql.ErrNotFound) {
+			return nil, fmt.Errorf("%w: collection %s/%s", datastore.ErrNotFound, namespace, name)
+		}
+		return nil, fmt.Errorf("scylla: get collection by name: %w", err)
+	}
+	return s.getCollectionByKey(nameRow.Namespace, nameRow.CreationTimestamp, nameRow.UID)
+}
+
+func (s *scyllaDatastore) getCollectionByKey(namespace string, createdAt time.Time, uid gocql.UUID) (*datastore.Collection, error) {
+	cols := strings.Join(s.collectionTable.Metadata().Columns, ", ")
+	stmt := fmt.Sprintf(
+		"SELECT %s FROM collection WHERE namespace = ? AND creation_timestamp = ? AND uid = ?",
+		cols,
+	)
+	var row collectionRow
+	if err := s.session.Query(stmt, nil).Bind(namespace, createdAt, uid).GetRelease(&row); err != nil {
+		if errors.Is(err, gocql.ErrNotFound) {
+			return nil, fmt.Errorf("%w: collection namespace=%s uid=%s", datastore.ErrNotFound, namespace, uid)
+		}
+		return nil, fmt.Errorf("scylla: get collection by key: %w", err)
 	}
 	return fromCollectionRow(&row), nil
 }
 
-func (s *scyllaDatastore) GetCollectionBySlug(_ context.Context, slug string) (*datastore.Collection, error) {
-	stmt, names := qb.Select("collections").
-		Columns(s.collectionTable.Metadata().Columns...).
-		Where(qb.Eq("slug")).
-		ToCql()
-	var row collectionRow
-	if err := s.session.Query(stmt, names).BindMap(qb.M{"slug": slug}).GetRelease(&row); err != nil {
-		if errors.Is(err, gocql.ErrNotFound) {
-			return nil, fmt.Errorf("%w: collection slug %s", datastore.ErrNotFound, slug)
-		}
-		return nil, fmt.Errorf("scylla: get collection by slug: %w", err)
-	}
-	return fromCollectionRow(&row), nil
-}
-
-func (s *scyllaDatastore) ListCollections(_ context.Context, page datastore.PageParams) (*datastore.PageResult[datastore.Collection], error) {
+func (s *scyllaDatastore) ListCollections(_ context.Context, namespace string, page datastore.PageParams) (*datastore.PageResult[datastore.Collection], error) {
 	limit := page.Limit()
-	pq := buildPaginatedSelect(s.collectionTable, page, "bucket", BucketAll, defaultClusterKeys, nil, nil)
+	pq := buildPaginatedSelect(s.collectionTable, page, "namespace", namespace, collectionClusterKeys, nil, nil)
 
 	var rows []collectionRow
 	if err := s.session.Query(pq.Stmt, nil).Bind(pq.Args...).SelectRelease(&rows); err != nil {
@@ -572,43 +612,53 @@ func (s *scyllaDatastore) ListCollections(_ context.Context, page datastore.Page
 		reverseRows(rows)
 	}
 
-	cols := make([]*datastore.Collection, len(rows))
+	items := make([]*datastore.Collection, len(rows))
 	for i := range rows {
-		cols[i] = fromCollectionRow(&rows[i])
+		items[i] = fromCollectionRow(&rows[i])
 	}
 
-	return buildPageResult(cols, limit, page), nil
+	return buildPageResult(items, limit, page), nil
 }
 
 func (s *scyllaDatastore) UpdateCollection(ctx context.Context, c *datastore.Collection) error {
-	if _, err := s.GetCollection(ctx, c.ID); err != nil {
+	existing, err := s.GetCollectionByName(ctx, c.Namespace, c.Name)
+	if err != nil {
 		return err
 	}
 	row := toCollectionRow(c)
-	stmt, names := s.collectionTable.Update(
-		"name", "slug", "display_order", "product_ids",
-		"updated_at", "body",
+	row.CreationTimestamp = existing.CreationTimestamp
+	existingUID := mustParseUUID(existing.UID)
+
+	const updNS = "UPDATE collection SET api_version=?, kind=?, generation=?, resource_version=?, " +
+		"revision=?, labels=?, annotations=?, git_commit_sha=?, git_ref=?, spec=?, body=?, status=? " +
+		"WHERE namespace=? AND creation_timestamp=? AND uid=?"
+
+	b := s.session.Batch(gocql.LoggedBatch).WithContext(ctx)
+	b.Query(updNS,
+		row.APIVersion, row.Kind, row.Generation, row.ResourceVersion,
+		row.Revision, row.Labels, row.Annotations,
+		row.GitCommitSHA, row.GitRef, row.Spec, row.Body, row.Status,
+		row.Namespace, row.CreationTimestamp, existingUID,
 	)
-	if err := s.session.Query(stmt, names).BindStruct(row).ExecRelease(); err != nil {
+	if err := s.session.ExecuteBatch(b); err != nil {
 		return fmt.Errorf("scylla: update collection: %w", err)
 	}
 	return nil
 }
 
-func (s *scyllaDatastore) DeleteCollection(ctx context.Context, id string) error {
-	col, err := s.GetCollection(ctx, id)
+func (s *scyllaDatastore) ListProductsByLabelSelector(ctx context.Context, namespace string, selector catalog.LabelSelector) ([]*datastore.Product, error) {
+	page := datastore.PageParams{First: 1000}
+	result, err := s.ListProducts(ctx, namespace, page)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	stmt, names := s.collectionTable.Delete()
-	if err := s.session.Query(stmt, names).BindMap(qb.M{
-		"bucket":     BucketAll,
-		"created_at": col.CreatedAt,
-		"id":         mustParseUUID(id),
-	}).ExecRelease(); err != nil {
-		return fmt.Errorf("scylla: delete collection: %w", err)
+	var matched []*datastore.Product
+	for _, p := range result.Items {
+		if catalog.MatchesLabels(&selector, p.Labels) {
+			matched = append(matched, p)
+		}
 	}
-	return nil
+	return matched, nil
 }
 
 // ── Namespace ─────────────────────────────────────────────────────────────────
@@ -827,28 +877,43 @@ func fromCategoryTaxonomyRow(r *categoryTaxonomyRow) *datastore.CategoryTaxonomy
 
 func toCollectionRow(c *datastore.Collection) *collectionRow {
 	return &collectionRow{
-		Bucket:       BucketAll,
-		CreatedAt:    c.CreatedAt,
-		ID:           mustParseUUID(c.ID),
-		Name:         c.Name,
-		Slug:         c.Slug,
-		DisplayOrder: c.DisplayOrder,
-		ProductIDs:   c.ProductIDs,
-		UpdatedAt:    c.UpdatedAt,
-		Body:         c.Body,
+		Namespace:         c.Namespace,
+		CreationTimestamp: c.CreationTimestamp,
+		UID:               mustParseUUID(c.UID),
+		Name:              c.Name,
+		APIVersion:        c.APIVersion,
+		Kind:              c.Kind,
+		Generation:        c.Generation,
+		ResourceVersion:   c.ResourceVersion,
+		Revision:          c.Revision,
+		Labels:            c.Labels,
+		Annotations:       c.Annotations,
+		GitCommitSHA:      c.GitCommitSHA,
+		GitRef:            c.GitRef,
+		Spec:              string(c.Spec),
+		Body:              c.Body,
+		Status:            string(c.Status),
 	}
 }
 
 func fromCollectionRow(r *collectionRow) *datastore.Collection {
 	return &datastore.Collection{
-		ID:           r.ID.String(),
-		Name:         r.Name,
-		Slug:         r.Slug,
-		DisplayOrder: r.DisplayOrder,
-		ProductIDs:   r.ProductIDs,
-		CreatedAt:    r.CreatedAt,
-		UpdatedAt:    r.UpdatedAt,
-		Body:         r.Body,
+		UID:               r.UID.String(),
+		Namespace:         r.Namespace,
+		Name:              r.Name,
+		APIVersion:        r.APIVersion,
+		Kind:              r.Kind,
+		Generation:        r.Generation,
+		ResourceVersion:   r.ResourceVersion,
+		CreationTimestamp: r.CreationTimestamp,
+		Revision:          r.Revision,
+		Labels:            r.Labels,
+		Annotations:       r.Annotations,
+		GitCommitSHA:      r.GitCommitSHA,
+		GitRef:            r.GitRef,
+		Spec:              jsonOrNil(r.Spec),
+		Body:              r.Body,
+		Status:            jsonOrNil(r.Status),
 	}
 }
 

--- a/gitstore-api/internal/datastore/scylla/backend.go
+++ b/gitstore-api/internal/datastore/scylla/backend.go
@@ -647,16 +647,26 @@ func (s *scyllaDatastore) UpdateCollection(ctx context.Context, c *datastore.Col
 }
 
 func (s *scyllaDatastore) ListProductsByLabelSelector(ctx context.Context, namespace string, selector catalog.LabelSelector) ([]*datastore.Product, error) {
-	page := datastore.PageParams{First: 1000}
-	result, err := s.ListProducts(ctx, namespace, page)
-	if err != nil {
-		return nil, err
-	}
-	var matched []*datastore.Product
-	for _, p := range result.Items {
-		if catalog.MatchesLabels(&selector, p.Labels) {
-			matched = append(matched, p)
+	const batchSize = 500
+	var (
+		matched []*datastore.Product
+		page    = datastore.PageParams{First: batchSize}
+	)
+	for {
+		result, err := s.ListProducts(ctx, namespace, page)
+		if err != nil {
+			return nil, err
 		}
+		for _, p := range result.Items {
+			if catalog.MatchesLabels(&selector, p.Labels) {
+				matched = append(matched, p)
+			}
+		}
+		if !result.HasNext || len(result.Items) == 0 {
+			break
+		}
+		last := result.Items[len(result.Items)-1]
+		page.After = encodeKeysetCursor(last.CreationTimestamp, last.UID)
 	}
 	return matched, nil
 }

--- a/gitstore-api/internal/datastore/scylla/backend_test.go
+++ b/gitstore-api/internal/datastore/scylla/backend_test.go
@@ -171,6 +171,17 @@ func newProduct(namespace, name string) *datastore.Product {
 	}
 }
 
+func newCollection(namespace, name string) *datastore.Collection {
+	return &datastore.Collection{
+		UID:               newID(),
+		Namespace:         namespace,
+		Name:              name,
+		APIVersion:        "catalog.gitstore.dev/v1beta1",
+		Kind:              "Collection",
+		CreationTimestamp: time.Now().UTC().Truncate(time.Millisecond),
+	}
+}
+
 // ── Product ───────────────────────────────────────────────────────────────────
 
 func TestScylla_CreateGetProduct(t *testing.T) {
@@ -387,22 +398,34 @@ func TestScylla_CreateGetCollection(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()
 
-	c := &datastore.Collection{ID: newID(), Name: "Summer Sale", Slug: "col-" + newID()[:8]}
+	c := newCollection("test-ns", "col-"+newID()[:8])
 	require.NoError(t, store.CreateCollection(ctx, c))
 
-	got, err := store.GetCollection(ctx, c.ID)
+	got, err := store.GetCollection(ctx, c.UID)
 	require.NoError(t, err)
-	assert.Equal(t, c.Slug, got.Slug)
+	assert.Equal(t, c.UID, got.UID)
+	assert.Equal(t, c.Name, got.Name)
+	assert.Equal(t, c.Namespace, got.Namespace)
 }
 
-func TestScylla_CreateCollection_DuplicateSlug(t *testing.T) {
+func TestScylla_CreateCollection_DuplicateUID(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()
 
-	slug := "dup-col-" + newID()[:8]
-	c1 := &datastore.Collection{ID: newID(), Slug: slug}
+	c := newCollection("test-ns", "dup-uid-"+newID()[:8])
+	require.NoError(t, store.CreateCollection(ctx, c))
+	err := store.CreateCollection(ctx, c)
+	require.ErrorIs(t, err, datastore.ErrAlreadyExists)
+}
+
+func TestScylla_CreateCollection_DuplicateName(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	name := "dup-col-" + newID()[:8]
+	c1 := newCollection("test-ns", name)
 	require.NoError(t, store.CreateCollection(ctx, c1))
-	c2 := &datastore.Collection{ID: newID(), Slug: slug}
+	c2 := newCollection("test-ns", name)
 	err := store.CreateCollection(ctx, c2)
 	require.ErrorIs(t, err, datastore.ErrAlreadyExists)
 }
@@ -413,22 +436,22 @@ func TestScylla_GetCollection_NotFound(t *testing.T) {
 	require.ErrorIs(t, err, datastore.ErrNotFound)
 }
 
-func TestScylla_GetCollectionBySlug(t *testing.T) {
+func TestScylla_GetCollectionByName(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()
 
-	slug := "find-col-" + newID()[:8]
-	c := &datastore.Collection{ID: newID(), Slug: slug}
+	name := "find-col-" + newID()[:8]
+	c := newCollection("test-ns", name)
 	require.NoError(t, store.CreateCollection(ctx, c))
 
-	got, err := store.GetCollectionBySlug(ctx, slug)
+	got, err := store.GetCollectionByName(ctx, "test-ns", name)
 	require.NoError(t, err)
-	assert.Equal(t, c.ID, got.ID)
+	assert.Equal(t, c.UID, got.UID)
 }
 
-func TestScylla_GetCollectionBySlug_NotFound(t *testing.T) {
+func TestScylla_GetCollectionByName_NotFound(t *testing.T) {
 	store := newTestStore(t)
-	_, err := store.GetCollectionBySlug(context.Background(), "no-col-"+newID()[:8])
+	_, err := store.GetCollectionByName(context.Background(), "test-ns", "no-col-"+newID()[:8])
 	require.ErrorIs(t, err, datastore.ErrNotFound)
 }
 
@@ -436,15 +459,15 @@ func TestScylla_ListCollections(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()
 
-	before, err := store.ListCollections(ctx, datastore.PageParams{First: 100})
+	before, err := store.ListCollections(ctx, "test-ns", datastore.PageParams{First: 100})
 	require.NoError(t, err)
 
-	c1 := &datastore.Collection{ID: newID(), Slug: "colls1-" + newID()[:8]}
-	c2 := &datastore.Collection{ID: newID(), Slug: "colls2-" + newID()[:8]}
+	c1 := newCollection("test-ns", "colls1-"+newID()[:8])
+	c2 := newCollection("test-ns", "colls2-"+newID()[:8])
 	require.NoError(t, store.CreateCollection(ctx, c1))
 	require.NoError(t, store.CreateCollection(ctx, c2))
 
-	after, err := store.ListCollections(ctx, datastore.PageParams{First: 100})
+	after, err := store.ListCollections(ctx, "test-ns", datastore.PageParams{First: 100})
 	require.NoError(t, err)
 	assert.Equal(t, len(before.Items)+2, len(after.Items))
 }
@@ -453,36 +476,20 @@ func TestScylla_UpdateCollection(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()
 
-	c := &datastore.Collection{ID: newID(), Slug: "upd-col-" + newID()[:8], Name: "Before"}
+	c := newCollection("test-ns", "upd-col-"+newID()[:8])
+	c.Body = "Before"
 	require.NoError(t, store.CreateCollection(ctx, c))
-	c.Name = "After"
+	c.Body = "After"
 	require.NoError(t, store.UpdateCollection(ctx, c))
 
-	got, err := store.GetCollection(ctx, c.ID)
+	got, err := store.GetCollection(ctx, c.UID)
 	require.NoError(t, err)
-	assert.Equal(t, "After", got.Name)
+	assert.Equal(t, "After", got.Body)
 }
 
 func TestScylla_UpdateCollection_NotFound(t *testing.T) {
 	store := newTestStore(t)
-	err := store.UpdateCollection(context.Background(), &datastore.Collection{ID: newID(), Slug: "ghost-col-" + newID()[:8]})
-	require.ErrorIs(t, err, datastore.ErrNotFound)
-}
-
-func TestScylla_DeleteCollection(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-
-	c := &datastore.Collection{ID: newID(), Slug: "del-col-" + newID()[:8]}
-	require.NoError(t, store.CreateCollection(ctx, c))
-	require.NoError(t, store.DeleteCollection(ctx, c.ID))
-	_, err := store.GetCollection(ctx, c.ID)
-	require.ErrorIs(t, err, datastore.ErrNotFound)
-}
-
-func TestScylla_DeleteCollection_NotFound(t *testing.T) {
-	store := newTestStore(t)
-	err := store.DeleteCollection(context.Background(), newID())
+	err := store.UpdateCollection(context.Background(), newCollection("test-ns", "ghost-col-"+newID()[:8]))
 	require.ErrorIs(t, err, datastore.ErrNotFound)
 }
 

--- a/gitstore-api/internal/datastore/scylla/migrations/001_initial_schema.cql
+++ b/gitstore-api/internal/datastore/scylla/migrations/001_initial_schema.cql
@@ -34,18 +34,40 @@ CREATE TABLE IF NOT EXISTS products_by_uid (
     PRIMARY KEY (uid)
 );
 
-CREATE TABLE IF NOT EXISTS collections (
-    bucket             text,
-    created_at         timestamp,
-    id                 uuid,
+CREATE TABLE IF NOT EXISTS collection (
+    namespace          text,
+    creation_timestamp timestamp,
+    uid                uuid,
     name               text,
-    slug               text,
-    display_order      int,
-    product_ids        set<text>,
-    updated_at         timestamp,
+    api_version        text,
+    kind               text,
+    generation         bigint,
+    resource_version   text,
+    revision           text,
+    labels             map<text, text>,
+    annotations        map<text, text>,
+    git_commit_sha     text,
+    git_ref            text,
+    spec               text,
     body               text,
-    PRIMARY KEY (bucket, created_at, id)
-) WITH CLUSTERING ORDER BY (created_at DESC, id DESC);
+    status             text,
+    PRIMARY KEY ((namespace), creation_timestamp, uid)
+) WITH CLUSTERING ORDER BY (creation_timestamp DESC, uid DESC);
+
+CREATE TABLE IF NOT EXISTS collection_by_name (
+    namespace          text,
+    name               text,
+    uid                uuid,
+    creation_timestamp timestamp,
+    PRIMARY KEY ((namespace), name)
+);
+
+CREATE TABLE IF NOT EXISTS collection_by_uid (
+    uid                uuid,
+    namespace          text,
+    creation_timestamp timestamp,
+    PRIMARY KEY (uid)
+);
 
 CREATE TABLE IF NOT EXISTS namespaces (
     bucket               text,

--- a/gitstore-api/internal/datastore/scylla/migrations/002_add_initial_indices.cql
+++ b/gitstore-api/internal/datastore/scylla/migrations/002_add_initial_indices.cql
@@ -1,6 +1,3 @@
-CREATE INDEX IF NOT EXISTS collections_by_id          ON collections        (id);
-CREATE INDEX IF NOT EXISTS collections_by_slug        ON collections        (slug);
-
 CREATE INDEX IF NOT EXISTS namespaces_by_id           ON namespaces         (id);
 CREATE INDEX IF NOT EXISTS namespaces_by_identifier   ON namespaces         (identifier);
 

--- a/gitstore-api/internal/datastore/scylla/models.go
+++ b/gitstore-api/internal/datastore/scylla/models.go
@@ -134,26 +134,65 @@ var (
 		SortKey: []string{},
 	})
 
+	// Collection is the primary paginated read table (newest-first per namespace).
 	Collection = table.New(table.Metadata{
-		Name: "collections",
+		Name: "collection",
 		Columns: []string{
-			"bucket",
-			"created_at",
-			"id",
+			"namespace",
+			"creation_timestamp",
+			"uid",
 			"name",
-			"slug",
-			"display_order",
-			"product_ids",
-			"updated_at",
+			"api_version",
+			"kind",
+			"generation",
+			"resource_version",
+			"revision",
+			"labels",
+			"annotations",
+			"git_commit_sha",
+			"git_ref",
+			"spec",
 			"body",
+			"status",
 		},
 		PartKey: []string{
-			"bucket",
+			"namespace",
 		},
 		SortKey: []string{
-			"created_at",
-			"id",
+			"creation_timestamp",
+			"uid",
 		},
+	})
+
+	// CollectionByName is the lookup table for GetCollectionByName(namespace, name).
+	CollectionByName = table.New(table.Metadata{
+		Name: "collection_by_name",
+		Columns: []string{
+			"namespace",
+			"name",
+			"uid",
+			"creation_timestamp",
+		},
+		PartKey: []string{
+			"namespace",
+		},
+		SortKey: []string{
+			"name",
+		},
+	})
+
+	// CollectionByUID is the lookup table for GetCollection(uid).
+	CollectionByUID = table.New(table.Metadata{
+		Name: "collection_by_uid",
+		Columns: []string{
+			"uid",
+			"namespace",
+			"creation_timestamp",
+		},
+		PartKey: []string{
+			"uid",
+		},
+		SortKey: []string{},
 	})
 
 	Namespace = table.New(table.Metadata{

--- a/gitstore-api/internal/datastore/scylla/pagination.go
+++ b/gitstore-api/internal/datastore/scylla/pagination.go
@@ -51,6 +51,7 @@ type clusterKeys struct {
 
 var defaultClusterKeys = clusterKeys{TimestampCol: "created_at", IDCol: "id"}
 var productClusterKeys = clusterKeys{TimestampCol: "creation_timestamp", IDCol: "uid"}
+var collectionClusterKeys = clusterKeys{TimestampCol: "creation_timestamp", IDCol: "uid"}
 
 // buildPaginatedSelect constructs a CQL SELECT with keyset pagination.
 // It uses tuple inequality comparisons on the two clustering columns for forward

--- a/gitstore-api/internal/datastore/scylla/pagination.go
+++ b/gitstore-api/internal/datastore/scylla/pagination.go
@@ -14,6 +14,13 @@ import (
 	"github.com/scylladb/gocqlx/v3/table"
 )
 
+// encodeKeysetCursor encodes a keyset position as an opaque base64 cursor.
+// The format mirrors the graph-layer EncodeKeysetCursor so cursors are interchangeable.
+func encodeKeysetCursor(ts time.Time, id string) string {
+	payload := fmt.Sprintf("keyset|%s|%s", ts.Format(time.RFC3339Nano), id)
+	return base64.StdEncoding.EncodeToString([]byte(payload))
+}
+
 // parsePageCursor decodes an opaque base64 keyset cursor into a PageCursor.
 func parsePageCursor(cursor string) (*datastore.PageCursor, error) {
 	decoded, err := base64.StdEncoding.DecodeString(cursor)

--- a/gitstore-api/internal/graph/collection.resolvers.go
+++ b/gitstore-api/internal/graph/collection.resolvers.go
@@ -8,7 +8,6 @@ package graph
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/gitstore-dev/gitstore/api/internal/graph/generated"
 	"github.com/gitstore-dev/gitstore/api/internal/graph/model"
@@ -16,138 +15,83 @@ import (
 
 // Products is the resolver for the products field.
 func (r *collectionResolver) Products(ctx context.Context, obj *model.Collection, first *int32, after *string, last *int32, before *string) (*model.ProductConnection, error) {
-	_, err := decodeNodeIDAs(nodeKindCollection, obj.ID)
+	uid, err := decodeNodeIDAs(nodeKindCollection, obj.ID)
 	if err != nil {
 		return nil, err
 	}
-	// TODO: Add collection-scoped product listing to the datastore interface.
-	// For now, return all products paginated (filter by collection will be added later).
-	params := toPageParams(first, after, last, before)
-	result, err := r.service.GetProducts(ctx, "", params)
+	c, err := r.service.GetCollectionByUID(ctx, uid)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get products: %w", err)
+		return nil, fmt.Errorf("collection not found: %w", err)
 	}
-	return BuildProductConnection(result), nil
+	var spec struct {
+		Selector *struct {
+			MatchLabels      map[string]string `json:"matchLabels"`
+			MatchExpressions []struct {
+				Key      string   `json:"key"`
+				Operator string   `json:"operator"`
+				Values   []string `json:"values"`
+			} `json:"matchExpressions"`
+		} `json:"selector"`
+	}
+	if c.Spec != nil {
+		if err := jsonUnmarshal(c.Spec, &spec); err == nil && spec.Selector != nil {
+			selector := specSelectorToCatalog(spec.Selector)
+			ns := c.Namespace
+			products, err := r.service.ListProductsByLabelSelector(ctx, ns, selector)
+			if err != nil {
+				return nil, fmt.Errorf("failed to list collection products: %w", err)
+			}
+			return BuildProductConnectionFromSlice(products), nil
+		}
+	}
+	return &model.ProductConnection{
+		Edges:    []*model.ProductEdge{},
+		PageInfo: &model.PageInfo{},
+	}, nil
 }
 
 // CreateCollection is the resolver for the createCollection field.
-func (r *mutationResolver) CreateCollection(ctx context.Context, input model.CreateCollectionInput) (*model.CreateCollectionPayload, error) {
-	if _, err := decodeNodeIDsAs(nodeKindProduct, input.ProductIds); err != nil {
-		return nil, err
-	}
-
-	serviceInput := map[string]interface{}{
-		"name": input.Name,
-		"slug": input.Slug,
-	}
-	if input.Body != nil {
-		serviceInput["body"] = *input.Body
-	}
-	if input.DisplayOrder != nil {
-		serviceInput["displayOrder"] = *input.DisplayOrder
-	}
-
-	collection, err := r.service.CreateCollection(ctx, serviceInput)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create collection: %w", err)
-	}
-
-	return &model.CreateCollectionPayload{
-		ClientMutationID: input.ClientMutationID,
-		Collection:       DatastoreCollectionToGraphQL(collection),
-	}, nil
+func (r *mutationResolver) CreateCollection(_ context.Context, _ model.CreateCollectionInput) (*model.CreateCollectionPayload, error) {
+	return nil, fmt.Errorf("createCollection is deprecated: manage collections via git push")
 }
 
 // UpdateCollection is the resolver for the updateCollection field.
-func (r *mutationResolver) UpdateCollection(ctx context.Context, input model.UpdateCollectionInput) (*model.UpdateCollectionPayload, error) {
-	collectionID, err := decodeNodeIDAs(nodeKindCollection, input.ID)
-	if err != nil {
-		return nil, err
-	}
-	if _, err := decodeNodeIDsAs(nodeKindProduct, input.ProductIds); err != nil {
-		return nil, err
-	}
-
-	collection := &model.Collection{
-		ID:           mustEncodeNodeID(nodeKindCollection, collectionID),
-		Name:         stringOrDefault(input.Name, "Updated Collection"),
-		Slug:         stringOrDefault(input.Slug, "updated-collection"),
-		Body:         input.Body,
-		DisplayOrder: intOrDefault(input.DisplayOrder, 0),
-		Products:     &model.ProductConnection{Edges: []*model.ProductEdge{}, PageInfo: &model.PageInfo{}},
-		CreatedAt:    time.Now().Add(-24 * time.Hour),
-		UpdatedAt:    time.Now(),
-	}
-	return &model.UpdateCollectionPayload{
-		ClientMutationID: input.ClientMutationID,
-		Collection:       collection,
-		Conflict:         nil,
-	}, nil
+func (r *mutationResolver) UpdateCollection(_ context.Context, _ model.UpdateCollectionInput) (*model.UpdateCollectionPayload, error) {
+	return nil, fmt.Errorf("updateCollection is deprecated: manage collections via git push")
 }
 
 // DeleteCollection is the resolver for the deleteCollection field.
-func (r *mutationResolver) DeleteCollection(ctx context.Context, input model.DeleteCollectionInput) (*model.DeleteCollectionPayload, error) {
-	collectionID, err := decodeNodeIDAs(nodeKindCollection, input.ID)
-	if err != nil {
-		return nil, err
-	}
-	idCopy := mustEncodeNodeID(nodeKindCollection, collectionID)
-	return &model.DeleteCollectionPayload{
-		ClientMutationID:    input.ClientMutationID,
-		DeletedCollectionID: &idCopy,
-	}, nil
-}
-
-// ReorderCollections is the resolver for the reorderCollections field.
-func (r *mutationResolver) ReorderCollections(ctx context.Context, input model.ReorderCollectionsInput) (*model.ReorderCollectionsPayload, error) {
-	orderedIDs, err := decodeNodeIDsAs(nodeKindCollection, input.OrderedIds)
-	if err != nil {
-		return nil, err
-	}
-
-	collections := make([]*model.Collection, len(orderedIDs))
-	for i, id := range orderedIDs {
-		collections[i] = &model.Collection{
-			ID:           mustEncodeNodeID(nodeKindCollection, id),
-			Name:         fmt.Sprintf("Collection %d", i+1),
-			Slug:         fmt.Sprintf("collection-%d", i+1),
-			DisplayOrder: int32(i),
-			Products:     &model.ProductConnection{Edges: []*model.ProductEdge{}, PageInfo: &model.PageInfo{}},
-			CreatedAt:    time.Now(),
-			UpdatedAt:    time.Now(),
-		}
-	}
-	return &model.ReorderCollectionsPayload{
-		ClientMutationID: input.ClientMutationID,
-		Collections:      collections,
-	}, nil
+func (r *mutationResolver) DeleteCollection(_ context.Context, _ model.DeleteCollectionInput) (*model.DeleteCollectionPayload, error) {
+	return nil, fmt.Errorf("deleteCollection is deprecated: manage collections via git push")
 }
 
 // Collection is the resolver for the collection field.
 func (r *queryResolver) Collection(ctx context.Context, by model.CollectionBy) (*model.Collection, error) {
 	if by.ID != nil {
-		collectionID, err := decodeNodeIDAs(nodeKindCollection, *by.ID)
+		uid, err := decodeNodeIDAs(nodeKindCollection, *by.ID)
 		if err != nil {
 			return nil, err
 		}
-		c, err := r.service.GetCollectionByID(ctx, collectionID)
+		c, err := r.service.GetCollectionByUID(ctx, uid)
 		if err != nil {
 			return nil, nil
 		}
 		return DatastoreCollectionToGraphQL(c), nil
 	}
-
-	c, err := r.service.GetCollectionBySlug(ctx, *by.Slug)
-	if err != nil {
-		return nil, nil
+	if by.NamespacePath != nil {
+		c, err := r.service.GetCollectionByName(ctx, by.NamespacePath.Namespace, by.NamespacePath.Name)
+		if err != nil {
+			return nil, nil
+		}
+		return DatastoreCollectionToGraphQL(c), nil
 	}
-	return DatastoreCollectionToGraphQL(c), nil
+	return nil, fmt.Errorf("collection lookup requires id or namespacePath")
 }
 
 // Collections returns collections as a Relay connection.
-func (r *queryResolver) Collections(ctx context.Context, first *int32, after *string, last *int32, before *string) (*model.CollectionConnection, error) {
+func (r *queryResolver) Collections(ctx context.Context, namespace string, first *int32, after *string, last *int32, before *string) (*model.CollectionConnection, error) {
 	params := toPageParams(first, after, last, before)
-	result, err := r.service.GetCollections(ctx, params)
+	result, err := r.service.GetCollections(ctx, namespace, params)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get collections: %w", err)
 	}

--- a/gitstore-api/internal/graph/collection.resolvers.go
+++ b/gitstore-api/internal/graph/collection.resolvers.go
@@ -7,10 +7,13 @@ package graph
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/gitstore-dev/gitstore/api/internal/datastore"
 	"github.com/gitstore-dev/gitstore/api/internal/graph/generated"
 	"github.com/gitstore-dev/gitstore/api/internal/graph/model"
+	"go.uber.org/zap"
 )
 
 // Products is the resolver for the products field.
@@ -34,14 +37,15 @@ func (r *collectionResolver) Products(ctx context.Context, obj *model.Collection
 		} `json:"selector"`
 	}
 	if c.Spec != nil {
-		if err := jsonUnmarshal(c.Spec, &spec); err == nil && spec.Selector != nil {
+		if err := jsonUnmarshal(c.Spec, &spec); err != nil {
+			r.logger.Warn("collection products: failed to unmarshal spec", zap.String("uid", uid), zap.Error(err))
+		} else if spec.Selector != nil {
 			selector := specSelectorToCatalog(spec.Selector)
-			ns := c.Namespace
-			products, err := r.service.ListProductsByLabelSelector(ctx, ns, selector)
+			products, err := r.service.ListProductsByLabelSelector(ctx, c.Namespace, selector)
 			if err != nil {
 				return nil, fmt.Errorf("failed to list collection products: %w", err)
 			}
-			return BuildProductConnectionFromSlice(products), nil
+			return BuildProductConnectionFromSlice(products, toPageParams(first, after, last, before)), nil
 		}
 	}
 	return &model.ProductConnection{
@@ -73,15 +77,21 @@ func (r *queryResolver) Collection(ctx context.Context, by model.CollectionBy) (
 			return nil, err
 		}
 		c, err := r.service.GetCollectionByUID(ctx, uid)
-		if err != nil {
+		if errors.Is(err, datastore.ErrNotFound) {
 			return nil, nil
+		}
+		if err != nil {
+			return nil, fmt.Errorf("collection lookup by id: %w", err)
 		}
 		return DatastoreCollectionToGraphQL(c), nil
 	}
 	if by.NamespacePath != nil {
 		c, err := r.service.GetCollectionByName(ctx, by.NamespacePath.Namespace, by.NamespacePath.Name)
-		if err != nil {
+		if errors.Is(err, datastore.ErrNotFound) {
 			return nil, nil
+		}
+		if err != nil {
+			return nil, fmt.Errorf("collection lookup by name: %w", err)
 		}
 		return DatastoreCollectionToGraphQL(c), nil
 	}

--- a/gitstore-api/internal/graph/converters.go
+++ b/gitstore-api/internal/graph/converters.go
@@ -467,7 +467,7 @@ func collectionSpecFromJSON(raw json.RawMessage) *model.CollectionSpec {
 	var rs struct {
 		Title    string `json:"title"`
 		Selector *struct {
-			MatchLabels      []*struct{ Key, Value string } `json:"matchLabels"`
+			MatchLabels      map[string]string `json:"matchLabels"`
 			MatchExpressions []*struct {
 				Key      string   `json:"key"`
 				Operator string   `json:"operator"`
@@ -489,9 +489,8 @@ func collectionSpecFromJSON(raw json.RawMessage) *model.CollectionSpec {
 	spec := &model.CollectionSpec{Title: rs.Title, Media: []*model.MediaDefinition{}}
 	if rs.Selector != nil {
 		sel := &model.LabelSelector{}
-		for _, kv := range rs.Selector.MatchLabels {
-			kk, vv := kv.Key, kv.Value
-			sel.MatchLabels = append(sel.MatchLabels, &model.KeyValuePair{Key: kk, Value: vv})
+		for k, v := range rs.Selector.MatchLabels {
+			sel.MatchLabels = append(sel.MatchLabels, &model.KeyValuePair{Key: k, Value: v})
 		}
 		for _, e := range rs.Selector.MatchExpressions {
 			sel.MatchExpressions = append(sel.MatchExpressions, &model.LabelSelectorRequirement{
@@ -591,21 +590,6 @@ func specSelectorToCatalog(sel *struct {
 	return s
 }
 
-// BuildProductConnectionFromSlice builds a ProductConnection from a flat slice (no pagination).
-func BuildProductConnectionFromSlice(products []*datastore.Product) *model.ProductConnection {
-	edges := make([]*model.ProductEdge, len(products))
-	for i, p := range products {
-		edges[i] = &model.ProductEdge{
-			Cursor: mustEncodeNodeID(nodeKindProduct, p.UID),
-			Node:   DatastoreProductToGraphQL(p),
-		}
-	}
-	return &model.ProductConnection{
-		Edges:      edges,
-		PageInfo:   &model.PageInfo{},
-		TotalCount: int32(len(products)),
-	}
-}
 
 // DatastoreRepositoryToGraphQL converts a datastore Repository to the GraphQL model
 // without namespace (namespace is resolved separately via field resolver).

--- a/gitstore-api/internal/graph/converters.go
+++ b/gitstore-api/internal/graph/converters.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gitstore-dev/gitstore/api/internal/catalog"
 	"github.com/gitstore-dev/gitstore/api/internal/datastore"
 	"github.com/gitstore-dev/gitstore/api/internal/graph/model"
 	"go.uber.org/zap"
@@ -418,14 +419,191 @@ func DatastoreCollectionToGraphQL(c *datastore.Collection) *model.Collection {
 	if c == nil {
 		return nil
 	}
-	return &model.Collection{
-		ID:        mustEncodeNodeID(nodeKindCollection, c.ID),
-		Name:      c.Name,
-		Slug:      c.Slug,
-		Body:      &c.Body,
-		Products:  nil,
-		CreatedAt: c.CreatedAt,
-		UpdatedAt: c.UpdatedAt,
+	gen := int32(c.Generation)
+	meta := &model.CollectionObjectMeta{
+		Name:              c.Name,
+		UID:               mustEncodeNodeID(nodeKindCollection, c.UID),
+		ResourceVersion:   c.ResourceVersion,
+		Generation:        gen,
+		CreationTimestamp: c.CreationTimestamp,
+		Labels:            kvPairs(c.Labels),
+		Annotations:       kvPairs(c.Annotations),
+	}
+	if c.Namespace != "" {
+		ns := c.Namespace
+		meta.Namespace = &ns
+	}
+	if c.Revision != "" {
+		r := c.Revision
+		meta.Revision = &r
+	}
+	out := &model.Collection{
+		ID:       mustEncodeNodeID(nodeKindCollection, c.UID),
+		Metadata: meta,
+		Spec:     collectionSpecFromJSON(c.Spec),
+		Status:   collectionStatusFromJSON(c.Status),
+		Products: &model.ProductConnection{Edges: []*model.ProductEdge{}, PageInfo: &model.PageInfo{}},
+	}
+	if c.APIVersion != "" {
+		v := c.APIVersion
+		out.APIVersion = &v
+	}
+	if c.Kind != "" {
+		k := c.Kind
+		out.Kind = &k
+	}
+	if c.Body != "" {
+		out.Body = &c.Body
+	}
+	return out
+}
+
+// collectionSpecFromJSON deserialises a CollectionSpec blob.
+func collectionSpecFromJSON(raw json.RawMessage) *model.CollectionSpec {
+	empty := &model.CollectionSpec{Media: []*model.MediaDefinition{}}
+	if len(raw) == 0 {
+		return empty
+	}
+	var rs struct {
+		Title    string `json:"title"`
+		Selector *struct {
+			MatchLabels      []*struct{ Key, Value string } `json:"matchLabels"`
+			MatchExpressions []*struct {
+				Key      string   `json:"key"`
+				Operator string   `json:"operator"`
+				Values   []string `json:"values"`
+			} `json:"matchExpressions"`
+		} `json:"selector"`
+		Media []struct {
+			FileRef *struct {
+				Name     string `json:"name"`
+				Kind     string `json:"kind"`
+				Optional bool   `json:"optional"`
+			} `json:"fileRef"`
+		} `json:"media"`
+	}
+	if err := json.Unmarshal(raw, &rs); err != nil {
+		converterLogger.Warn("collection blob unmarshal error", zap.String("field", "spec"), zap.Error(err))
+		return empty
+	}
+	spec := &model.CollectionSpec{Title: rs.Title, Media: []*model.MediaDefinition{}}
+	if rs.Selector != nil {
+		sel := &model.LabelSelector{}
+		for _, kv := range rs.Selector.MatchLabels {
+			kk, vv := kv.Key, kv.Value
+			sel.MatchLabels = append(sel.MatchLabels, &model.KeyValuePair{Key: kk, Value: vv})
+		}
+		for _, e := range rs.Selector.MatchExpressions {
+			sel.MatchExpressions = append(sel.MatchExpressions, &model.LabelSelectorRequirement{
+				Key:      e.Key,
+				Operator: model.LabelSelectorOperator(e.Operator),
+				Values:   e.Values,
+			})
+		}
+		spec.Selector = sel
+	}
+	for _, m := range rs.Media {
+		if m.FileRef == nil {
+			continue
+		}
+		spec.Media = append(spec.Media, &model.MediaDefinition{
+			FileRef: &model.FileReference{
+				Name:     m.FileRef.Name,
+				Kind:     m.FileRef.Kind,
+				Optional: m.FileRef.Optional,
+			},
+		})
+	}
+	return spec
+}
+
+// collectionStatusFromJSON deserialises a CollectionStatus blob.
+func collectionStatusFromJSON(raw json.RawMessage) *model.CollectionStatus {
+	if len(raw) == 0 {
+		return nil
+	}
+	var rs struct {
+		ObservedGeneration  int32          `json:"observedGeneration"`
+		LastAppliedRevision string         `json:"lastAppliedRevision"`
+		Conditions          []rawCondition `json:"conditions"`
+		Resolved            *struct {
+			MemberCount int32 `json:"memberCount"`
+		} `json:"resolved"`
+	}
+	if err := json.Unmarshal(raw, &rs); err != nil {
+		converterLogger.Warn("collection blob unmarshal error", zap.String("field", "status"), zap.Error(err))
+		return nil
+	}
+	conditions := make([]*model.CollectionCondition, 0, len(rs.Conditions))
+	for _, c := range rs.Conditions {
+		cond := &model.CollectionCondition{
+			Type:   c.Type,
+			Status: c.Status,
+		}
+		gen := c.ObservedGeneration
+		cond.ObservedGeneration = &gen
+		if c.Reason != "" {
+			r := c.Reason
+			cond.Reason = &r
+		}
+		if c.Message != "" {
+			m := c.Message
+			cond.Message = &m
+		}
+		conditions = append(conditions, cond)
+	}
+	status := &model.CollectionStatus{
+		ObservedGeneration: rs.ObservedGeneration,
+		Conditions:         conditions,
+	}
+	if rs.LastAppliedRevision != "" {
+		s := rs.LastAppliedRevision
+		status.LastAppliedRevision = &s
+	}
+	if rs.Resolved != nil {
+		status.Resolved = &model.ResolvedCollectionDefinition{MemberCount: rs.Resolved.MemberCount}
+	}
+	return status
+}
+
+// jsonUnmarshal is a thin wrapper so resolver files can call it without importing encoding/json.
+func jsonUnmarshal(data json.RawMessage, v any) error {
+	return json.Unmarshal(data, v)
+}
+
+// specSelectorToCatalog converts an inline spec selector struct to catalog.LabelSelector.
+func specSelectorToCatalog(sel *struct {
+	MatchLabels      map[string]string `json:"matchLabels"`
+	MatchExpressions []struct {
+		Key      string   `json:"key"`
+		Operator string   `json:"operator"`
+		Values   []string `json:"values"`
+	} `json:"matchExpressions"`
+}) catalog.LabelSelector {
+	s := catalog.LabelSelector{MatchLabels: sel.MatchLabels}
+	for _, e := range sel.MatchExpressions {
+		s.MatchExpressions = append(s.MatchExpressions, catalog.LabelSelectorRequirement{
+			Key:      e.Key,
+			Operator: e.Operator,
+			Values:   e.Values,
+		})
+	}
+	return s
+}
+
+// BuildProductConnectionFromSlice builds a ProductConnection from a flat slice (no pagination).
+func BuildProductConnectionFromSlice(products []*datastore.Product) *model.ProductConnection {
+	edges := make([]*model.ProductEdge, len(products))
+	for i, p := range products {
+		edges[i] = &model.ProductEdge{
+			Cursor: mustEncodeNodeID(nodeKindProduct, p.UID),
+			Node:   DatastoreProductToGraphQL(p),
+		}
+	}
+	return &model.ProductConnection{
+		Edges:      edges,
+		PageInfo:   &model.PageInfo{},
+		TotalCount: int32(len(products)),
 	}
 }
 

--- a/gitstore-api/internal/graph/converters.go
+++ b/gitstore-api/internal/graph/converters.go
@@ -590,7 +590,6 @@ func specSelectorToCatalog(sel *struct {
 	return s
 }
 
-
 // DatastoreRepositoryToGraphQL converts a datastore Repository to the GraphQL model
 // without namespace (namespace is resolved separately via field resolver).
 func DatastoreRepositoryToGraphQL(r *datastore.Repository) *model.Repository {

--- a/gitstore-api/internal/graph/generated/collection.generated.go
+++ b/gitstore-api/internal/graph/generated/collection.generated.go
@@ -310,73 +310,169 @@ func (ec *executionContext) fieldContext_Collection_id(_ context.Context, field 
 	return graphql.NewScalarFieldContext("Collection", field, false, false, errors.New("field of type ID does not have child fields"))
 }
 
-func (ec *executionContext) _Collection_name(ctx context.Context, field graphql.CollectedField, obj *model.Collection) (ret graphql.Marshaler) {
+func (ec *executionContext) _Collection_apiVersion(ctx context.Context, field graphql.CollectedField, obj *model.Collection) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
 		field,
 		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_Collection_name(ctx, field)
+			return ec.fieldContext_Collection_apiVersion(ctx, field)
 		},
 		func(ctx context.Context) (any, error) {
-			return obj.Name, nil
+			return obj.APIVersion, nil
 		},
 		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
-			return ec.marshalNString2string(ctx, selections, v)
+		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
+			return ec.marshalOString2ᚖstring(ctx, selections, v)
 		},
 		true,
-		true,
+		false,
 	)
 }
-func (ec *executionContext) fieldContext_Collection_name(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Collection_apiVersion(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	return graphql.NewScalarFieldContext("Collection", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
-func (ec *executionContext) _Collection_slug(ctx context.Context, field graphql.CollectedField, obj *model.Collection) (ret graphql.Marshaler) {
+func (ec *executionContext) _Collection_kind(ctx context.Context, field graphql.CollectedField, obj *model.Collection) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
 		field,
 		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_Collection_slug(ctx, field)
+			return ec.fieldContext_Collection_kind(ctx, field)
 		},
 		func(ctx context.Context) (any, error) {
-			return obj.Slug, nil
+			return obj.Kind, nil
 		},
 		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
-			return ec.marshalNString2string(ctx, selections, v)
+		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
+			return ec.marshalOString2ᚖstring(ctx, selections, v)
 		},
 		true,
-		true,
+		false,
 	)
 }
-func (ec *executionContext) fieldContext_Collection_slug(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Collection_kind(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	return graphql.NewScalarFieldContext("Collection", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
-func (ec *executionContext) _Collection_displayOrder(ctx context.Context, field graphql.CollectedField, obj *model.Collection) (ret graphql.Marshaler) {
+func (ec *executionContext) _Collection_metadata(ctx context.Context, field graphql.CollectedField, obj *model.Collection) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
 		field,
 		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_Collection_displayOrder(ctx, field)
+			return ec.fieldContext_Collection_metadata(ctx, field)
 		},
 		func(ctx context.Context) (any, error) {
-			return obj.DisplayOrder, nil
+			return obj.Metadata, nil
 		},
 		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v int32) graphql.Marshaler {
-			return ec.marshalNInt2int32(ctx, selections, v)
+		func(ctx context.Context, selections ast.SelectionSet, v *model.CollectionObjectMeta) graphql.Marshaler {
+			return ec.marshalNCollectionObjectMeta2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐCollectionObjectMeta(ctx, selections, v)
 		},
 		true,
 		true,
 	)
 }
-func (ec *executionContext) fieldContext_Collection_displayOrder(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("Collection", field, false, false, errors.New("field of type Int does not have child fields"))
+func (ec *executionContext) fieldContext_Collection_metadata(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Collection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_CollectionObjectMeta(ctx, field)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Collection_spec(ctx context.Context, field graphql.CollectedField, obj *model.Collection) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Collection_spec(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Spec, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *model.CollectionSpec) graphql.Marshaler {
+			return ec.marshalNCollectionSpec2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐCollectionSpec(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Collection_spec(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Collection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_CollectionSpec(ctx, field)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Collection_status(ctx context.Context, field graphql.CollectedField, obj *model.Collection) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Collection_status(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Status, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *model.CollectionStatus) graphql.Marshaler {
+			return ec.marshalOCollectionStatus2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐCollectionStatus(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_Collection_status(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Collection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_CollectionStatus(ctx, field)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Collection_body(ctx context.Context, field graphql.CollectedField, obj *model.Collection) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Collection_body(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Body, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
+			return ec.marshalOString2ᚖstring(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_Collection_body(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("Collection", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
 func (ec *executionContext) _Collection_products(ctx context.Context, field graphql.CollectedField, obj *model.Collection) (ret graphql.Marshaler) {
@@ -423,16 +519,85 @@ func (ec *executionContext) fieldContext_Collection_products(ctx context.Context
 	return fc, nil
 }
 
-func (ec *executionContext) _Collection_body(ctx context.Context, field graphql.CollectedField, obj *model.Collection) (ret graphql.Marshaler) {
+func (ec *executionContext) _CollectionCondition_type(ctx context.Context, field graphql.CollectedField, obj *model.CollectionCondition) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
 		field,
 		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_Collection_body(ctx, field)
+			return ec.fieldContext_CollectionCondition_type(ctx, field)
 		},
 		func(ctx context.Context) (any, error) {
-			return obj.Body, nil
+			return obj.Type, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNString2string(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_CollectionCondition_type(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("CollectionCondition", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _CollectionCondition_status(ctx context.Context, field graphql.CollectedField, obj *model.CollectionCondition) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_CollectionCondition_status(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Status, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNString2string(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_CollectionCondition_status(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("CollectionCondition", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _CollectionCondition_observedGeneration(ctx context.Context, field graphql.CollectedField, obj *model.CollectionCondition) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_CollectionCondition_observedGeneration(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.ObservedGeneration, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *int32) graphql.Marshaler {
+			return ec.marshalOInt2ᚖint32(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_CollectionCondition_observedGeneration(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("CollectionCondition", field, false, false, errors.New("field of type Int does not have child fields"))
+}
+
+func (ec *executionContext) _CollectionCondition_reason(ctx context.Context, field graphql.CollectedField, obj *model.CollectionCondition) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_CollectionCondition_reason(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Reason, nil
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
@@ -442,77 +607,31 @@ func (ec *executionContext) _Collection_body(ctx context.Context, field graphql.
 		false,
 	)
 }
-func (ec *executionContext) fieldContext_Collection_body(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("Collection", field, false, false, errors.New("field of type String does not have child fields"))
+func (ec *executionContext) fieldContext_CollectionCondition_reason(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("CollectionCondition", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
-func (ec *executionContext) _Collection_createdAt(ctx context.Context, field graphql.CollectedField, obj *model.Collection) (ret graphql.Marshaler) {
+func (ec *executionContext) _CollectionCondition_message(ctx context.Context, field graphql.CollectedField, obj *model.CollectionCondition) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
 		field,
 		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_Collection_createdAt(ctx, field)
+			return ec.fieldContext_CollectionCondition_message(ctx, field)
 		},
 		func(ctx context.Context) (any, error) {
-			return obj.CreatedAt, nil
+			return obj.Message, nil
 		},
 		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v time.Time) graphql.Marshaler {
-			return ec.marshalNDateTime2timeᚐTime(ctx, selections, v)
+		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
+			return ec.marshalOString2ᚖstring(ctx, selections, v)
 		},
 		true,
-		true,
+		false,
 	)
 }
-func (ec *executionContext) fieldContext_Collection_createdAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("Collection", field, false, false, errors.New("field of type DateTime does not have child fields"))
-}
-
-func (ec *executionContext) _Collection_updatedAt(ctx context.Context, field graphql.CollectedField, obj *model.Collection) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_Collection_updatedAt(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return obj.UpdatedAt, nil
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v time.Time) graphql.Marshaler {
-			return ec.marshalNDateTime2timeᚐTime(ctx, selections, v)
-		},
-		true,
-		true,
-	)
-}
-func (ec *executionContext) fieldContext_Collection_updatedAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("Collection", field, false, false, errors.New("field of type DateTime does not have child fields"))
-}
-
-func (ec *executionContext) _Collection_productCount(ctx context.Context, field graphql.CollectedField, obj *model.Collection) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_Collection_productCount(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return obj.ProductCount, nil
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v int32) graphql.Marshaler {
-			return ec.marshalNInt2int32(ctx, selections, v)
-		},
-		true,
-		true,
-	)
-}
-func (ec *executionContext) fieldContext_Collection_productCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("Collection", field, false, false, errors.New("field of type Int does not have child fields"))
+func (ec *executionContext) fieldContext_CollectionCondition_message(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("CollectionCondition", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
 func (ec *executionContext) _CollectionConnection_edges(ctx context.Context, field graphql.CollectedField, obj *model.CollectionConnection) (ret graphql.Marshaler) {
@@ -657,39 +776,131 @@ func (ec *executionContext) fieldContext_CollectionEdge_node(_ context.Context, 
 	return fc, nil
 }
 
-func (ec *executionContext) _CollectionOptimisticLockConflict_currentVersion(ctx context.Context, field graphql.CollectedField, obj *model.CollectionOptimisticLockConflict) (ret graphql.Marshaler) {
+func (ec *executionContext) _CollectionObjectMeta_name(ctx context.Context, field graphql.CollectedField, obj *model.CollectionObjectMeta) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
 		field,
 		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_CollectionOptimisticLockConflict_currentVersion(ctx, field)
+			return ec.fieldContext_CollectionObjectMeta_name(ctx, field)
 		},
 		func(ctx context.Context) (any, error) {
-			return obj.CurrentVersion, nil
+			return obj.Name, nil
 		},
 		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v time.Time) graphql.Marshaler {
-			return ec.marshalNDateTime2timeᚐTime(ctx, selections, v)
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNString2string(ctx, selections, v)
 		},
 		true,
 		true,
 	)
 }
-func (ec *executionContext) fieldContext_CollectionOptimisticLockConflict_currentVersion(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("CollectionOptimisticLockConflict", field, false, false, errors.New("field of type DateTime does not have child fields"))
+func (ec *executionContext) fieldContext_CollectionObjectMeta_name(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("CollectionObjectMeta", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
-func (ec *executionContext) _CollectionOptimisticLockConflict_attemptedVersion(ctx context.Context, field graphql.CollectedField, obj *model.CollectionOptimisticLockConflict) (ret graphql.Marshaler) {
+func (ec *executionContext) _CollectionObjectMeta_namespace(ctx context.Context, field graphql.CollectedField, obj *model.CollectionObjectMeta) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
 		field,
 		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_CollectionOptimisticLockConflict_attemptedVersion(ctx, field)
+			return ec.fieldContext_CollectionObjectMeta_namespace(ctx, field)
 		},
 		func(ctx context.Context) (any, error) {
-			return obj.AttemptedVersion, nil
+			return obj.Namespace, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
+			return ec.marshalOString2ᚖstring(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_CollectionObjectMeta_namespace(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("CollectionObjectMeta", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _CollectionObjectMeta_uid(ctx context.Context, field graphql.CollectedField, obj *model.CollectionObjectMeta) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_CollectionObjectMeta_uid(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.UID, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNID2string(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_CollectionObjectMeta_uid(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("CollectionObjectMeta", field, false, false, errors.New("field of type ID does not have child fields"))
+}
+
+func (ec *executionContext) _CollectionObjectMeta_resourceVersion(ctx context.Context, field graphql.CollectedField, obj *model.CollectionObjectMeta) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_CollectionObjectMeta_resourceVersion(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.ResourceVersion, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNString2string(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_CollectionObjectMeta_resourceVersion(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("CollectionObjectMeta", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _CollectionObjectMeta_generation(ctx context.Context, field graphql.CollectedField, obj *model.CollectionObjectMeta) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_CollectionObjectMeta_generation(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Generation, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v int32) graphql.Marshaler {
+			return ec.marshalNInt2int32(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_CollectionObjectMeta_generation(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("CollectionObjectMeta", field, false, false, errors.New("field of type Int does not have child fields"))
+}
+
+func (ec *executionContext) _CollectionObjectMeta_creationTimestamp(ctx context.Context, field graphql.CollectedField, obj *model.CollectionObjectMeta) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_CollectionObjectMeta_creationTimestamp(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.CreationTimestamp, nil
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v time.Time) graphql.Marshaler {
@@ -699,8 +910,95 @@ func (ec *executionContext) _CollectionOptimisticLockConflict_attemptedVersion(c
 		true,
 	)
 }
-func (ec *executionContext) fieldContext_CollectionOptimisticLockConflict_attemptedVersion(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("CollectionOptimisticLockConflict", field, false, false, errors.New("field of type DateTime does not have child fields"))
+func (ec *executionContext) fieldContext_CollectionObjectMeta_creationTimestamp(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("CollectionObjectMeta", field, false, false, errors.New("field of type DateTime does not have child fields"))
+}
+
+func (ec *executionContext) _CollectionObjectMeta_revision(ctx context.Context, field graphql.CollectedField, obj *model.CollectionObjectMeta) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_CollectionObjectMeta_revision(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Revision, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
+			return ec.marshalOString2ᚖstring(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_CollectionObjectMeta_revision(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("CollectionObjectMeta", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _CollectionObjectMeta_labels(ctx context.Context, field graphql.CollectedField, obj *model.CollectionObjectMeta) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_CollectionObjectMeta_labels(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Labels, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v []*model.KeyValuePair) graphql.Marshaler {
+			return ec.marshalNKeyValuePair2ᚕᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐKeyValuePairᚄ(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_CollectionObjectMeta_labels(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CollectionObjectMeta",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_KeyValuePair(ctx, field)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CollectionObjectMeta_annotations(ctx context.Context, field graphql.CollectedField, obj *model.CollectionObjectMeta) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_CollectionObjectMeta_annotations(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Annotations, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v []*model.KeyValuePair) graphql.Marshaler {
+			return ec.marshalNKeyValuePair2ᚕᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐKeyValuePairᚄ(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_CollectionObjectMeta_annotations(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CollectionObjectMeta",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_KeyValuePair(ctx, field)
+		},
+	}
+	return fc, nil
 }
 
 func (ec *executionContext) _CollectionOptimisticLockConflict_current(ctx context.Context, field graphql.CollectedField, obj *model.CollectionOptimisticLockConflict) (ret graphql.Marshaler) {
@@ -735,16 +1033,16 @@ func (ec *executionContext) fieldContext_CollectionOptimisticLockConflict_curren
 	return fc, nil
 }
 
-func (ec *executionContext) _CollectionOptimisticLockConflict_diff(ctx context.Context, field graphql.CollectedField, obj *model.CollectionOptimisticLockConflict) (ret graphql.Marshaler) {
+func (ec *executionContext) _CollectionSpec_title(ctx context.Context, field graphql.CollectedField, obj *model.CollectionSpec) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
 		field,
 		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_CollectionOptimisticLockConflict_diff(ctx, field)
+			return ec.fieldContext_CollectionSpec_title(ctx, field)
 		},
 		func(ctx context.Context) (any, error) {
-			return obj.Diff, nil
+			return obj.Title, nil
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
@@ -754,20 +1052,107 @@ func (ec *executionContext) _CollectionOptimisticLockConflict_diff(ctx context.C
 		true,
 	)
 }
-func (ec *executionContext) fieldContext_CollectionOptimisticLockConflict_diff(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("CollectionOptimisticLockConflict", field, false, false, errors.New("field of type String does not have child fields"))
+func (ec *executionContext) fieldContext_CollectionSpec_title(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("CollectionSpec", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
-func (ec *executionContext) _CreateCollectionPayload_clientMutationId(ctx context.Context, field graphql.CollectedField, obj *model.CreateCollectionPayload) (ret graphql.Marshaler) {
+func (ec *executionContext) _CollectionSpec_selector(ctx context.Context, field graphql.CollectedField, obj *model.CollectionSpec) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
 		field,
 		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_CreateCollectionPayload_clientMutationId(ctx, field)
+			return ec.fieldContext_CollectionSpec_selector(ctx, field)
 		},
 		func(ctx context.Context) (any, error) {
-			return obj.ClientMutationID, nil
+			return obj.Selector, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *model.LabelSelector) graphql.Marshaler {
+			return ec.marshalOLabelSelector2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐLabelSelector(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_CollectionSpec_selector(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CollectionSpec",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_LabelSelector(ctx, field)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CollectionSpec_media(ctx context.Context, field graphql.CollectedField, obj *model.CollectionSpec) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_CollectionSpec_media(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Media, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v []*model.MediaDefinition) graphql.Marshaler {
+			return ec.marshalNMediaDefinition2ᚕᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐMediaDefinitionᚄ(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_CollectionSpec_media(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CollectionSpec",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_MediaDefinition(ctx, field)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CollectionStatus_observedGeneration(ctx context.Context, field graphql.CollectedField, obj *model.CollectionStatus) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_CollectionStatus_observedGeneration(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.ObservedGeneration, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v int32) graphql.Marshaler {
+			return ec.marshalNInt2int32(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_CollectionStatus_observedGeneration(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("CollectionStatus", field, false, false, errors.New("field of type Int does not have child fields"))
+}
+
+func (ec *executionContext) _CollectionStatus_lastAppliedRevision(ctx context.Context, field graphql.CollectedField, obj *model.CollectionStatus) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_CollectionStatus_lastAppliedRevision(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.LastAppliedRevision, nil
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
@@ -777,8 +1162,72 @@ func (ec *executionContext) _CreateCollectionPayload_clientMutationId(ctx contex
 		false,
 	)
 }
-func (ec *executionContext) fieldContext_CreateCollectionPayload_clientMutationId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("CreateCollectionPayload", field, false, false, errors.New("field of type String does not have child fields"))
+func (ec *executionContext) fieldContext_CollectionStatus_lastAppliedRevision(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("CollectionStatus", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _CollectionStatus_conditions(ctx context.Context, field graphql.CollectedField, obj *model.CollectionStatus) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_CollectionStatus_conditions(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Conditions, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v []*model.CollectionCondition) graphql.Marshaler {
+			return ec.marshalNCollectionCondition2ᚕᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐCollectionConditionᚄ(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_CollectionStatus_conditions(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CollectionStatus",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_CollectionCondition(ctx, field)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CollectionStatus_resolved(ctx context.Context, field graphql.CollectedField, obj *model.CollectionStatus) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_CollectionStatus_resolved(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Resolved, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *model.ResolvedCollectionDefinition) graphql.Marshaler {
+			return ec.marshalOResolvedCollectionDefinition2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐResolvedCollectionDefinition(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_CollectionStatus_resolved(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CollectionStatus",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_ResolvedCollectionDefinition(ctx, field)
+		},
+	}
+	return fc, nil
 }
 
 func (ec *executionContext) _CreateCollectionPayload_collection(ctx context.Context, field graphql.CollectedField, obj *model.CreateCollectionPayload) (ret graphql.Marshaler) {
@@ -813,29 +1262,6 @@ func (ec *executionContext) fieldContext_CreateCollectionPayload_collection(_ co
 	return fc, nil
 }
 
-func (ec *executionContext) _DeleteCollectionPayload_clientMutationId(ctx context.Context, field graphql.CollectedField, obj *model.DeleteCollectionPayload) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_DeleteCollectionPayload_clientMutationId(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return obj.ClientMutationID, nil
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
-			return ec.marshalOString2ᚖstring(ctx, selections, v)
-		},
-		true,
-		false,
-	)
-}
-func (ec *executionContext) fieldContext_DeleteCollectionPayload_clientMutationId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("DeleteCollectionPayload", field, false, false, errors.New("field of type String does not have child fields"))
-}
-
 func (ec *executionContext) _DeleteCollectionPayload_deletedCollectionId(ctx context.Context, field graphql.CollectedField, obj *model.DeleteCollectionPayload) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -857,6 +1283,139 @@ func (ec *executionContext) _DeleteCollectionPayload_deletedCollectionId(ctx con
 }
 func (ec *executionContext) fieldContext_DeleteCollectionPayload_deletedCollectionId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	return graphql.NewScalarFieldContext("DeleteCollectionPayload", field, false, false, errors.New("field of type ID does not have child fields"))
+}
+
+func (ec *executionContext) _LabelSelector_matchLabels(ctx context.Context, field graphql.CollectedField, obj *model.LabelSelector) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_LabelSelector_matchLabels(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.MatchLabels, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v []*model.KeyValuePair) graphql.Marshaler {
+			return ec.marshalNKeyValuePair2ᚕᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐKeyValuePairᚄ(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_LabelSelector_matchLabels(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "LabelSelector",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_KeyValuePair(ctx, field)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _LabelSelector_matchExpressions(ctx context.Context, field graphql.CollectedField, obj *model.LabelSelector) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_LabelSelector_matchExpressions(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.MatchExpressions, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v []*model.LabelSelectorRequirement) graphql.Marshaler {
+			return ec.marshalNLabelSelectorRequirement2ᚕᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐLabelSelectorRequirementᚄ(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_LabelSelector_matchExpressions(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "LabelSelector",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_LabelSelectorRequirement(ctx, field)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _LabelSelectorRequirement_key(ctx context.Context, field graphql.CollectedField, obj *model.LabelSelectorRequirement) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_LabelSelectorRequirement_key(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Key, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNString2string(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_LabelSelectorRequirement_key(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("LabelSelectorRequirement", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _LabelSelectorRequirement_operator(ctx context.Context, field graphql.CollectedField, obj *model.LabelSelectorRequirement) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_LabelSelectorRequirement_operator(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Operator, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v model.LabelSelectorOperator) graphql.Marshaler {
+			return ec.marshalNLabelSelectorOperator2githubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐLabelSelectorOperator(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_LabelSelectorRequirement_operator(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("LabelSelectorRequirement", field, false, false, errors.New("field of type LabelSelectorOperator does not have child fields"))
+}
+
+func (ec *executionContext) _LabelSelectorRequirement_values(ctx context.Context, field graphql.CollectedField, obj *model.LabelSelectorRequirement) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_LabelSelectorRequirement_values(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Values, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v []string) graphql.Marshaler {
+			return ec.marshalNString2ᚕstringᚄ(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_LabelSelectorRequirement_values(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("LabelSelectorRequirement", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
 func (ec *executionContext) _PublishCatalogPayload_clientMutationId(ctx context.Context, field graphql.CollectedField, obj *model.PublishCatalogPayload) (ret graphql.Marshaler) {
@@ -914,82 +1473,27 @@ func (ec *executionContext) fieldContext_PublishCatalogPayload_catalogVersion(_ 
 	return fc, nil
 }
 
-func (ec *executionContext) _ReorderCollectionsPayload_clientMutationId(ctx context.Context, field graphql.CollectedField, obj *model.ReorderCollectionsPayload) (ret graphql.Marshaler) {
+func (ec *executionContext) _ResolvedCollectionDefinition_memberCount(ctx context.Context, field graphql.CollectedField, obj *model.ResolvedCollectionDefinition) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
 		field,
 		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_ReorderCollectionsPayload_clientMutationId(ctx, field)
+			return ec.fieldContext_ResolvedCollectionDefinition_memberCount(ctx, field)
 		},
 		func(ctx context.Context) (any, error) {
-			return obj.ClientMutationID, nil
+			return obj.MemberCount, nil
 		},
 		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
-			return ec.marshalOString2ᚖstring(ctx, selections, v)
+		func(ctx context.Context, selections ast.SelectionSet, v int32) graphql.Marshaler {
+			return ec.marshalNInt2int32(ctx, selections, v)
 		},
 		true,
-		false,
-	)
-}
-func (ec *executionContext) fieldContext_ReorderCollectionsPayload_clientMutationId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("ReorderCollectionsPayload", field, false, false, errors.New("field of type String does not have child fields"))
-}
-
-func (ec *executionContext) _ReorderCollectionsPayload_collections(ctx context.Context, field graphql.CollectedField, obj *model.ReorderCollectionsPayload) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_ReorderCollectionsPayload_collections(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return obj.Collections, nil
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v []*model.Collection) graphql.Marshaler {
-			return ec.marshalOCollection2ᚕᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐCollectionᚄ(ctx, selections, v)
-		},
 		true,
-		false,
 	)
 }
-func (ec *executionContext) fieldContext_ReorderCollectionsPayload_collections(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "ReorderCollectionsPayload",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.childFields_Collection(ctx, field)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _UpdateCollectionPayload_clientMutationId(ctx context.Context, field graphql.CollectedField, obj *model.UpdateCollectionPayload) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_UpdateCollectionPayload_clientMutationId(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return obj.ClientMutationID, nil
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
-			return ec.marshalOString2ᚖstring(ctx, selections, v)
-		},
-		true,
-		false,
-	)
-}
-func (ec *executionContext) fieldContext_UpdateCollectionPayload_clientMutationId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("UpdateCollectionPayload", field, false, false, errors.New("field of type String does not have child fields"))
+func (ec *executionContext) fieldContext_ResolvedCollectionDefinition_memberCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("ResolvedCollectionDefinition", field, false, false, errors.New("field of type Int does not have child fields"))
 }
 
 func (ec *executionContext) _UpdateCollectionPayload_collection(ctx context.Context, field graphql.CollectedField, obj *model.UpdateCollectionPayload) (ret graphql.Marshaler) {
@@ -1071,20 +1575,13 @@ func (ec *executionContext) unmarshalInputCreateCollectionInput(ctx context.Cont
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"clientMutationId", "name", "slug", "displayOrder", "productIds", "body"}
+	fieldsInOrder := [...]string{"name"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "clientMutationId":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("clientMutationId"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.ClientMutationID = data
 		case "name":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
 			data, err := ec.unmarshalNString2string(ctx, v)
@@ -1092,34 +1589,6 @@ func (ec *executionContext) unmarshalInputCreateCollectionInput(ctx context.Cont
 				return it, err
 			}
 			it.Name = data
-		case "slug":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("slug"))
-			data, err := ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Slug = data
-		case "displayOrder":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("displayOrder"))
-			data, err := ec.unmarshalOInt2ᚖint32(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.DisplayOrder = data
-		case "productIds":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("productIds"))
-			data, err := ec.unmarshalOID2ᚕstringᚄ(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.ProductIds = data
-		case "body":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("body"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Body = data
 		}
 	}
 	return it, nil
@@ -1136,20 +1605,13 @@ func (ec *executionContext) unmarshalInputDeleteCollectionInput(ctx context.Cont
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"clientMutationId", "id"}
+	fieldsInOrder := [...]string{"id"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "clientMutationId":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("clientMutationId"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.ClientMutationID = data
 		case "id":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
 			data, err := ec.unmarshalNID2string(ctx, v)
@@ -1206,43 +1668,6 @@ func (ec *executionContext) unmarshalInputPublishCatalogInput(ctx context.Contex
 	return it, nil
 }
 
-func (ec *executionContext) unmarshalInputReorderCollectionsInput(ctx context.Context, obj any) (model.ReorderCollectionsInput, error) {
-	var it model.ReorderCollectionsInput
-	if obj == nil {
-		return it, nil
-	}
-
-	asMap := map[string]any{}
-	for k, v := range obj.(map[string]any) {
-		asMap[k] = v
-	}
-
-	fieldsInOrder := [...]string{"clientMutationId", "orderedIds"}
-	for _, k := range fieldsInOrder {
-		v, ok := asMap[k]
-		if !ok {
-			continue
-		}
-		switch k {
-		case "clientMutationId":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("clientMutationId"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.ClientMutationID = data
-		case "orderedIds":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("orderedIds"))
-			data, err := ec.unmarshalNID2ᚕstringᚄ(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.OrderedIds = data
-		}
-	}
-	return it, nil
-}
-
 func (ec *executionContext) unmarshalInputUpdateCollectionInput(ctx context.Context, obj any) (model.UpdateCollectionInput, error) {
 	var it model.UpdateCollectionInput
 	if obj == nil {
@@ -1254,20 +1679,13 @@ func (ec *executionContext) unmarshalInputUpdateCollectionInput(ctx context.Cont
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"clientMutationId", "id", "name", "slug", "displayOrder", "productIds", "body", "version"}
+	fieldsInOrder := [...]string{"id"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "clientMutationId":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("clientMutationId"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.ClientMutationID = data
 		case "id":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
 			data, err := ec.unmarshalNID2string(ctx, v)
@@ -1275,48 +1693,6 @@ func (ec *executionContext) unmarshalInputUpdateCollectionInput(ctx context.Cont
 				return it, err
 			}
 			it.ID = data
-		case "name":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Name = data
-		case "slug":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("slug"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Slug = data
-		case "displayOrder":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("displayOrder"))
-			data, err := ec.unmarshalOInt2ᚖint32(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.DisplayOrder = data
-		case "productIds":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("productIds"))
-			data, err := ec.unmarshalOID2ᚕstringᚄ(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.ProductIds = data
-		case "body":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("body"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Body = data
-		case "version":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("version"))
-			data, err := ec.unmarshalNDateTime2timeᚐTime(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Version = data
 		}
 	}
 	return it, nil
@@ -1456,21 +1832,24 @@ func (ec *executionContext) _Collection(ctx context.Context, sel ast.SelectionSe
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
-		case "name":
-			out.Values[i] = ec._Collection_name(ctx, field, obj)
+		case "apiVersion":
+			out.Values[i] = ec._Collection_apiVersion(ctx, field, obj)
+		case "kind":
+			out.Values[i] = ec._Collection_kind(ctx, field, obj)
+		case "metadata":
+			out.Values[i] = ec._Collection_metadata(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
-		case "slug":
-			out.Values[i] = ec._Collection_slug(ctx, field, obj)
+		case "spec":
+			out.Values[i] = ec._Collection_spec(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
-		case "displayOrder":
-			out.Values[i] = ec._Collection_displayOrder(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
+		case "status":
+			out.Values[i] = ec._Collection_status(ctx, field, obj)
+		case "body":
+			out.Values[i] = ec._Collection_body(ctx, field, obj)
 		case "products":
 			field := field
 
@@ -1507,23 +1886,56 @@ func (ec *executionContext) _Collection(ctx context.Context, sel ast.SelectionSe
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-		case "body":
-			out.Values[i] = ec._Collection_body(ctx, field, obj)
-		case "createdAt":
-			out.Values[i] = ec._Collection_createdAt(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(min(len(deferred), math.MaxInt32)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var collectionConditionImplementors = []string{"CollectionCondition"}
+
+func (ec *executionContext) _CollectionCondition(ctx context.Context, sel ast.SelectionSet, obj *model.CollectionCondition) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, collectionConditionImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CollectionCondition")
+		case "type":
+			out.Values[i] = ec._CollectionCondition_type(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
+				out.Invalids++
 			}
-		case "updatedAt":
-			out.Values[i] = ec._Collection_updatedAt(ctx, field, obj)
+		case "status":
+			out.Values[i] = ec._CollectionCondition_status(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
+				out.Invalids++
 			}
-		case "productCount":
-			out.Values[i] = ec._Collection_productCount(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
+		case "observedGeneration":
+			out.Values[i] = ec._CollectionCondition_observedGeneration(ctx, field, obj)
+		case "reason":
+			out.Values[i] = ec._CollectionCondition_reason(ctx, field, obj)
+		case "message":
+			out.Values[i] = ec._CollectionCondition_message(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -1640,6 +2052,79 @@ func (ec *executionContext) _CollectionEdge(ctx context.Context, sel ast.Selecti
 	return out
 }
 
+var collectionObjectMetaImplementors = []string{"CollectionObjectMeta"}
+
+func (ec *executionContext) _CollectionObjectMeta(ctx context.Context, sel ast.SelectionSet, obj *model.CollectionObjectMeta) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, collectionObjectMetaImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CollectionObjectMeta")
+		case "name":
+			out.Values[i] = ec._CollectionObjectMeta_name(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "namespace":
+			out.Values[i] = ec._CollectionObjectMeta_namespace(ctx, field, obj)
+		case "uid":
+			out.Values[i] = ec._CollectionObjectMeta_uid(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "resourceVersion":
+			out.Values[i] = ec._CollectionObjectMeta_resourceVersion(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "generation":
+			out.Values[i] = ec._CollectionObjectMeta_generation(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "creationTimestamp":
+			out.Values[i] = ec._CollectionObjectMeta_creationTimestamp(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "revision":
+			out.Values[i] = ec._CollectionObjectMeta_revision(ctx, field, obj)
+		case "labels":
+			out.Values[i] = ec._CollectionObjectMeta_labels(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "annotations":
+			out.Values[i] = ec._CollectionObjectMeta_annotations(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(min(len(deferred), math.MaxInt32)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var collectionOptimisticLockConflictImplementors = []string{"CollectionOptimisticLockConflict"}
 
 func (ec *executionContext) _CollectionOptimisticLockConflict(ctx context.Context, sel ast.SelectionSet, obj *model.CollectionOptimisticLockConflict) graphql.Marshaler {
@@ -1651,26 +2136,105 @@ func (ec *executionContext) _CollectionOptimisticLockConflict(ctx context.Contex
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("CollectionOptimisticLockConflict")
-		case "currentVersion":
-			out.Values[i] = ec._CollectionOptimisticLockConflict_currentVersion(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "attemptedVersion":
-			out.Values[i] = ec._CollectionOptimisticLockConflict_attemptedVersion(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		case "current":
 			out.Values[i] = ec._CollectionOptimisticLockConflict_current(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "diff":
-			out.Values[i] = ec._CollectionOptimisticLockConflict_diff(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(min(len(deferred), math.MaxInt32)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var collectionSpecImplementors = []string{"CollectionSpec"}
+
+func (ec *executionContext) _CollectionSpec(ctx context.Context, sel ast.SelectionSet, obj *model.CollectionSpec) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, collectionSpecImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CollectionSpec")
+		case "title":
+			out.Values[i] = ec._CollectionSpec_title(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "selector":
+			out.Values[i] = ec._CollectionSpec_selector(ctx, field, obj)
+		case "media":
+			out.Values[i] = ec._CollectionSpec_media(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(min(len(deferred), math.MaxInt32)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var collectionStatusImplementors = []string{"CollectionStatus"}
+
+func (ec *executionContext) _CollectionStatus(ctx context.Context, sel ast.SelectionSet, obj *model.CollectionStatus) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, collectionStatusImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CollectionStatus")
+		case "observedGeneration":
+			out.Values[i] = ec._CollectionStatus_observedGeneration(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "lastAppliedRevision":
+			out.Values[i] = ec._CollectionStatus_lastAppliedRevision(ctx, field, obj)
+		case "conditions":
+			out.Values[i] = ec._CollectionStatus_conditions(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "resolved":
+			out.Values[i] = ec._CollectionStatus_resolved(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -1705,8 +2269,6 @@ func (ec *executionContext) _CreateCollectionPayload(ctx context.Context, sel as
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("CreateCollectionPayload")
-		case "clientMutationId":
-			out.Values[i] = ec._CreateCollectionPayload_clientMutationId(ctx, field, obj)
 		case "collection":
 			out.Values[i] = ec._CreateCollectionPayload_collection(ctx, field, obj)
 		default:
@@ -1743,10 +2305,101 @@ func (ec *executionContext) _DeleteCollectionPayload(ctx context.Context, sel as
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("DeleteCollectionPayload")
-		case "clientMutationId":
-			out.Values[i] = ec._DeleteCollectionPayload_clientMutationId(ctx, field, obj)
 		case "deletedCollectionId":
 			out.Values[i] = ec._DeleteCollectionPayload_deletedCollectionId(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(min(len(deferred), math.MaxInt32)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var labelSelectorImplementors = []string{"LabelSelector"}
+
+func (ec *executionContext) _LabelSelector(ctx context.Context, sel ast.SelectionSet, obj *model.LabelSelector) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, labelSelectorImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("LabelSelector")
+		case "matchLabels":
+			out.Values[i] = ec._LabelSelector_matchLabels(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "matchExpressions":
+			out.Values[i] = ec._LabelSelector_matchExpressions(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(min(len(deferred), math.MaxInt32)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var labelSelectorRequirementImplementors = []string{"LabelSelectorRequirement"}
+
+func (ec *executionContext) _LabelSelectorRequirement(ctx context.Context, sel ast.SelectionSet, obj *model.LabelSelectorRequirement) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, labelSelectorRequirementImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("LabelSelectorRequirement")
+		case "key":
+			out.Values[i] = ec._LabelSelectorRequirement_key(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "operator":
+			out.Values[i] = ec._LabelSelectorRequirement_operator(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "values":
+			out.Values[i] = ec._LabelSelectorRequirement_values(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -1808,21 +2461,22 @@ func (ec *executionContext) _PublishCatalogPayload(ctx context.Context, sel ast.
 	return out
 }
 
-var reorderCollectionsPayloadImplementors = []string{"ReorderCollectionsPayload"}
+var resolvedCollectionDefinitionImplementors = []string{"ResolvedCollectionDefinition"}
 
-func (ec *executionContext) _ReorderCollectionsPayload(ctx context.Context, sel ast.SelectionSet, obj *model.ReorderCollectionsPayload) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, reorderCollectionsPayloadImplementors)
+func (ec *executionContext) _ResolvedCollectionDefinition(ctx context.Context, sel ast.SelectionSet, obj *model.ResolvedCollectionDefinition) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, resolvedCollectionDefinitionImplementors)
 
 	out := graphql.NewFieldSet(fields)
 	deferred := make(map[string]*graphql.FieldSet)
 	for i, field := range fields {
 		switch field.Name {
 		case "__typename":
-			out.Values[i] = graphql.MarshalString("ReorderCollectionsPayload")
-		case "clientMutationId":
-			out.Values[i] = ec._ReorderCollectionsPayload_clientMutationId(ctx, field, obj)
-		case "collections":
-			out.Values[i] = ec._ReorderCollectionsPayload_collections(ctx, field, obj)
+			out.Values[i] = graphql.MarshalString("ResolvedCollectionDefinition")
+		case "memberCount":
+			out.Values[i] = ec._ResolvedCollectionDefinition_memberCount(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -1857,8 +2511,6 @@ func (ec *executionContext) _UpdateCollectionPayload(ctx context.Context, sel as
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("UpdateCollectionPayload")
-		case "clientMutationId":
-			out.Values[i] = ec._UpdateCollectionPayload_clientMutationId(ctx, field, obj)
 		case "collection":
 			out.Values[i] = ec._UpdateCollectionPayload_collection(ctx, field, obj)
 		case "conflict":
@@ -1924,6 +2576,32 @@ func (ec *executionContext) marshalNCollection2ᚖgithubᚗcomᚋgitstoreᚑdev�
 	return ec._Collection(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNCollectionCondition2ᚕᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐCollectionConditionᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.CollectionCondition) graphql.Marshaler {
+	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 1000, false, func(ctx context.Context, i int) graphql.Marshaler {
+		fc := graphql.GetFieldContext(ctx)
+		fc.Result = &v[i]
+		return ec.marshalNCollectionCondition2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐCollectionCondition(ctx, sel, v[i])
+	})
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNCollectionCondition2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐCollectionCondition(ctx context.Context, sel ast.SelectionSet, v *model.CollectionCondition) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._CollectionCondition(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalNCollectionConnection2githubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐCollectionConnection(ctx context.Context, sel ast.SelectionSet, v model.CollectionConnection) graphql.Marshaler {
 	return ec._CollectionConnection(ctx, sel, &v)
 }
@@ -1964,6 +2642,26 @@ func (ec *executionContext) marshalNCollectionEdge2ᚖgithubᚗcomᚋgitstoreᚑ
 	return ec._CollectionEdge(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNCollectionObjectMeta2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐCollectionObjectMeta(ctx context.Context, sel ast.SelectionSet, v *model.CollectionObjectMeta) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._CollectionObjectMeta(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNCollectionSpec2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐCollectionSpec(ctx context.Context, sel ast.SelectionSet, v *model.CollectionSpec) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._CollectionSpec(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalNCreateCollectionInput2githubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐCreateCollectionInput(ctx context.Context, v any) (model.CreateCollectionInput, error) {
 	res, err := ec.unmarshalInputCreateCollectionInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -2002,6 +2700,42 @@ func (ec *executionContext) marshalNDeleteCollectionPayload2ᚖgithubᚗcomᚋgi
 	return ec._DeleteCollectionPayload(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalNLabelSelectorOperator2githubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐLabelSelectorOperator(ctx context.Context, v any) (model.LabelSelectorOperator, error) {
+	var res model.LabelSelectorOperator
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNLabelSelectorOperator2githubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐLabelSelectorOperator(ctx context.Context, sel ast.SelectionSet, v model.LabelSelectorOperator) graphql.Marshaler {
+	return v
+}
+
+func (ec *executionContext) marshalNLabelSelectorRequirement2ᚕᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐLabelSelectorRequirementᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.LabelSelectorRequirement) graphql.Marshaler {
+	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 1000, false, func(ctx context.Context, i int) graphql.Marshaler {
+		fc := graphql.GetFieldContext(ctx)
+		fc.Result = &v[i]
+		return ec.marshalNLabelSelectorRequirement2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐLabelSelectorRequirement(ctx, sel, v[i])
+	})
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNLabelSelectorRequirement2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐLabelSelectorRequirement(ctx context.Context, sel ast.SelectionSet, v *model.LabelSelectorRequirement) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._LabelSelectorRequirement(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalNPublishCatalogInput2githubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐPublishCatalogInput(ctx context.Context, v any) (model.PublishCatalogInput, error) {
 	res, err := ec.unmarshalInputPublishCatalogInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -2019,25 +2753,6 @@ func (ec *executionContext) marshalNPublishCatalogPayload2ᚖgithubᚗcomᚋgits
 		return graphql.Null
 	}
 	return ec._PublishCatalogPayload(ctx, sel, v)
-}
-
-func (ec *executionContext) unmarshalNReorderCollectionsInput2githubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐReorderCollectionsInput(ctx context.Context, v any) (model.ReorderCollectionsInput, error) {
-	res, err := ec.unmarshalInputReorderCollectionsInput(ctx, v)
-	return res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalNReorderCollectionsPayload2githubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐReorderCollectionsPayload(ctx context.Context, sel ast.SelectionSet, v model.ReorderCollectionsPayload) graphql.Marshaler {
-	return ec._ReorderCollectionsPayload(ctx, sel, &v)
-}
-
-func (ec *executionContext) marshalNReorderCollectionsPayload2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐReorderCollectionsPayload(ctx context.Context, sel ast.SelectionSet, v *model.ReorderCollectionsPayload) graphql.Marshaler {
-	if v == nil {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
-		}
-		return graphql.Null
-	}
-	return ec._ReorderCollectionsPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNUpdateCollectionInput2githubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐUpdateCollectionInput(ctx context.Context, v any) (model.UpdateCollectionInput, error) {
@@ -2066,25 +2781,6 @@ func (ec *executionContext) marshalOCatalogVersion2ᚖgithubᚗcomᚋgitstoreᚑ
 	return ec._CatalogVersion(ctx, sel, v)
 }
 
-func (ec *executionContext) marshalOCollection2ᚕᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐCollectionᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Collection) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 1000, false, func(ctx context.Context, i int) graphql.Marshaler {
-		fc := graphql.GetFieldContext(ctx)
-		fc.Result = &v[i]
-		return ec.marshalNCollection2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐCollection(ctx, sel, v[i])
-	})
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
-}
-
 func (ec *executionContext) marshalOCollection2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐCollection(ctx context.Context, sel ast.SelectionSet, v *model.Collection) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
@@ -2097,6 +2793,27 @@ func (ec *executionContext) marshalOCollectionOptimisticLockConflict2ᚖgithub�
 		return graphql.Null
 	}
 	return ec._CollectionOptimisticLockConflict(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOCollectionStatus2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐCollectionStatus(ctx context.Context, sel ast.SelectionSet, v *model.CollectionStatus) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._CollectionStatus(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOLabelSelector2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐLabelSelector(ctx context.Context, sel ast.SelectionSet, v *model.LabelSelector) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._LabelSelector(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOResolvedCollectionDefinition2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐResolvedCollectionDefinition(ctx context.Context, sel ast.SelectionSet, v *model.ResolvedCollectionDefinition) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._ResolvedCollectionDefinition(ctx, sel, v)
 }
 
 // endregion ***************************** type.gotpl *****************************

--- a/gitstore-api/internal/graph/generated/root_.generated.go
+++ b/gitstore-api/internal/graph/generated/root_.generated.go
@@ -132,15 +132,22 @@ type ComplexityRoot struct {
 	}
 
 	Collection struct {
-		Body         func(childComplexity int) int
-		CreatedAt    func(childComplexity int) int
-		DisplayOrder func(childComplexity int) int
-		ID           func(childComplexity int) int
-		Name         func(childComplexity int) int
-		ProductCount func(childComplexity int) int
-		Products     func(childComplexity int, first *int32, after *string, last *int32, before *string) int
-		Slug         func(childComplexity int) int
-		UpdatedAt    func(childComplexity int) int
+		APIVersion func(childComplexity int) int
+		Body       func(childComplexity int) int
+		ID         func(childComplexity int) int
+		Kind       func(childComplexity int) int
+		Metadata   func(childComplexity int) int
+		Products   func(childComplexity int, first *int32, after *string, last *int32, before *string) int
+		Spec       func(childComplexity int) int
+		Status     func(childComplexity int) int
+	}
+
+	CollectionCondition struct {
+		Message            func(childComplexity int) int
+		ObservedGeneration func(childComplexity int) int
+		Reason             func(childComplexity int) int
+		Status             func(childComplexity int) int
+		Type               func(childComplexity int) int
 	}
 
 	CollectionConnection struct {
@@ -154,11 +161,33 @@ type ComplexityRoot struct {
 		Node   func(childComplexity int) int
 	}
 
+	CollectionObjectMeta struct {
+		Annotations       func(childComplexity int) int
+		CreationTimestamp func(childComplexity int) int
+		Generation        func(childComplexity int) int
+		Labels            func(childComplexity int) int
+		Name              func(childComplexity int) int
+		Namespace         func(childComplexity int) int
+		ResourceVersion   func(childComplexity int) int
+		Revision          func(childComplexity int) int
+		UID               func(childComplexity int) int
+	}
+
 	CollectionOptimisticLockConflict struct {
-		AttemptedVersion func(childComplexity int) int
-		Current          func(childComplexity int) int
-		CurrentVersion   func(childComplexity int) int
-		Diff             func(childComplexity int) int
+		Current func(childComplexity int) int
+	}
+
+	CollectionSpec struct {
+		Media    func(childComplexity int) int
+		Selector func(childComplexity int) int
+		Title    func(childComplexity int) int
+	}
+
+	CollectionStatus struct {
+		Conditions          func(childComplexity int) int
+		LastAppliedRevision func(childComplexity int) int
+		ObservedGeneration  func(childComplexity int) int
+		Resolved            func(childComplexity int) int
 	}
 
 	CreateCategoryPayload struct {
@@ -167,8 +196,7 @@ type ComplexityRoot struct {
 	}
 
 	CreateCollectionPayload struct {
-		ClientMutationID func(childComplexity int) int
-		Collection       func(childComplexity int) int
+		Collection func(childComplexity int) int
 	}
 
 	CreateNamespacePayload struct {
@@ -188,7 +216,6 @@ type ComplexityRoot struct {
 	}
 
 	DeleteCollectionPayload struct {
-		ClientMutationID    func(childComplexity int) int
 		DeletedCollectionID func(childComplexity int) int
 	}
 
@@ -211,6 +238,17 @@ type ComplexityRoot struct {
 	KeyValuePair struct {
 		Key   func(childComplexity int) int
 		Value func(childComplexity int) int
+	}
+
+	LabelSelector struct {
+		MatchExpressions func(childComplexity int) int
+		MatchLabels      func(childComplexity int) int
+	}
+
+	LabelSelectorRequirement struct {
+		Key      func(childComplexity int) int
+		Operator func(childComplexity int) int
+		Values   func(childComplexity int) int
 	}
 
 	LoginPayload struct {
@@ -242,7 +280,6 @@ type ComplexityRoot struct {
 		RefreshToken       func(childComplexity int, input model.RefreshTokenInput) int
 		RenameRepository   func(childComplexity int, input model.RenameRepositoryInput) int
 		ReorderCategories  func(childComplexity int, input model.ReorderCategoriesInput) int
-		ReorderCollections func(childComplexity int, input model.ReorderCollectionsInput) int
 		TransferRepository func(childComplexity int, input model.TransferRepositoryInput) int
 		UpdateCategory     func(childComplexity int, input model.UpdateCategoryInput) int
 		UpdateCollection   func(childComplexity int, input model.UpdateCollectionInput) int
@@ -364,7 +401,7 @@ type ComplexityRoot struct {
 		Categories     func(childComplexity int, first *int32, after *string, last *int32, before *string) int
 		Category       func(childComplexity int, by model.CategoryBy) int
 		Collection     func(childComplexity int, by model.CollectionBy) int
-		Collections    func(childComplexity int, first *int32, after *string, last *int32, before *string) int
+		Collections    func(childComplexity int, namespace string, first *int32, after *string, last *int32, before *string) int
 		Namespace      func(childComplexity int, by model.NamespaceBy) int
 		Namespaces     func(childComplexity int, first *int32, after *string, last *int32, before *string) int
 		Node           func(childComplexity int, id string) int
@@ -388,11 +425,6 @@ type ComplexityRoot struct {
 	ReorderCategoriesPayload struct {
 		Categories       func(childComplexity int) int
 		ClientMutationID func(childComplexity int) int
-	}
-
-	ReorderCollectionsPayload struct {
-		ClientMutationID func(childComplexity int) int
-		Collections      func(childComplexity int) int
 	}
 
 	Repository struct {
@@ -431,6 +463,10 @@ type ComplexityRoot struct {
 		ProductCount func(childComplexity int) int
 	}
 
+	ResolvedCollectionDefinition struct {
+		MemberCount func(childComplexity int) int
+	}
+
 	ResolvedFileDefinition struct {
 		ContentType func(childComplexity int) int
 		Name        func(childComplexity int) int
@@ -458,9 +494,8 @@ type ComplexityRoot struct {
 	}
 
 	UpdateCollectionPayload struct {
-		ClientMutationID func(childComplexity int) int
-		Collection       func(childComplexity int) int
-		Conflict         func(childComplexity int) int
+		Collection func(childComplexity int) int
+		Conflict   func(childComplexity int) int
 	}
 
 	User struct {
@@ -935,26 +970,19 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.CategoryTaxonomyStatus.Resolved(childComplexity), true
 
+	case "Collection.apiVersion":
+		if e.ComplexityRoot.Collection.APIVersion == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Collection.APIVersion(childComplexity), true
+
 	case "Collection.body":
 		if e.ComplexityRoot.Collection.Body == nil {
 			break
 		}
 
 		return e.ComplexityRoot.Collection.Body(childComplexity), true
-
-	case "Collection.createdAt":
-		if e.ComplexityRoot.Collection.CreatedAt == nil {
-			break
-		}
-
-		return e.ComplexityRoot.Collection.CreatedAt(childComplexity), true
-
-	case "Collection.displayOrder":
-		if e.ComplexityRoot.Collection.DisplayOrder == nil {
-			break
-		}
-
-		return e.ComplexityRoot.Collection.DisplayOrder(childComplexity), true
 
 	case "Collection.id":
 		if e.ComplexityRoot.Collection.ID == nil {
@@ -963,19 +991,19 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.Collection.ID(childComplexity), true
 
-	case "Collection.name":
-		if e.ComplexityRoot.Collection.Name == nil {
+	case "Collection.kind":
+		if e.ComplexityRoot.Collection.Kind == nil {
 			break
 		}
 
-		return e.ComplexityRoot.Collection.Name(childComplexity), true
+		return e.ComplexityRoot.Collection.Kind(childComplexity), true
 
-	case "Collection.productCount":
-		if e.ComplexityRoot.Collection.ProductCount == nil {
+	case "Collection.metadata":
+		if e.ComplexityRoot.Collection.Metadata == nil {
 			break
 		}
 
-		return e.ComplexityRoot.Collection.ProductCount(childComplexity), true
+		return e.ComplexityRoot.Collection.Metadata(childComplexity), true
 
 	case "Collection.products":
 		if e.ComplexityRoot.Collection.Products == nil {
@@ -989,19 +1017,54 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.Collection.Products(childComplexity, args["first"].(*int32), args["after"].(*string), args["last"].(*int32), args["before"].(*string)), true
 
-	case "Collection.slug":
-		if e.ComplexityRoot.Collection.Slug == nil {
+	case "Collection.spec":
+		if e.ComplexityRoot.Collection.Spec == nil {
 			break
 		}
 
-		return e.ComplexityRoot.Collection.Slug(childComplexity), true
+		return e.ComplexityRoot.Collection.Spec(childComplexity), true
 
-	case "Collection.updatedAt":
-		if e.ComplexityRoot.Collection.UpdatedAt == nil {
+	case "Collection.status":
+		if e.ComplexityRoot.Collection.Status == nil {
 			break
 		}
 
-		return e.ComplexityRoot.Collection.UpdatedAt(childComplexity), true
+		return e.ComplexityRoot.Collection.Status(childComplexity), true
+
+	case "CollectionCondition.message":
+		if e.ComplexityRoot.CollectionCondition.Message == nil {
+			break
+		}
+
+		return e.ComplexityRoot.CollectionCondition.Message(childComplexity), true
+
+	case "CollectionCondition.observedGeneration":
+		if e.ComplexityRoot.CollectionCondition.ObservedGeneration == nil {
+			break
+		}
+
+		return e.ComplexityRoot.CollectionCondition.ObservedGeneration(childComplexity), true
+
+	case "CollectionCondition.reason":
+		if e.ComplexityRoot.CollectionCondition.Reason == nil {
+			break
+		}
+
+		return e.ComplexityRoot.CollectionCondition.Reason(childComplexity), true
+
+	case "CollectionCondition.status":
+		if e.ComplexityRoot.CollectionCondition.Status == nil {
+			break
+		}
+
+		return e.ComplexityRoot.CollectionCondition.Status(childComplexity), true
+
+	case "CollectionCondition.type":
+		if e.ComplexityRoot.CollectionCondition.Type == nil {
+			break
+		}
+
+		return e.ComplexityRoot.CollectionCondition.Type(childComplexity), true
 
 	case "CollectionConnection.edges":
 		if e.ComplexityRoot.CollectionConnection.Edges == nil {
@@ -1038,12 +1101,68 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.CollectionEdge.Node(childComplexity), true
 
-	case "CollectionOptimisticLockConflict.attemptedVersion":
-		if e.ComplexityRoot.CollectionOptimisticLockConflict.AttemptedVersion == nil {
+	case "CollectionObjectMeta.annotations":
+		if e.ComplexityRoot.CollectionObjectMeta.Annotations == nil {
 			break
 		}
 
-		return e.ComplexityRoot.CollectionOptimisticLockConflict.AttemptedVersion(childComplexity), true
+		return e.ComplexityRoot.CollectionObjectMeta.Annotations(childComplexity), true
+
+	case "CollectionObjectMeta.creationTimestamp":
+		if e.ComplexityRoot.CollectionObjectMeta.CreationTimestamp == nil {
+			break
+		}
+
+		return e.ComplexityRoot.CollectionObjectMeta.CreationTimestamp(childComplexity), true
+
+	case "CollectionObjectMeta.generation":
+		if e.ComplexityRoot.CollectionObjectMeta.Generation == nil {
+			break
+		}
+
+		return e.ComplexityRoot.CollectionObjectMeta.Generation(childComplexity), true
+
+	case "CollectionObjectMeta.labels":
+		if e.ComplexityRoot.CollectionObjectMeta.Labels == nil {
+			break
+		}
+
+		return e.ComplexityRoot.CollectionObjectMeta.Labels(childComplexity), true
+
+	case "CollectionObjectMeta.name":
+		if e.ComplexityRoot.CollectionObjectMeta.Name == nil {
+			break
+		}
+
+		return e.ComplexityRoot.CollectionObjectMeta.Name(childComplexity), true
+
+	case "CollectionObjectMeta.namespace":
+		if e.ComplexityRoot.CollectionObjectMeta.Namespace == nil {
+			break
+		}
+
+		return e.ComplexityRoot.CollectionObjectMeta.Namespace(childComplexity), true
+
+	case "CollectionObjectMeta.resourceVersion":
+		if e.ComplexityRoot.CollectionObjectMeta.ResourceVersion == nil {
+			break
+		}
+
+		return e.ComplexityRoot.CollectionObjectMeta.ResourceVersion(childComplexity), true
+
+	case "CollectionObjectMeta.revision":
+		if e.ComplexityRoot.CollectionObjectMeta.Revision == nil {
+			break
+		}
+
+		return e.ComplexityRoot.CollectionObjectMeta.Revision(childComplexity), true
+
+	case "CollectionObjectMeta.uid":
+		if e.ComplexityRoot.CollectionObjectMeta.UID == nil {
+			break
+		}
+
+		return e.ComplexityRoot.CollectionObjectMeta.UID(childComplexity), true
 
 	case "CollectionOptimisticLockConflict.current":
 		if e.ComplexityRoot.CollectionOptimisticLockConflict.Current == nil {
@@ -1052,19 +1171,54 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.CollectionOptimisticLockConflict.Current(childComplexity), true
 
-	case "CollectionOptimisticLockConflict.currentVersion":
-		if e.ComplexityRoot.CollectionOptimisticLockConflict.CurrentVersion == nil {
+	case "CollectionSpec.media":
+		if e.ComplexityRoot.CollectionSpec.Media == nil {
 			break
 		}
 
-		return e.ComplexityRoot.CollectionOptimisticLockConflict.CurrentVersion(childComplexity), true
+		return e.ComplexityRoot.CollectionSpec.Media(childComplexity), true
 
-	case "CollectionOptimisticLockConflict.diff":
-		if e.ComplexityRoot.CollectionOptimisticLockConflict.Diff == nil {
+	case "CollectionSpec.selector":
+		if e.ComplexityRoot.CollectionSpec.Selector == nil {
 			break
 		}
 
-		return e.ComplexityRoot.CollectionOptimisticLockConflict.Diff(childComplexity), true
+		return e.ComplexityRoot.CollectionSpec.Selector(childComplexity), true
+
+	case "CollectionSpec.title":
+		if e.ComplexityRoot.CollectionSpec.Title == nil {
+			break
+		}
+
+		return e.ComplexityRoot.CollectionSpec.Title(childComplexity), true
+
+	case "CollectionStatus.conditions":
+		if e.ComplexityRoot.CollectionStatus.Conditions == nil {
+			break
+		}
+
+		return e.ComplexityRoot.CollectionStatus.Conditions(childComplexity), true
+
+	case "CollectionStatus.lastAppliedRevision":
+		if e.ComplexityRoot.CollectionStatus.LastAppliedRevision == nil {
+			break
+		}
+
+		return e.ComplexityRoot.CollectionStatus.LastAppliedRevision(childComplexity), true
+
+	case "CollectionStatus.observedGeneration":
+		if e.ComplexityRoot.CollectionStatus.ObservedGeneration == nil {
+			break
+		}
+
+		return e.ComplexityRoot.CollectionStatus.ObservedGeneration(childComplexity), true
+
+	case "CollectionStatus.resolved":
+		if e.ComplexityRoot.CollectionStatus.Resolved == nil {
+			break
+		}
+
+		return e.ComplexityRoot.CollectionStatus.Resolved(childComplexity), true
 
 	case "CreateCategoryPayload.category":
 		if e.ComplexityRoot.CreateCategoryPayload.Category == nil {
@@ -1079,13 +1233,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.CreateCategoryPayload.ClientMutationID(childComplexity), true
-
-	case "CreateCollectionPayload.clientMutationId":
-		if e.ComplexityRoot.CreateCollectionPayload.ClientMutationID == nil {
-			break
-		}
-
-		return e.ComplexityRoot.CreateCollectionPayload.ClientMutationID(childComplexity), true
 
 	case "CreateCollectionPayload.collection":
 		if e.ComplexityRoot.CreateCollectionPayload.Collection == nil {
@@ -1142,13 +1289,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.DeleteCategoryPayload.OrphanedProductIds(childComplexity), true
-
-	case "DeleteCollectionPayload.clientMutationId":
-		if e.ComplexityRoot.DeleteCollectionPayload.ClientMutationID == nil {
-			break
-		}
-
-		return e.ComplexityRoot.DeleteCollectionPayload.ClientMutationID(childComplexity), true
 
 	case "DeleteCollectionPayload.deletedCollectionId":
 		if e.ComplexityRoot.DeleteCollectionPayload.DeletedCollectionID == nil {
@@ -1219,6 +1359,41 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.KeyValuePair.Value(childComplexity), true
+
+	case "LabelSelector.matchExpressions":
+		if e.ComplexityRoot.LabelSelector.MatchExpressions == nil {
+			break
+		}
+
+		return e.ComplexityRoot.LabelSelector.MatchExpressions(childComplexity), true
+
+	case "LabelSelector.matchLabels":
+		if e.ComplexityRoot.LabelSelector.MatchLabels == nil {
+			break
+		}
+
+		return e.ComplexityRoot.LabelSelector.MatchLabels(childComplexity), true
+
+	case "LabelSelectorRequirement.key":
+		if e.ComplexityRoot.LabelSelectorRequirement.Key == nil {
+			break
+		}
+
+		return e.ComplexityRoot.LabelSelectorRequirement.Key(childComplexity), true
+
+	case "LabelSelectorRequirement.operator":
+		if e.ComplexityRoot.LabelSelectorRequirement.Operator == nil {
+			break
+		}
+
+		return e.ComplexityRoot.LabelSelectorRequirement.Operator(childComplexity), true
+
+	case "LabelSelectorRequirement.values":
+		if e.ComplexityRoot.LabelSelectorRequirement.Values == nil {
+			break
+		}
+
+		return e.ComplexityRoot.LabelSelectorRequirement.Values(childComplexity), true
 
 	case "LoginPayload.clientMutationId":
 		if e.ComplexityRoot.LoginPayload.ClientMutationID == nil {
@@ -1422,18 +1597,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Mutation.ReorderCategories(childComplexity, args["input"].(model.ReorderCategoriesInput)), true
-
-	case "Mutation.reorderCollections":
-		if e.ComplexityRoot.Mutation.ReorderCollections == nil {
-			break
-		}
-
-		args, err := ec.field_Mutation_reorderCollections_args(ctx, rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.ComplexityRoot.Mutation.ReorderCollections(childComplexity, args["input"].(model.ReorderCollectionsInput)), true
 
 	case "Mutation.transferRepository":
 		if e.ComplexityRoot.Mutation.TransferRepository == nil {
@@ -1986,7 +2149,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.ComplexityRoot.Query.Collections(childComplexity, args["first"].(*int32), args["after"].(*string), args["last"].(*int32), args["before"].(*string)), true
+		return e.ComplexityRoot.Query.Collections(childComplexity, args["namespace"].(string), args["first"].(*int32), args["after"].(*string), args["last"].(*int32), args["before"].(*string)), true
 
 	case "Query.namespace":
 		if e.ComplexityRoot.Query.Namespace == nil {
@@ -2125,20 +2288,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.ReorderCategoriesPayload.ClientMutationID(childComplexity), true
-
-	case "ReorderCollectionsPayload.clientMutationId":
-		if e.ComplexityRoot.ReorderCollectionsPayload.ClientMutationID == nil {
-			break
-		}
-
-		return e.ComplexityRoot.ReorderCollectionsPayload.ClientMutationID(childComplexity), true
-
-	case "ReorderCollectionsPayload.collections":
-		if e.ComplexityRoot.ReorderCollectionsPayload.Collections == nil {
-			break
-		}
-
-		return e.ComplexityRoot.ReorderCollectionsPayload.Collections(childComplexity), true
 
 	case "Repository.createdAt":
 		if e.ComplexityRoot.Repository.CreatedAt == nil {
@@ -2287,6 +2436,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.ResolvedCategoryTaxonomy.ProductCount(childComplexity), true
 
+	case "ResolvedCollectionDefinition.memberCount":
+		if e.ComplexityRoot.ResolvedCollectionDefinition.MemberCount == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ResolvedCollectionDefinition.MemberCount(childComplexity), true
+
 	case "ResolvedFileDefinition.contentType":
 		if e.ComplexityRoot.ResolvedFileDefinition.ContentType == nil {
 			break
@@ -2385,13 +2541,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.UpdateCategoryPayload.Conflict(childComplexity), true
 
-	case "UpdateCollectionPayload.clientMutationId":
-		if e.ComplexityRoot.UpdateCollectionPayload.ClientMutationID == nil {
-			break
-		}
-
-		return e.ComplexityRoot.UpdateCollectionPayload.ClientMutationID(childComplexity), true
-
 	case "UpdateCollectionPayload.collection":
 		if e.ComplexityRoot.UpdateCollectionPayload.Collection == nil {
 			break
@@ -2452,6 +2601,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputCategoryBy,
 		ec.unmarshalInputCategoryNamespacePath,
 		ec.unmarshalInputCollectionBy,
+		ec.unmarshalInputCollectionNamespacePath,
 		ec.unmarshalInputCreateCategoryInput,
 		ec.unmarshalInputCreateCollectionInput,
 		ec.unmarshalInputCreateNamespaceInput,
@@ -2469,7 +2619,6 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputRefreshTokenInput,
 		ec.unmarshalInputRenameRepositoryInput,
 		ec.unmarshalInputReorderCategoriesInput,
-		ec.unmarshalInputReorderCollectionsInput,
 		ec.unmarshalInputRepositoryBy,
 		ec.unmarshalInputRepositoryNamespacePath,
 		ec.unmarshalInputTransferRepositoryInput,
@@ -3141,18 +3290,20 @@ type CategoryOptimisticLockConflict {
   diff: String!
 }
 `, BuiltIn: false},
-	{Name: "../../../../shared/schemas/collection.graphqls", Input: `# Collection Entity GraphQL Types
+	{Name: "../../../../shared/schemas/collection.graphqls", Input: `# Collection Entity GraphQL Types (Kubernetes-style resource envelope)
+# Replaces the legacy flat collection schema.
 
 extend type Query {
   """
-  Get collection by one unique selector.
+  Get a collection by one unique selector.
   """
   collection(by: CollectionBy!): Collection
 
   """
-  List collections with Relay cursor-based pagination
+  List collections with Relay cursor-based pagination, scoped to a namespace.
   """
   collections(
+    namespace: String!
     first: Int
     after: String
     last: Int
@@ -3161,55 +3312,67 @@ extend type Query {
 }
 
 extend type Mutation {
-
   """
-  Create a new collection
+  Deprecated: Collection resources are managed via git push.
+  This mutation always returns an informative error.
   """
   createCollection(input: CreateCollectionInput!): CreateCollectionPayload!
 
   """
-  Update an existing collection
+  Deprecated: Collection resources are managed via git push.
+  This mutation always returns an informative error.
   """
   updateCollection(input: UpdateCollectionInput!): UpdateCollectionPayload!
 
   """
-  Delete a collection
+  Deprecated: Collection resources are managed via git push.
+  This mutation always returns an informative error.
   """
   deleteCollection(input: DeleteCollectionInput!): DeleteCollectionPayload!
-
-  """
-  Reorder collections (drag-and-drop)
-  """
-  reorderCollections(input: ReorderCollectionsInput!): ReorderCollectionsPayload!
-
 }
 
 """
-Collection represents a curated grouping of products (flat, non-hierarchical)
+A Collection is a namespace-scoped catalog resource that groups products via
+a declarative label selector. Defined by git push; mutations are not supported.
 """
 type Collection implements Node {
   """
-  Globally unique identifier (format: coll_[base62])
+  Globally unique Relay ID (encodes the collection UID).
   """
   id: ID!
 
   """
-  Collection display name
+  API version. Always catalog.gitstore.dev/v1beta1.
   """
-  name: String!
+  apiVersion: String
 
   """
-  URL-friendly slug (unique)
+  Resource kind. Always Collection.
   """
-  slug: String!
+  kind: String
 
   """
-  Display order for collection listing
+  System-managed identity and metadata.
   """
-  displayOrder: Int!
+  metadata: CollectionObjectMeta!
 
   """
-  Products in this collection
+  Author-controlled specification: title, selector, and media.
+  """
+  spec: CollectionSpec!
+
+  """
+  System-computed status: conditions and member count.
+  """
+  status: CollectionStatus
+
+  """
+  Markdown body content (collection description).
+  """
+  body: String
+
+  """
+  Paginated connection of products matched by this collection's label selector.
   """
   products(
     first: Int
@@ -3217,361 +3380,250 @@ type Collection implements Node {
     last: Int
     before: String
   ): ProductConnection!
-
-  """
-  Markdown body content (collection description with rich formatting)
-  """
-  body: String
-
-  """
-  Creation timestamp
-  """
-  createdAt: DateTime!
-
-  """
-  Last modification timestamp
-  """
-  updatedAt: DateTime!
-
-  """
-  Number of products in this collection
-  """
-  productCount: Int!
 }
 
 """
-Edge type for Collection connection (Relay pattern)
+System-managed identity fields for a Collection resource.
+All fields are read-only; they are set and updated by the system.
 """
-type CollectionEdge {
+type CollectionObjectMeta {
   """
-  Cursor for pagination
-  """
-  cursor: String!
-
-  """
-  The collection node
-  """
-  node: Collection!
-}
-
-"""
-Connection type for paginated collections (Relay pattern)
-"""
-type CollectionConnection {
-  """
-  List of collection edges
-  """
-  edges: [CollectionEdge!]!
-
-  """
-  Pagination information
-  """
-  pageInfo: PageInfo!
-
-  """
-  Total count of collections
-  """
-  totalCount: Int!
-}
-
-# ============================================================================
-# Mutations
-# ============================================================================
-
-"""
-Input for creating a collection
-"""
-input CreateCollectionInput {
-  """
-  Client mutation ID (Relay pattern)
-  """
-  clientMutationId: String
-
-  """
-  Collection name
+  DNS-label name, unique within the namespace.
   """
   name: String!
 
   """
-  URL-friendly slug (must be unique)
+  Namespace identifier the collection belongs to.
   """
-  slug: String!
+  namespace: String
 
   """
-  Display order
+  Globally unique system-generated identifier.
   """
-  displayOrder: Int
+  uid: ID!
 
   """
-  Product IDs to include
+  Opaque concurrency token. Changes on every spec update.
   """
-  productIds: [ID!]
+  resourceVersion: String!
 
   """
-  Markdown body content
+  Monotonically increasing counter incremented on every spec change.
   """
-  body: String
+  generation: Int!
+
+  """
+  Timestamp of first admission.
+  """
+  creationTimestamp: DateTime!
+
+  """
+  Git revision of the last successful push (e.g. main@sha1:abc123).
+  """
+  revision: String
+
+  """
+  Author-supplied key-value labels.
+  """
+  labels: [KeyValuePair!]!
+
+  """
+  Author-supplied annotations.
+  """
+  annotations: [KeyValuePair!]!
 }
 
 """
-Payload for createCollection mutation
+Author-controlled specification for a Collection resource.
 """
+type CollectionSpec {
+  """
+  Human-readable display title for the collection.
+  """
+  title: String!
+
+  """
+  Label selector that determines collection membership.
+  An absent or empty selector yields zero members.
+  """
+  selector: LabelSelector
+
+  """
+  Media slots referencing File resources.
+  """
+  media: [MediaDefinition!]!
+}
+
+"""
+A label selector that matches products by their labels.
+matchLabels and matchExpressions are combined with logical AND.
+An empty selector (all fields absent) matches nothing.
+"""
+type LabelSelector {
+  """
+  Exact key-value pairs that must all be present on a product's labels.
+  """
+  matchLabels: [KeyValuePair!]!
+
+  """
+  Set-based requirements. All entries must be satisfied.
+  """
+  matchExpressions: [LabelSelectorRequirement!]!
+}
+
+"""
+A single label selector expression with set-based semantics.
+"""
+type LabelSelectorRequirement {
+  """
+  The label key this requirement applies to.
+  """
+  key: String!
+
+  """
+  The operator: IN, NOT_IN, EXISTS, or DOES_NOT_EXIST.
+  """
+  operator: LabelSelectorOperator!
+
+  """
+  The set of values. Required for IN and NOT_IN; must be empty for EXISTS and DOES_NOT_EXIST.
+  """
+  values: [String!]!
+}
+
+"""
+Operators supported in a LabelSelectorRequirement.
+"""
+enum LabelSelectorOperator {
+  IN
+  NOT_IN
+  EXISTS
+  DOES_NOT_EXIST
+}
+
+"""
+System-computed status for a Collection resource.
+"""
+type CollectionStatus {
+  """
+  Generation of the spec that this status was computed from.
+  """
+  observedGeneration: Int!
+
+  """
+  Git revision of the last successfully admitted push.
+  """
+  lastAppliedRevision: String
+
+  """
+  Condition set written at admission time.
+  """
+  conditions: [CollectionCondition!]!
+
+  """
+  Resolved membership snapshot (cached hint; collection.products is authoritative).
+  """
+  resolved: ResolvedCollectionDefinition
+}
+
+"""
+A single status condition on a Collection resource.
+"""
+type CollectionCondition {
+  type: String!
+  status: String!
+  observedGeneration: Int
+  reason: String
+  message: String
+}
+
+"""
+Resolved membership information cached at last admission.
+"""
+type ResolvedCollectionDefinition {
+  """
+  Cached count of matching products at last admission.
+  """
+  memberCount: Int!
+}
+
+"""
+Edge type for Collection connection (Relay pattern).
+"""
+type CollectionEdge {
+  cursor: String!
+  node: Collection!
+}
+
+"""
+Paginated connection for collections (Relay pattern).
+"""
+type CollectionConnection {
+  edges: [CollectionEdge!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+# ============================================================================
+# Minimal stub inputs (legacy mutations deprecated — managed via git push)
+# ============================================================================
+
+input CreateCollectionInput {
+  name: String!
+}
+
 type CreateCollectionPayload {
-  """
-  Client mutation ID (Relay pattern)
-  """
-  clientMutationId: String
-
-  """
-  The created collection
-  """
   collection: Collection
 }
 
-"""
-Input for updating a collection
-"""
 input UpdateCollectionInput {
-  """
-  Client mutation ID (Relay pattern)
-  """
-  clientMutationId: String
-
-  """
-  Collection ID to update
-  """
   id: ID!
-
-  """
-  New name
-  """
-  name: String
-
-  """
-  New slug
-  """
-  slug: String
-
-  """
-  New display order
-  """
-  displayOrder: Int
-
-  """
-  New product IDs (replaces all)
-  """
-  productIds: [ID!]
-
-  """
-  New body content
-  """
-  body: String
-
-  """
-  TODO: Should this be a datatime?
-  Version for optimistic locking
-  """
-  version: DateTime!
 }
 
-"""
-Payload for updateCollection mutation
-"""
 type UpdateCollectionPayload {
-  """
-  Client mutation ID (Relay pattern)
-  """
-  clientMutationId: String
-
-  """
-  The updated collection
-  """
   collection: Collection
-
-  """
-  Conflict information (if optimistic lock failed)
-  """
   conflict: CollectionOptimisticLockConflict
 }
 
-"""
-Input for deleting a collection
-"""
-input DeleteCollectionInput {
-  """
-  Client mutation ID (Relay pattern)
-  """
-  clientMutationId: String
+type CollectionOptimisticLockConflict {
+  current: Collection!
+}
 
-  """
-  Collection ID to delete
-  """
+input DeleteCollectionInput {
   id: ID!
 }
 
-"""
-Payload for deleteCollection mutation
-"""
 type DeleteCollectionPayload {
-  """
-  Client mutation ID (Relay pattern)
-  """
-  clientMutationId: String
-
-  """
-  Deleted collection ID
-  """
   deletedCollectionId: ID
 }
 
-"""
-Input for reordering collections (drag-and-drop)
-"""
-input ReorderCollectionsInput {
-  """
-  Client mutation ID (Relay pattern)
-  """
-  clientMutationId: String
-
-  """
-  Ordered list of collection IDs
-  """
-  orderedIds: [ID!]!
-}
-
-"""
-Payload for reorderCollections mutation
-"""
-type ReorderCollectionsPayload {
-  """
-  Client mutation ID (Relay pattern)
-  """
-  clientMutationId: String
-
-  """
-  Updated collections
-  """
-  collections: [Collection!]
-}
-
-"""
-Optimistic lock conflict for collection
-"""
-type CollectionOptimisticLockConflict {
-  """
-  TODO: Should this be a datetime?
-  Current version in database
-  """
-  currentVersion: DateTime!
-
-  """
-  TODO: Should this be a datetime?
-  Version client attempted to update
-  """
-  attemptedVersion: DateTime!
-
-  """
-  Current state of the collection
-  """
-  current: Collection!
-
-  """
-  Diff between current and attempted
-  """
-  diff: String!
-}
-
 # ============================================================================
-# Publish Mutation (shared across entities)
+# Publish / CatalogVersion (kept here for schema continuity)
 # ============================================================================
 
-"""
-Input for publishing catalog changes
-"""
 input PublishCatalogInput {
-  """
-  Client mutation ID (Relay pattern)
-  """
   clientMutationId: String
-
-  """
-  Release version tag (e.g., v1.0.0)
-  """
   version: String!
-
-  """
-  Release notes/commit message
-  """
   message: String!
 }
 
-"""
-Payload for publishCatalog mutation
-"""
 type PublishCatalogPayload {
-  """
-  Client mutation ID (Relay pattern)
-  """
   clientMutationId: String
-
-  """
-  New catalog version
-  """
   catalogVersion: CatalogVersion
 }
 
-"""
-Catalog version information
-"""
 type CatalogVersion {
-  """
-  Version tag (e.g., v1.0.0)
-  """
   tag: String!
-
-  """
-  Commit SHA
-  """
   commit: String!
-
-  """
-  Release timestamp
-  """
   publishedAt: DateTime!
-
-  """
-  Release message
-  """
   message: String
-
-  """
-  Statistics
-  """
   stats: CatalogStats!
 }
 
-"""
-Catalog statistics
-"""
 type CatalogStats {
-  """
-  Total products
-  """
   productCount: Int!
-
-  """
-  Total categories
-  """
   categoryCount: Int!
-
-  """
-  Total collections
-  """
   collectionCount: Int!
-
-  """
-  Number of orphaned product references
-  """
   orphanedReferences: Int!
 }
 `, BuiltIn: false},
@@ -4326,8 +4378,19 @@ input CategoryNamespacePath {
 Selector for looking up a collection by exactly one unique key.
 """
 input CollectionBy @oneOf {
+  """Look up by globally unique Relay ID (encodes the collection UID)."""
   id: ID
-  slug: String
+
+  """Look up by namespace identifier + collection name."""
+  namespacePath: CollectionNamespacePath
+}
+
+"""
+Composite selector: namespace identifier + collection name.
+"""
+input CollectionNamespacePath {
+  namespace: String!
+  name: String!
 }
 
 """
@@ -4558,24 +4621,38 @@ func (ec *executionContext) childFields_Collection(ctx context.Context, field gr
 	switch field.Name {
 	case "id":
 		return ec.fieldContext_Collection_id(ctx, field)
-	case "name":
-		return ec.fieldContext_Collection_name(ctx, field)
-	case "slug":
-		return ec.fieldContext_Collection_slug(ctx, field)
-	case "displayOrder":
-		return ec.fieldContext_Collection_displayOrder(ctx, field)
-	case "products":
-		return ec.fieldContext_Collection_products(ctx, field)
+	case "apiVersion":
+		return ec.fieldContext_Collection_apiVersion(ctx, field)
+	case "kind":
+		return ec.fieldContext_Collection_kind(ctx, field)
+	case "metadata":
+		return ec.fieldContext_Collection_metadata(ctx, field)
+	case "spec":
+		return ec.fieldContext_Collection_spec(ctx, field)
+	case "status":
+		return ec.fieldContext_Collection_status(ctx, field)
 	case "body":
 		return ec.fieldContext_Collection_body(ctx, field)
-	case "createdAt":
-		return ec.fieldContext_Collection_createdAt(ctx, field)
-	case "updatedAt":
-		return ec.fieldContext_Collection_updatedAt(ctx, field)
-	case "productCount":
-		return ec.fieldContext_Collection_productCount(ctx, field)
+	case "products":
+		return ec.fieldContext_Collection_products(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type Collection", field.Name)
+}
+
+func (ec *executionContext) childFields_CollectionCondition(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+	switch field.Name {
+	case "type":
+		return ec.fieldContext_CollectionCondition_type(ctx, field)
+	case "status":
+		return ec.fieldContext_CollectionCondition_status(ctx, field)
+	case "observedGeneration":
+		return ec.fieldContext_CollectionCondition_observedGeneration(ctx, field)
+	case "reason":
+		return ec.fieldContext_CollectionCondition_reason(ctx, field)
+	case "message":
+		return ec.fieldContext_CollectionCondition_message(ctx, field)
+	}
+	return nil, fmt.Errorf("no field named %q was found under type CollectionCondition", field.Name)
 }
 
 func (ec *executionContext) childFields_CollectionConnection(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
@@ -4600,18 +4677,62 @@ func (ec *executionContext) childFields_CollectionEdge(ctx context.Context, fiel
 	return nil, fmt.Errorf("no field named %q was found under type CollectionEdge", field.Name)
 }
 
+func (ec *executionContext) childFields_CollectionObjectMeta(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+	switch field.Name {
+	case "name":
+		return ec.fieldContext_CollectionObjectMeta_name(ctx, field)
+	case "namespace":
+		return ec.fieldContext_CollectionObjectMeta_namespace(ctx, field)
+	case "uid":
+		return ec.fieldContext_CollectionObjectMeta_uid(ctx, field)
+	case "resourceVersion":
+		return ec.fieldContext_CollectionObjectMeta_resourceVersion(ctx, field)
+	case "generation":
+		return ec.fieldContext_CollectionObjectMeta_generation(ctx, field)
+	case "creationTimestamp":
+		return ec.fieldContext_CollectionObjectMeta_creationTimestamp(ctx, field)
+	case "revision":
+		return ec.fieldContext_CollectionObjectMeta_revision(ctx, field)
+	case "labels":
+		return ec.fieldContext_CollectionObjectMeta_labels(ctx, field)
+	case "annotations":
+		return ec.fieldContext_CollectionObjectMeta_annotations(ctx, field)
+	}
+	return nil, fmt.Errorf("no field named %q was found under type CollectionObjectMeta", field.Name)
+}
+
 func (ec *executionContext) childFields_CollectionOptimisticLockConflict(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 	switch field.Name {
-	case "currentVersion":
-		return ec.fieldContext_CollectionOptimisticLockConflict_currentVersion(ctx, field)
-	case "attemptedVersion":
-		return ec.fieldContext_CollectionOptimisticLockConflict_attemptedVersion(ctx, field)
 	case "current":
 		return ec.fieldContext_CollectionOptimisticLockConflict_current(ctx, field)
-	case "diff":
-		return ec.fieldContext_CollectionOptimisticLockConflict_diff(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type CollectionOptimisticLockConflict", field.Name)
+}
+
+func (ec *executionContext) childFields_CollectionSpec(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+	switch field.Name {
+	case "title":
+		return ec.fieldContext_CollectionSpec_title(ctx, field)
+	case "selector":
+		return ec.fieldContext_CollectionSpec_selector(ctx, field)
+	case "media":
+		return ec.fieldContext_CollectionSpec_media(ctx, field)
+	}
+	return nil, fmt.Errorf("no field named %q was found under type CollectionSpec", field.Name)
+}
+
+func (ec *executionContext) childFields_CollectionStatus(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+	switch field.Name {
+	case "observedGeneration":
+		return ec.fieldContext_CollectionStatus_observedGeneration(ctx, field)
+	case "lastAppliedRevision":
+		return ec.fieldContext_CollectionStatus_lastAppliedRevision(ctx, field)
+	case "conditions":
+		return ec.fieldContext_CollectionStatus_conditions(ctx, field)
+	case "resolved":
+		return ec.fieldContext_CollectionStatus_resolved(ctx, field)
+	}
+	return nil, fmt.Errorf("no field named %q was found under type CollectionStatus", field.Name)
 }
 
 func (ec *executionContext) childFields_CreateCategoryPayload(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
@@ -4626,8 +4747,6 @@ func (ec *executionContext) childFields_CreateCategoryPayload(ctx context.Contex
 
 func (ec *executionContext) childFields_CreateCollectionPayload(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 	switch field.Name {
-	case "clientMutationId":
-		return ec.fieldContext_CreateCollectionPayload_clientMutationId(ctx, field)
 	case "collection":
 		return ec.fieldContext_CreateCollectionPayload_collection(ctx, field)
 	}
@@ -4668,8 +4787,6 @@ func (ec *executionContext) childFields_DeleteCategoryPayload(ctx context.Contex
 
 func (ec *executionContext) childFields_DeleteCollectionPayload(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 	switch field.Name {
-	case "clientMutationId":
-		return ec.fieldContext_DeleteCollectionPayload_clientMutationId(ctx, field)
 	case "deletedCollectionId":
 		return ec.fieldContext_DeleteCollectionPayload_deletedCollectionId(ctx, field)
 	}
@@ -4716,6 +4833,28 @@ func (ec *executionContext) childFields_KeyValuePair(ctx context.Context, field 
 		return ec.fieldContext_KeyValuePair_value(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type KeyValuePair", field.Name)
+}
+
+func (ec *executionContext) childFields_LabelSelector(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+	switch field.Name {
+	case "matchLabels":
+		return ec.fieldContext_LabelSelector_matchLabels(ctx, field)
+	case "matchExpressions":
+		return ec.fieldContext_LabelSelector_matchExpressions(ctx, field)
+	}
+	return nil, fmt.Errorf("no field named %q was found under type LabelSelector", field.Name)
+}
+
+func (ec *executionContext) childFields_LabelSelectorRequirement(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+	switch field.Name {
+	case "key":
+		return ec.fieldContext_LabelSelectorRequirement_key(ctx, field)
+	case "operator":
+		return ec.fieldContext_LabelSelectorRequirement_operator(ctx, field)
+	case "values":
+		return ec.fieldContext_LabelSelectorRequirement_values(ctx, field)
+	}
+	return nil, fmt.Errorf("no field named %q was found under type LabelSelectorRequirement", field.Name)
 }
 
 func (ec *executionContext) childFields_LoginPayload(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
@@ -4998,16 +5137,6 @@ func (ec *executionContext) childFields_ReorderCategoriesPayload(ctx context.Con
 	return nil, fmt.Errorf("no field named %q was found under type ReorderCategoriesPayload", field.Name)
 }
 
-func (ec *executionContext) childFields_ReorderCollectionsPayload(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-	switch field.Name {
-	case "clientMutationId":
-		return ec.fieldContext_ReorderCollectionsPayload_clientMutationId(ctx, field)
-	case "collections":
-		return ec.fieldContext_ReorderCollectionsPayload_collections(ctx, field)
-	}
-	return nil, fmt.Errorf("no field named %q was found under type ReorderCollectionsPayload", field.Name)
-}
-
 func (ec *executionContext) childFields_Repository(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 	switch field.Name {
 	case "id":
@@ -5080,6 +5209,14 @@ func (ec *executionContext) childFields_ResolvedCategoryTaxonomy(ctx context.Con
 	return nil, fmt.Errorf("no field named %q was found under type ResolvedCategoryTaxonomy", field.Name)
 }
 
+func (ec *executionContext) childFields_ResolvedCollectionDefinition(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+	switch field.Name {
+	case "memberCount":
+		return ec.fieldContext_ResolvedCollectionDefinition_memberCount(ctx, field)
+	}
+	return nil, fmt.Errorf("no field named %q was found under type ResolvedCollectionDefinition", field.Name)
+}
+
 func (ec *executionContext) childFields_ResolvedFileDefinition(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 	switch field.Name {
 	case "name":
@@ -5134,8 +5271,6 @@ func (ec *executionContext) childFields_UpdateCategoryPayload(ctx context.Contex
 
 func (ec *executionContext) childFields_UpdateCollectionPayload(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 	switch field.Name {
-	case "clientMutationId":
-		return ec.fieldContext_UpdateCollectionPayload_clientMutationId(ctx, field)
 	case "collection":
 		return ec.fieldContext_UpdateCollectionPayload_collection(ctx, field)
 	case "conflict":

--- a/gitstore-api/internal/graph/generated/schema.generated.go
+++ b/gitstore-api/internal/graph/generated/schema.generated.go
@@ -33,7 +33,6 @@ type MutationResolver interface {
 	CreateCollection(ctx context.Context, input model.CreateCollectionInput) (*model.CreateCollectionPayload, error)
 	UpdateCollection(ctx context.Context, input model.UpdateCollectionInput) (*model.UpdateCollectionPayload, error)
 	DeleteCollection(ctx context.Context, input model.DeleteCollectionInput) (*model.DeleteCollectionPayload, error)
-	ReorderCollections(ctx context.Context, input model.ReorderCollectionsInput) (*model.ReorderCollectionsPayload, error)
 	CreateNamespace(ctx context.Context, input model.CreateNamespaceInput) (*model.CreateNamespacePayload, error)
 	DeleteNamespace(ctx context.Context, input model.DeleteNamespaceInput) (*model.DeleteNamespacePayload, error)
 	CreateRepository(ctx context.Context, input model.CreateRepositoryInput) (*model.CreateRepositoryPayload, error)
@@ -48,7 +47,7 @@ type QueryResolver interface {
 	Category(ctx context.Context, by model.CategoryBy) (*model.Category, error)
 	Categories(ctx context.Context, first *int32, after *string, last *int32, before *string) (*model.CategoryConnection, error)
 	Collection(ctx context.Context, by model.CollectionBy) (*model.Collection, error)
-	Collections(ctx context.Context, first *int32, after *string, last *int32, before *string) (*model.CollectionConnection, error)
+	Collections(ctx context.Context, namespace string, first *int32, after *string, last *int32, before *string) (*model.CollectionConnection, error)
 	Namespace(ctx context.Context, by model.NamespaceBy) (*model.Namespace, error)
 	Namespaces(ctx context.Context, first *int32, after *string, last *int32, before *string) (*model.NamespaceConnection, error)
 	Product(ctx context.Context, by model.ProductBy) (*model.Product, error)
@@ -257,20 +256,6 @@ func (ec *executionContext) field_Mutation_reorderCategories_args(ctx context.Co
 	return args, nil
 }
 
-func (ec *executionContext) field_Mutation_reorderCollections_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
-	var err error
-	args := map[string]any{}
-	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "input",
-		func(ctx context.Context, v any) (model.ReorderCollectionsInput, error) {
-			return ec.unmarshalNReorderCollectionsInput2githubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐReorderCollectionsInput(ctx, v)
-		})
-	if err != nil {
-		return nil, err
-	}
-	args["input"] = arg0
-	return args, nil
-}
-
 func (ec *executionContext) field_Mutation_transferRepository_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -396,38 +381,46 @@ func (ec *executionContext) field_Query_collection_args(ctx context.Context, raw
 func (ec *executionContext) field_Query_collections_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
-	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "first",
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "namespace",
+		func(ctx context.Context, v any) (string, error) {
+			return ec.unmarshalNString2string(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["namespace"] = arg0
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "first",
 		func(ctx context.Context, v any) (*int32, error) {
 			return ec.unmarshalOInt2ᚖint32(ctx, v)
 		})
 	if err != nil {
 		return nil, err
 	}
-	args["first"] = arg0
-	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "after",
+	args["first"] = arg1
+	arg2, err := graphql.ProcessArgField(ctx, rawArgs, "after",
 		func(ctx context.Context, v any) (*string, error) {
 			return ec.unmarshalOString2ᚖstring(ctx, v)
 		})
 	if err != nil {
 		return nil, err
 	}
-	args["after"] = arg1
-	arg2, err := graphql.ProcessArgField(ctx, rawArgs, "last",
+	args["after"] = arg2
+	arg3, err := graphql.ProcessArgField(ctx, rawArgs, "last",
 		func(ctx context.Context, v any) (*int32, error) {
 			return ec.unmarshalOInt2ᚖint32(ctx, v)
 		})
 	if err != nil {
 		return nil, err
 	}
-	args["last"] = arg2
-	arg3, err := graphql.ProcessArgField(ctx, rawArgs, "before",
+	args["last"] = arg3
+	arg4, err := graphql.ProcessArgField(ctx, rawArgs, "before",
 		func(ctx context.Context, v any) (*string, error) {
 			return ec.unmarshalOString2ᚖstring(ctx, v)
 		})
 	if err != nil {
 		return nil, err
 	}
-	args["before"] = arg3
+	args["before"] = arg4
 	return args, nil
 }
 
@@ -1123,50 +1116,6 @@ func (ec *executionContext) fieldContext_Mutation_deleteCollection(ctx context.C
 	return fc, nil
 }
 
-func (ec *executionContext) _Mutation_reorderCollections(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_Mutation_reorderCollections(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			fc := graphql.GetFieldContext(ctx)
-			return ec.Resolvers.Mutation().ReorderCollections(ctx, fc.Args["input"].(model.ReorderCollectionsInput))
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *model.ReorderCollectionsPayload) graphql.Marshaler {
-			return ec.marshalNReorderCollectionsPayload2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐReorderCollectionsPayload(ctx, selections, v)
-		},
-		true,
-		true,
-	)
-}
-func (ec *executionContext) fieldContext_Mutation_reorderCollections(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Mutation",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.childFields_ReorderCollectionsPayload(ctx, field)
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Mutation_reorderCollections_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return fc, err
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _Mutation_createNamespace(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -1785,7 +1734,7 @@ func (ec *executionContext) _Query_collections(ctx context.Context, field graphq
 		},
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.Resolvers.Query().Collections(ctx, fc.Args["first"].(*int32), fc.Args["after"].(*string), fc.Args["last"].(*int32), fc.Args["before"].(*string))
+			return ec.Resolvers.Query().Collections(ctx, fc.Args["namespace"].(string), fc.Args["first"].(*int32), fc.Args["after"].(*string), fc.Args["last"].(*int32), fc.Args["before"].(*string))
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v *model.CollectionConnection) graphql.Marshaler {
@@ -2248,7 +2197,7 @@ func (ec *executionContext) unmarshalInputCollectionBy(ctx context.Context, obj 
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "slug"}
+	fieldsInOrder := [...]string{"id", "namespacePath"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -2262,13 +2211,50 @@ func (ec *executionContext) unmarshalInputCollectionBy(ctx context.Context, obj 
 				return it, err
 			}
 			it.ID = data
-		case "slug":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("slug"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+		case "namespacePath":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("namespacePath"))
+			data, err := ec.unmarshalOCollectionNamespacePath2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐCollectionNamespacePath(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.Slug = data
+			it.NamespacePath = data
+		}
+	}
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputCollectionNamespacePath(ctx context.Context, obj any) (model.CollectionNamespacePath, error) {
+	var it model.CollectionNamespacePath
+	if obj == nil {
+		return it, nil
+	}
+
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"namespace", "name"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "namespace":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("namespace"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Namespace = data
+		case "name":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Name = data
 		}
 	}
 	return it, nil
@@ -2496,13 +2482,6 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "deleteCollection":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_deleteCollection(ctx, field)
-			})
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "reorderCollections":
-			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._Mutation_reorderCollections(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
@@ -3014,6 +2993,14 @@ func (ec *executionContext) unmarshalOCategoryNamespacePath2ᚖgithubᚗcomᚋgi
 		return nil, nil
 	}
 	res, err := ec.unmarshalInputCategoryNamespacePath(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOCollectionNamespacePath2ᚖgithubᚗcomᚋgitstoreᚑdevᚋgitstoreᚋapiᚋinternalᚋgraphᚋmodelᚐCollectionNamespacePath(ctx context.Context, v any) (*model.CollectionNamespacePath, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputCollectionNamespacePath(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 

--- a/gitstore-api/internal/graph/helpers.go
+++ b/gitstore-api/internal/graph/helpers.go
@@ -12,20 +12,6 @@ import (
 
 // Helper functions for GraphQL resolvers
 
-func stringOrDefault(s *string, def string) string {
-	if s != nil {
-		return *s
-	}
-	return def
-}
-
-func intOrDefault(i *int32, def int32) int32 {
-	if i != nil {
-		return *i
-	}
-	return def
-}
-
 // namespaceFromContext extracts the namespace from the request context.
 // Falls back to an empty string (which lists across all namespaces in memdb).
 func namespaceFromContext(_ context.Context) string {

--- a/gitstore-api/internal/graph/helpers.go
+++ b/gitstore-api/internal/graph/helpers.go
@@ -44,7 +44,7 @@ func callerUsernameOrAnon(ctx context.Context, r *mutationResolver) string {
 func (r *Resolver) getCatalogStats(ctx context.Context) *model.CatalogStats {
 	products, _ := r.service.GetProducts(ctx, "", datastore.PageParams{First: 1})
 	categories, _ := r.service.GetCategoryTaxonomies(ctx, "", datastore.PageParams{First: 1})
-	collections, _ := r.service.GetCollections(ctx, datastore.PageParams{First: 1})
+	collections, _ := r.service.GetCollections(ctx, "", datastore.PageParams{First: 1})
 	var pc, cc, colc int32
 	if products != nil {
 		pc = products.TotalCount

--- a/gitstore-api/internal/graph/model/models_gen.go
+++ b/gitstore-api/internal/graph/model/models_gen.go
@@ -40,30 +40,19 @@ type CatalogObjectReference struct {
 	FieldPath       *string `json:"fieldPath,omitempty"`
 }
 
-// Catalog statistics
 type CatalogStats struct {
-	// Total products
-	ProductCount int32 `json:"productCount"`
-	// Total categories
-	CategoryCount int32 `json:"categoryCount"`
-	// Total collections
-	CollectionCount int32 `json:"collectionCount"`
-	// Number of orphaned product references
+	ProductCount       int32 `json:"productCount"`
+	CategoryCount      int32 `json:"categoryCount"`
+	CollectionCount    int32 `json:"collectionCount"`
 	OrphanedReferences int32 `json:"orphanedReferences"`
 }
 
-// Catalog version information
 type CatalogVersion struct {
-	// Version tag (e.g., v1.0.0)
-	Tag string `json:"tag"`
-	// Commit SHA
-	Commit string `json:"commit"`
-	// Release timestamp
-	PublishedAt time.Time `json:"publishedAt"`
-	// Release message
-	Message *string `json:"message,omitempty"`
-	// Statistics
-	Stats *CatalogStats `json:"stats"`
+	Tag         string        `json:"tag"`
+	Commit      string        `json:"commit"`
+	PublishedAt time.Time     `json:"publishedAt"`
+	Message     *string       `json:"message,omitempty"`
+	Stats       *CatalogStats `json:"stats"`
 }
 
 // Category represents a hierarchical classification system for products.
@@ -191,26 +180,25 @@ type CategoryTaxonomyStatus struct {
 	Resolved            *ResolvedCategoryTaxonomy `json:"resolved,omitempty"`
 }
 
-// Collection represents a curated grouping of products (flat, non-hierarchical)
+// A Collection is a namespace-scoped catalog resource that groups products via
+// a declarative label selector. Defined by git push; mutations are not supported.
 type Collection struct {
-	// Globally unique identifier (format: coll_[base62])
+	// Globally unique Relay ID (encodes the collection UID).
 	ID string `json:"id"`
-	// Collection display name
-	Name string `json:"name"`
-	// URL-friendly slug (unique)
-	Slug string `json:"slug"`
-	// Display order for collection listing
-	DisplayOrder int32 `json:"displayOrder"`
-	// Products in this collection
-	Products *ProductConnection `json:"products"`
-	// Markdown body content (collection description with rich formatting)
+	// API version. Always catalog.gitstore.dev/v1beta1.
+	APIVersion *string `json:"apiVersion,omitempty"`
+	// Resource kind. Always Collection.
+	Kind *string `json:"kind,omitempty"`
+	// System-managed identity and metadata.
+	Metadata *CollectionObjectMeta `json:"metadata"`
+	// Author-controlled specification: title, selector, and media.
+	Spec *CollectionSpec `json:"spec"`
+	// System-computed status: conditions and member count.
+	Status *CollectionStatus `json:"status,omitempty"`
+	// Markdown body content (collection description).
 	Body *string `json:"body,omitempty"`
-	// Creation timestamp
-	CreatedAt time.Time `json:"createdAt"`
-	// Last modification timestamp
-	UpdatedAt time.Time `json:"updatedAt"`
-	// Number of products in this collection
-	ProductCount int32 `json:"productCount"`
+	// Paginated connection of products matched by this collection's label selector.
+	Products *ProductConnection `json:"products"`
 }
 
 func (Collection) IsNode() {}
@@ -220,40 +208,88 @@ func (this Collection) GetID() string { return this.ID }
 
 // Selector for looking up a collection by exactly one unique key.
 type CollectionBy struct {
-	ID   *string `json:"id,omitempty"`
-	Slug *string `json:"slug,omitempty"`
+	// Look up by globally unique Relay ID (encodes the collection UID).
+	ID *string `json:"id,omitempty"`
+	// Look up by namespace identifier + collection name.
+	NamespacePath *CollectionNamespacePath `json:"namespacePath,omitempty"`
 }
 
-// Connection type for paginated collections (Relay pattern)
+// A single status condition on a Collection resource.
+type CollectionCondition struct {
+	Type               string  `json:"type"`
+	Status             string  `json:"status"`
+	ObservedGeneration *int32  `json:"observedGeneration,omitempty"`
+	Reason             *string `json:"reason,omitempty"`
+	Message            *string `json:"message,omitempty"`
+}
+
+// Paginated connection for collections (Relay pattern).
 type CollectionConnection struct {
-	// List of collection edges
-	Edges []*CollectionEdge `json:"edges"`
-	// Pagination information
-	PageInfo *PageInfo `json:"pageInfo"`
-	// Total count of collections
-	TotalCount int32 `json:"totalCount"`
+	Edges      []*CollectionEdge `json:"edges"`
+	PageInfo   *PageInfo         `json:"pageInfo"`
+	TotalCount int32             `json:"totalCount"`
 }
 
-// Edge type for Collection connection (Relay pattern)
+// Edge type for Collection connection (Relay pattern).
 type CollectionEdge struct {
-	// Cursor for pagination
-	Cursor string `json:"cursor"`
-	// The collection node
-	Node *Collection `json:"node"`
+	Cursor string      `json:"cursor"`
+	Node   *Collection `json:"node"`
 }
 
-// Optimistic lock conflict for collection
+// Composite selector: namespace identifier + collection name.
+type CollectionNamespacePath struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+}
+
+// System-managed identity fields for a Collection resource.
+// All fields are read-only; they are set and updated by the system.
+type CollectionObjectMeta struct {
+	// DNS-label name, unique within the namespace.
+	Name string `json:"name"`
+	// Namespace identifier the collection belongs to.
+	Namespace *string `json:"namespace,omitempty"`
+	// Globally unique system-generated identifier.
+	UID string `json:"uid"`
+	// Opaque concurrency token. Changes on every spec update.
+	ResourceVersion string `json:"resourceVersion"`
+	// Monotonically increasing counter incremented on every spec change.
+	Generation int32 `json:"generation"`
+	// Timestamp of first admission.
+	CreationTimestamp time.Time `json:"creationTimestamp"`
+	// Git revision of the last successful push (e.g. main@sha1:abc123).
+	Revision *string `json:"revision,omitempty"`
+	// Author-supplied key-value labels.
+	Labels []*KeyValuePair `json:"labels"`
+	// Author-supplied annotations.
+	Annotations []*KeyValuePair `json:"annotations"`
+}
+
 type CollectionOptimisticLockConflict struct {
-	// TODO: Should this be a datetime?
-	// Current version in database
-	CurrentVersion time.Time `json:"currentVersion"`
-	// TODO: Should this be a datetime?
-	// Version client attempted to update
-	AttemptedVersion time.Time `json:"attemptedVersion"`
-	// Current state of the collection
 	Current *Collection `json:"current"`
-	// Diff between current and attempted
-	Diff string `json:"diff"`
+}
+
+// Author-controlled specification for a Collection resource.
+type CollectionSpec struct {
+	// Human-readable display title for the collection.
+	Title string `json:"title"`
+	// Label selector that determines collection membership.
+	// An absent or empty selector yields zero members.
+	Selector *LabelSelector `json:"selector,omitempty"`
+	// Media slots referencing File resources.
+	Media []*MediaDefinition `json:"media"`
+}
+
+// System-computed status for a Collection resource.
+type CollectionStatus struct {
+	// Generation of the spec that this status was computed from.
+	ObservedGeneration int32 `json:"observedGeneration"`
+	// Git revision of the last successfully admitted push.
+	LastAppliedRevision *string `json:"lastAppliedRevision,omitempty"`
+	// Condition set written at admission time.
+	Conditions []*CollectionCondition `json:"conditions"`
+	// Resolved membership snapshot (cached hint; collection.products is authoritative).
+	Resolved *ResolvedCollectionDefinition `json:"resolved,omitempty"`
 }
 
 // Input for creating a category
@@ -280,27 +316,11 @@ type CreateCategoryPayload struct {
 	Category *Category `json:"category,omitempty"`
 }
 
-// Input for creating a collection
 type CreateCollectionInput struct {
-	// Client mutation ID (Relay pattern)
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
-	// Collection name
 	Name string `json:"name"`
-	// URL-friendly slug (must be unique)
-	Slug string `json:"slug"`
-	// Display order
-	DisplayOrder *int32 `json:"displayOrder,omitempty"`
-	// Product IDs to include
-	ProductIds []string `json:"productIds,omitempty"`
-	// Markdown body content
-	Body *string `json:"body,omitempty"`
 }
 
-// Payload for createCollection mutation
 type CreateCollectionPayload struct {
-	// Client mutation ID (Relay pattern)
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
-	// The created collection
 	Collection *Collection `json:"collection,omitempty"`
 }
 
@@ -363,19 +383,11 @@ type DeleteCategoryPayload struct {
 	OrphanedProductIds []string `json:"orphanedProductIds,omitempty"`
 }
 
-// Input for deleting a collection
 type DeleteCollectionInput struct {
-	// Client mutation ID (Relay pattern)
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
-	// Collection ID to delete
 	ID string `json:"id"`
 }
 
-// Payload for deleteCollection mutation
 type DeleteCollectionPayload struct {
-	// Client mutation ID (Relay pattern)
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
-	// Deleted collection ID
 	DeletedCollectionID *string `json:"deletedCollectionId,omitempty"`
 }
 
@@ -417,6 +429,26 @@ type FileReference struct {
 type KeyValuePair struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
+}
+
+// A label selector that matches products by their labels.
+// matchLabels and matchExpressions are combined with logical AND.
+// An empty selector (all fields absent) matches nothing.
+type LabelSelector struct {
+	// Exact key-value pairs that must all be present on a product's labels.
+	MatchLabels []*KeyValuePair `json:"matchLabels"`
+	// Set-based requirements. All entries must be satisfied.
+	MatchExpressions []*LabelSelectorRequirement `json:"matchExpressions"`
+}
+
+// A single label selector expression with set-based semantics.
+type LabelSelectorRequirement struct {
+	// The label key this requirement applies to.
+	Key string `json:"key"`
+	// The operator: IN, NOT_IN, EXISTS, or DOES_NOT_EXIST.
+	Operator LabelSelectorOperator `json:"operator"`
+	// The set of values. Required for IN and NOT_IN; must be empty for EXISTS and DOES_NOT_EXIST.
+	Values []string `json:"values"`
 }
 
 // Login mutation input (Relay pattern)
@@ -629,22 +661,15 @@ type ProductStatus struct {
 	Resolved            *ResolvedProductDefinition `json:"resolved,omitempty"`
 }
 
-// Input for publishing catalog changes
 type PublishCatalogInput struct {
-	// Client mutation ID (Relay pattern)
 	ClientMutationID *string `json:"clientMutationId,omitempty"`
-	// Release version tag (e.g., v1.0.0)
-	Version string `json:"version"`
-	// Release notes/commit message
-	Message string `json:"message"`
+	Version          string  `json:"version"`
+	Message          string  `json:"message"`
 }
 
-// Payload for publishCatalog mutation
 type PublishCatalogPayload struct {
-	// Client mutation ID (Relay pattern)
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
-	// New catalog version
-	CatalogVersion *CatalogVersion `json:"catalogVersion,omitempty"`
+	ClientMutationID *string         `json:"clientMutationId,omitempty"`
+	CatalogVersion   *CatalogVersion `json:"catalogVersion,omitempty"`
 }
 
 type Query struct {
@@ -696,22 +721,6 @@ type ReorderCategoriesPayload struct {
 	ClientMutationID *string `json:"clientMutationId,omitempty"`
 	// Updated categories
 	Categories []*Category `json:"categories,omitempty"`
-}
-
-// Input for reordering collections (drag-and-drop)
-type ReorderCollectionsInput struct {
-	// Client mutation ID (Relay pattern)
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
-	// Ordered list of collection IDs
-	OrderedIds []string `json:"orderedIds"`
-}
-
-// Payload for reorderCollections mutation
-type ReorderCollectionsPayload struct {
-	// Client mutation ID (Relay pattern)
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
-	// Updated collections
-	Collections []*Collection `json:"collections,omitempty"`
 }
 
 // A git repository. Has a stable internal identity (id) that is independent of
@@ -784,6 +793,12 @@ type ResolvedCategoryTaxonomy struct {
 	ProductCount int32  `json:"productCount"`
 }
 
+// Resolved membership information cached at last admission.
+type ResolvedCollectionDefinition struct {
+	// Cached count of matching products at last admission.
+	MemberCount int32 `json:"memberCount"`
+}
+
 type ResolvedFileDefinition struct {
 	Name        string  `json:"name"`
 	URL         string  `json:"url"`
@@ -843,35 +858,13 @@ type UpdateCategoryPayload struct {
 	Conflict *CategoryOptimisticLockConflict `json:"conflict,omitempty"`
 }
 
-// Input for updating a collection
 type UpdateCollectionInput struct {
-	// Client mutation ID (Relay pattern)
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
-	// Collection ID to update
 	ID string `json:"id"`
-	// New name
-	Name *string `json:"name,omitempty"`
-	// New slug
-	Slug *string `json:"slug,omitempty"`
-	// New display order
-	DisplayOrder *int32 `json:"displayOrder,omitempty"`
-	// New product IDs (replaces all)
-	ProductIds []string `json:"productIds,omitempty"`
-	// New body content
-	Body *string `json:"body,omitempty"`
-	// TODO: Should this be a datatime?
-	// Version for optimistic locking
-	Version time.Time `json:"version"`
 }
 
-// Payload for updateCollection mutation
 type UpdateCollectionPayload struct {
-	// Client mutation ID (Relay pattern)
-	ClientMutationID *string `json:"clientMutationId,omitempty"`
-	// The updated collection
-	Collection *Collection `json:"collection,omitempty"`
-	// Conflict information (if optimistic lock failed)
-	Conflict *CollectionOptimisticLockConflict `json:"conflict,omitempty"`
+	Collection *Collection                       `json:"collection,omitempty"`
+	Conflict   *CollectionOptimisticLockConflict `json:"conflict,omitempty"`
 }
 
 // Authenticated user information
@@ -1000,6 +993,66 @@ func (e *InventoryStatus) UnmarshalJSON(b []byte) error {
 }
 
 func (e InventoryStatus) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
+}
+
+// Operators supported in a LabelSelectorRequirement.
+type LabelSelectorOperator string
+
+const (
+	LabelSelectorOperatorIn           LabelSelectorOperator = "IN"
+	LabelSelectorOperatorNotIn        LabelSelectorOperator = "NOT_IN"
+	LabelSelectorOperatorExists       LabelSelectorOperator = "EXISTS"
+	LabelSelectorOperatorDoesNotExist LabelSelectorOperator = "DOES_NOT_EXIST"
+)
+
+var AllLabelSelectorOperator = []LabelSelectorOperator{
+	LabelSelectorOperatorIn,
+	LabelSelectorOperatorNotIn,
+	LabelSelectorOperatorExists,
+	LabelSelectorOperatorDoesNotExist,
+}
+
+func (e LabelSelectorOperator) IsValid() bool {
+	switch e {
+	case LabelSelectorOperatorIn, LabelSelectorOperatorNotIn, LabelSelectorOperatorExists, LabelSelectorOperatorDoesNotExist:
+		return true
+	}
+	return false
+}
+
+func (e LabelSelectorOperator) String() string {
+	return string(e)
+}
+
+func (e *LabelSelectorOperator) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = LabelSelectorOperator(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid LabelSelectorOperator", str)
+	}
+	return nil
+}
+
+func (e LabelSelectorOperator) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+func (e *LabelSelectorOperator) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e LabelSelectorOperator) MarshalJSON() ([]byte, error) {
 	var buf bytes.Buffer
 	e.MarshalGQL(&buf)
 	return buf.Bytes(), nil

--- a/gitstore-api/internal/graph/oneof_lookup_validation_test.go
+++ b/gitstore-api/internal/graph/oneof_lookup_validation_test.go
@@ -58,7 +58,7 @@ func TestLookupOneOfSelectorsValidateExactlyOneKey(t *testing.T) {
 		natural   string
 		selection string
 	}{
-		{field: "collection", natural: `slug: "collection-1"`, selection: "id"},
+		{field: "collection", natural: `namespacePath: {namespace: "my-store", name: "collection-1"}`, selection: "id"},
 		{field: "namespace", natural: `identifier: "namespace-1"`, selection: "id"},
 	}
 

--- a/gitstore-api/internal/graph/pagination.go
+++ b/gitstore-api/internal/graph/pagination.go
@@ -80,14 +80,14 @@ func BuildCollectionConnection(result *datastore.PageResult[datastore.Collection
 	edges := make([]*model.CollectionEdge, len(result.Items))
 	for i, c := range result.Items {
 		edges[i] = &model.CollectionEdge{
-			Cursor: EncodeKeysetCursor(c.CreatedAt, c.ID),
+			Cursor: EncodeKeysetCursor(c.CreationTimestamp, c.UID),
 			Node:   DatastoreCollectionToGraphQL(c),
 		}
 	}
 	return &model.CollectionConnection{
 		Edges:      edges,
 		TotalCount: result.TotalCount,
-		PageInfo:   buildPageInfo(result, func(c *datastore.Collection) string { return EncodeKeysetCursor(c.CreatedAt, c.ID) }),
+		PageInfo:   buildPageInfo(result, func(c *datastore.Collection) string { return EncodeKeysetCursor(c.CreationTimestamp, c.UID) }),
 	}
 }
 

--- a/gitstore-api/internal/graph/pagination.go
+++ b/gitstore-api/internal/graph/pagination.go
@@ -43,6 +43,70 @@ func buildPageInfo[T any](result *datastore.PageResult[T], cursorFn func(*T) str
 	return pi
 }
 
+// BuildProductConnectionFromSlice builds a paginated ProductConnection from a flat slice.
+// It applies cursor-based keyset pagination (after/before) and honours first/last limits.
+// Products must be pre-sorted by (CreationTimestamp DESC, UID DESC) for cursor seeks to be stable.
+func BuildProductConnectionFromSlice(products []*datastore.Product, params datastore.PageParams) *model.ProductConnection {
+	// Apply cursor filter
+	if params.After != "" {
+		if c, err := DecodeKeysetCursor(params.After); err == nil {
+			for i, p := range products {
+				if p.CreationTimestamp.Equal(c.CreatedAt) && p.UID == c.ID {
+					products = products[i+1:]
+					break
+				}
+			}
+		}
+	} else if params.Before != "" {
+		if c, err := DecodeKeysetCursor(params.Before); err == nil {
+			for i, p := range products {
+				if p.CreationTimestamp.Equal(c.CreatedAt) && p.UID == c.ID {
+					products = products[:i]
+					break
+				}
+			}
+		}
+	}
+
+	totalFiltered := len(products)
+	limit := params.Limit()
+	hasNext, hasPrevious := false, false
+
+	if params.Last > 0 {
+		if len(products) > limit {
+			products = products[len(products)-limit:]
+			hasPrevious = true
+		}
+		hasNext = params.Before != ""
+	} else {
+		if len(products) > limit {
+			products = products[:limit]
+			hasNext = true
+		}
+		hasPrevious = params.After != ""
+	}
+
+	edges := make([]*model.ProductEdge, len(products))
+	for i, p := range products {
+		edges[i] = &model.ProductEdge{
+			Cursor: EncodeKeysetCursor(p.CreationTimestamp, p.UID),
+			Node:   DatastoreProductToGraphQL(p),
+		}
+	}
+	pi := &model.PageInfo{HasNextPage: hasNext, HasPreviousPage: hasPrevious}
+	if len(products) > 0 {
+		sc := EncodeKeysetCursor(products[0].CreationTimestamp, products[0].UID)
+		ec := EncodeKeysetCursor(products[len(products)-1].CreationTimestamp, products[len(products)-1].UID)
+		pi.StartCursor = &sc
+		pi.EndCursor = &ec
+	}
+	return &model.ProductConnection{
+		Edges:      edges,
+		PageInfo:   pi,
+		TotalCount: int32(totalFiltered),
+	}
+}
+
 // BuildProductConnection converts a PageResult[Product] into a GraphQL ProductConnection.
 func BuildProductConnection(result *datastore.PageResult[datastore.Product]) *model.ProductConnection {
 	edges := make([]*model.ProductEdge, len(result.Items))

--- a/gitstore-api/internal/graph/query_helpers.go
+++ b/gitstore-api/internal/graph/query_helpers.go
@@ -24,7 +24,7 @@ func (r *queryResolver) resolveNode(ctx context.Context, kind, rawID string) (mo
 		}
 		return DatastoreCategoryTaxonomyToGraphQL(category), nil
 	case nodeKindCollection:
-		collection, err := r.service.GetCollectionByID(ctx, rawID)
+		collection, err := r.service.GetCollectionByUID(ctx, rawID)
 		if err != nil {
 			return nil, nil
 		}

--- a/gitstore-api/internal/graph/resolver_global_id_test.go
+++ b/gitstore-api/internal/graph/resolver_global_id_test.go
@@ -133,11 +133,12 @@ func seedGlobalIDTestData(t *testing.T, ctx context.Context, store datastore.Dat
 		CreationTimestamp: now,
 	}))
 	require.NoError(t, store.CreateCollection(ctx, &datastore.Collection{
-		ID:        globalIDTestCollectionID,
-		Name:      "Collection 1",
-		Slug:      "collection-1",
-		CreatedAt: now,
-		UpdatedAt: now,
+		UID:               globalIDTestCollectionID,
+		Namespace:         "test-store",
+		Name:              "collection-1",
+		APIVersion:        "catalog.gitstore.dev/v1beta1",
+		Kind:              "Collection",
+		CreationTimestamp: now,
 	}))
 	require.NoError(t, store.CreateProduct(ctx, &datastore.Product{
 		UID:               globalIDTestProductUID,

--- a/gitstore-api/internal/graph/service.go
+++ b/gitstore-api/internal/graph/service.go
@@ -175,9 +175,9 @@ func (s *Service) DeleteProduct(ctx context.Context, uid string) error {
 // This is a transitional method; collection admission via git push is the primary path.
 func (s *Service) CreateCollection(ctx context.Context, input map[string]interface{}) (*datastore.Collection, error) {
 	c := &datastore.Collection{
-		UID:       uuid.New().String(),
-		Name:      getStringOrEmpty(input, "name"),
-		Body:      getStringOrEmpty(input, "body"),
+		UID:  uuid.New().String(),
+		Name: getStringOrEmpty(input, "name"),
+		Body: getStringOrEmpty(input, "body"),
 	}
 	if err := s.store.CreateCollection(ctx, c); err != nil {
 		return nil, fmt.Errorf("failed to create collection: %w", err)

--- a/gitstore-api/internal/graph/service.go
+++ b/gitstore-api/internal/graph/service.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gitstore-dev/gitstore/api/internal/catalog"
 	"github.com/gitstore-dev/gitstore/api/internal/datastore"
 	"github.com/gitstore-dev/gitstore/api/internal/gitclient"
 	"github.com/gitstore-dev/gitstore/api/internal/graph/model"
@@ -129,31 +130,36 @@ func (s *Service) GetCategoryTaxonomyByName(ctx context.Context, namespace, name
 	return c, nil
 }
 
-// GetCollections returns paginated collections.
-func (s *Service) GetCollections(ctx context.Context, params datastore.PageParams) (*datastore.PageResult[datastore.Collection], error) {
-	result, err := s.store.ListCollections(ctx, params)
+// GetCollections returns paginated collections for a namespace.
+func (s *Service) GetCollections(ctx context.Context, namespace string, params datastore.PageParams) (*datastore.PageResult[datastore.Collection], error) {
+	result, err := s.store.ListCollections(ctx, namespace, params)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list collections: %w", err)
 	}
 	return result, nil
 }
 
-// GetCollectionByID returns a collection by ID.
-func (s *Service) GetCollectionByID(ctx context.Context, id string) (*datastore.Collection, error) {
-	c, err := s.store.GetCollection(ctx, id)
+// GetCollectionByUID returns a collection by UID.
+func (s *Service) GetCollectionByUID(ctx context.Context, uid string) (*datastore.Collection, error) {
+	c, err := s.store.GetCollection(ctx, uid)
 	if err != nil {
-		return nil, fmt.Errorf("collection not found: %s", id)
+		return nil, fmt.Errorf("collection not found: %s", uid)
 	}
 	return c, nil
 }
 
-// GetCollectionBySlug returns a collection by slug.
-func (s *Service) GetCollectionBySlug(ctx context.Context, slug string) (*datastore.Collection, error) {
-	c, err := s.store.GetCollectionBySlug(ctx, slug)
+// GetCollectionByName returns a collection by namespace/name.
+func (s *Service) GetCollectionByName(ctx context.Context, namespace, name string) (*datastore.Collection, error) {
+	c, err := s.store.GetCollectionByName(ctx, namespace, name)
 	if err != nil {
-		return nil, fmt.Errorf("collection not found with slug: %s", slug)
+		return nil, fmt.Errorf("collection not found: %s/%s", namespace, name)
 	}
 	return c, nil
+}
+
+// ListProductsByLabelSelector returns products in a namespace matching the label selector.
+func (s *Service) ListProductsByLabelSelector(ctx context.Context, namespace string, selector catalog.LabelSelector) ([]*datastore.Product, error) {
+	return s.store.ListProductsByLabelSelector(ctx, namespace, selector)
 }
 
 // DeleteProduct deletes a product from the datastore by UID.
@@ -166,18 +172,12 @@ func (s *Service) DeleteProduct(ctx context.Context, uid string) error {
 }
 
 // CreateCollection creates a new collection in the datastore.
+// This is a transitional method; collection admission via git push is the primary path.
 func (s *Service) CreateCollection(ctx context.Context, input map[string]interface{}) (*datastore.Collection, error) {
-	now := time.Now()
 	c := &datastore.Collection{
-		ID:        uuid.New().String(),
+		UID:       uuid.New().String(),
 		Name:      getStringOrEmpty(input, "name"),
-		Slug:      getStringOrEmpty(input, "slug"),
 		Body:      getStringOrEmpty(input, "body"),
-		CreatedAt: now,
-		UpdatedAt: now,
-	}
-	if order, ok := input["displayOrder"].(int); ok {
-		c.DisplayOrder = order
 	}
 	if err := s.store.CreateCollection(ctx, c); err != nil {
 		return nil, fmt.Errorf("failed to create collection: %w", err)
@@ -186,34 +186,22 @@ func (s *Service) CreateCollection(ctx context.Context, input map[string]interfa
 }
 
 // UpdateCollection updates an existing collection.
-func (s *Service) UpdateCollection(ctx context.Context, id string, input map[string]interface{}) (*datastore.Collection, error) {
-	existing, err := s.store.GetCollection(ctx, id)
+func (s *Service) UpdateCollection(ctx context.Context, uid string, input map[string]interface{}) (*datastore.Collection, error) {
+	existing, err := s.store.GetCollection(ctx, uid)
 	if err != nil {
-		return nil, fmt.Errorf("collection not found: %s", id)
+		return nil, fmt.Errorf("collection not found: %s", uid)
 	}
 	c := *existing
-	c.UpdatedAt = time.Now()
 	if name, ok := input["name"].(string); ok {
 		c.Name = name
 	}
-	if slug, ok := input["slug"].(string); ok {
-		c.Slug = slug
-	}
 	if body, ok := input["body"].(string); ok {
 		c.Body = body
-	}
-	if order, ok := input["displayOrder"].(int); ok {
-		c.DisplayOrder = order
 	}
 	if err := s.store.UpdateCollection(ctx, &c); err != nil {
 		return nil, fmt.Errorf("failed to update collection: %w", err)
 	}
 	return &c, nil
-}
-
-// DeleteCollection deletes a collection from the datastore.
-func (s *Service) DeleteCollection(ctx context.Context, id string) error {
-	return s.store.DeleteCollection(ctx, id)
 }
 
 // ── Namespace ─────────────────────────────────────────────────────────────────

--- a/gitstore-api/internal/validate/validator.go
+++ b/gitstore-api/internal/validate/validator.go
@@ -184,6 +184,9 @@ func ParseResource(r io.Reader) (*ParsedResource, []byte, error) {
 		if err := validateLabels(res.Metadata.Labels); err != nil {
 			errs = append(errs, err)
 		}
+		if err := validateCollectionSpec(res.Spec); err != nil {
+			errs = append(errs, err)
+		}
 		if len(errs) > 0 {
 			return nil, nil, errors.Join(errs...)
 		}
@@ -198,6 +201,21 @@ func ParseResource(r io.Reader) (*ParsedResource, []byte, error) {
 func validateCategorySpec(name string, spec catalog.CategoryTaxonomySpec) error {
 	if spec.ParentRef != nil && spec.ParentRef.Name == name {
 		return fmt.Errorf("validate: spec.parentRef.name must not reference the category itself")
+	}
+	return nil
+}
+
+// validateCollectionSpec enforces spec-level rules for Collection.
+func validateCollectionSpec(spec catalog.CollectionSpec) error {
+	if spec.TargetRef != nil && spec.TargetRef.Kind != "Product" {
+		return fmt.Errorf("validate: spec.targetRef.kind must be %q, got %q", "Product", spec.TargetRef.Kind)
+	}
+	if spec.Selector != nil {
+		for i, expr := range spec.Selector.MatchExpressions {
+			if (expr.Operator == "In" || expr.Operator == "NotIn") && len(expr.Values) == 0 {
+				return fmt.Errorf("validate: spec.selector.matchExpressions[%d]: operator %q requires at least one value", i, expr.Operator)
+			}
+		}
 	}
 	return nil
 }

--- a/gitstore-api/internal/validate/validator.go
+++ b/gitstore-api/internal/validate/validator.go
@@ -19,12 +19,13 @@ import (
 
 var validate = validator.New()
 
-// ParsedResource is the result of ParseResource; exactly one of Product or
-// CategoryTaxonomy is set, matching the Kind field.
+// ParsedResource is the result of ParseResource; exactly one of Product,
+// CategoryTaxonomy, or Collection is set, matching the Kind field.
 type ParsedResource struct {
 	Kind             string
 	Product          *catalog.ProductResource
 	CategoryTaxonomy *catalog.CategoryTaxonomyResource
+	Collection       *catalog.CollectionResource
 }
 
 // Parse reads a Markdown document, extracts the YAML frontmatter into a
@@ -169,6 +170,24 @@ func ParseResource(r io.Reader) (*ParsedResource, []byte, error) {
 			return nil, nil, errors.Join(errs...)
 		}
 		return &ParsedResource{Kind: "CategoryTaxonomy", CategoryTaxonomy: &res}, body, nil
+
+	case "Collection":
+		var res catalog.CollectionResource
+		body, err := frontmatter.Parse(bytes.NewReader(raw), &res, formats...)
+		if err != nil {
+			return nil, nil, fmt.Errorf("validate: parse frontmatter: %w", err)
+		}
+		var errs []error
+		if err := validate.Struct(res); err != nil {
+			errs = append(errs, toFriendlyError(err))
+		}
+		if err := validateLabels(res.Metadata.Labels); err != nil {
+			errs = append(errs, err)
+		}
+		if len(errs) > 0 {
+			return nil, nil, errors.Join(errs...)
+		}
+		return &ParsedResource{Kind: "Collection", Collection: &res}, body, nil
 
 	default:
 		return nil, nil, fmt.Errorf("validate: kind %q is not a recognized catalog resource type", kindProbe.Kind)

--- a/gitstore-api/tests/contract/datastore/contract_test.go
+++ b/gitstore-api/tests/contract/datastore/contract_test.go
@@ -10,9 +10,11 @@ package datastore_contract_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/gitstore-dev/gitstore/api/internal/catalog"
 	"github.com/gitstore-dev/gitstore/api/internal/datastore"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -49,14 +51,12 @@ func newCategoryTaxonomy() *datastore.CategoryTaxonomy {
 }
 
 func newCollection() *datastore.Collection {
-	now := time.Now()
-	slug := "coll-" + newID()[:8]
 	return &datastore.Collection{
-		ID:        newID(),
-		Name:      "Test Collection",
-		Slug:      slug,
-		CreatedAt: now,
-		UpdatedAt: now,
+		UID:        newID(),
+		Namespace:  "test-store",
+		Name:       "coll-" + newID()[:8],
+		APIVersion: "catalog.gitstore.dev/v1beta1",
+		Kind:       "Collection",
 	}
 }
 
@@ -268,10 +268,10 @@ func RunContractSuite(t *testing.T, ds datastore.Datastore) {
 		c := newCollection()
 		require.NoError(t, ds.CreateCollection(ctx, c))
 
-		got, err := ds.GetCollection(ctx, c.ID)
+		got, err := ds.GetCollection(ctx, c.UID)
 		require.NoError(t, err)
-		assert.Equal(t, c.ID, got.ID)
-		assert.Equal(t, c.Slug, got.Slug)
+		assert.Equal(t, c.UID, got.UID)
+		assert.Equal(t, c.Name, got.Name)
 	})
 
 	t.Run("Collection/GetNotFound", func(t *testing.T) {
@@ -279,26 +279,26 @@ func RunContractSuite(t *testing.T, ds datastore.Datastore) {
 		assert.ErrorIs(t, err, datastore.ErrNotFound)
 	})
 
-	t.Run("Collection/GetBySlug", func(t *testing.T) {
+	t.Run("Collection/GetByName", func(t *testing.T) {
 		c := newCollection()
 		require.NoError(t, ds.CreateCollection(ctx, c))
 
-		got, err := ds.GetCollectionBySlug(ctx, c.Slug)
+		got, err := ds.GetCollectionByName(ctx, c.Namespace, c.Name)
 		require.NoError(t, err)
-		assert.Equal(t, c.ID, got.ID)
+		assert.Equal(t, c.UID, got.UID)
 	})
 
-	t.Run("Collection/GetBySlugNotFound", func(t *testing.T) {
-		_, err := ds.GetCollectionBySlug(ctx, "slug-does-not-exist-"+newID()[:8])
+	t.Run("Collection/GetByNameNotFound", func(t *testing.T) {
+		_, err := ds.GetCollectionByName(ctx, "test-store", "name-does-not-exist-"+newID()[:8])
 		assert.ErrorIs(t, err, datastore.ErrNotFound)
 	})
 
-	t.Run("Collection/DuplicateSlugReturnsAlreadyExists", func(t *testing.T) {
+	t.Run("Collection/DuplicateNameReturnsAlreadyExists", func(t *testing.T) {
 		c := newCollection()
 		require.NoError(t, ds.CreateCollection(ctx, c))
 
 		c2 := newCollection()
-		c2.Slug = c.Slug
+		c2.Name = c.Name
 		err := ds.CreateCollection(ctx, c2)
 		assert.ErrorIs(t, err, datastore.ErrAlreadyExists)
 	})
@@ -307,33 +307,83 @@ func RunContractSuite(t *testing.T, ds datastore.Datastore) {
 		c := newCollection()
 		require.NoError(t, ds.CreateCollection(ctx, c))
 
-		c.Name = "Renamed"
+		c.Body = "Updated description"
 		require.NoError(t, ds.UpdateCollection(ctx, c))
 
-		got, err := ds.GetCollection(ctx, c.ID)
+		got, err := ds.GetCollection(ctx, c.UID)
 		require.NoError(t, err)
-		assert.Equal(t, "Renamed", got.Name)
+		assert.Equal(t, "Updated description", got.Body)
 	})
 
 	t.Run("Collection/UpdateNotFound", func(t *testing.T) {
 		c := newCollection()
-		c.ID = newID()
+		c.UID = newID()
 		err := ds.UpdateCollection(ctx, c)
 		assert.ErrorIs(t, err, datastore.ErrNotFound)
 	})
 
-	t.Run("Collection/Delete", func(t *testing.T) {
-		c := newCollection()
-		require.NoError(t, ds.CreateCollection(ctx, c))
-		require.NoError(t, ds.DeleteCollection(ctx, c.ID))
-
-		_, err := ds.GetCollection(ctx, c.ID)
-		assert.ErrorIs(t, err, datastore.ErrNotFound)
+	t.Run("Collection/ListByNamespace", func(t *testing.T) {
+		ns := "list-ns-" + newID()[:8]
+		for i := 0; i < 3; i++ {
+			c := newCollection()
+			c.Namespace = ns
+			c.Name = fmt.Sprintf("coll-%d-%s", i, newID()[:6])
+			require.NoError(t, ds.CreateCollection(ctx, c))
+		}
+		result, err := ds.ListCollections(ctx, ns, datastore.PageParams{First: 10})
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(result.Items), 3)
 	})
 
-	t.Run("Collection/DeleteNotFound", func(t *testing.T) {
-		err := ds.DeleteCollection(ctx, newID())
-		assert.ErrorIs(t, err, datastore.ErrNotFound)
+	// ── ListProductsByLabelSelector ───────────────────────────────────────────
+
+	t.Run("ListProductsByLabelSelector/MatchLabels", func(t *testing.T) {
+		ns := "sel-ns-" + newID()[:8]
+		p1 := newProduct()
+		p1.Namespace = ns
+		p1.Name = "sel-p1-" + newID()[:6]
+		p1.Labels = map[string]string{"env": "prod", "tier": "web"}
+		require.NoError(t, ds.CreateProduct(ctx, p1))
+
+		p2 := newProduct()
+		p2.Namespace = ns
+		p2.Name = "sel-p2-" + newID()[:6]
+		p2.Labels = map[string]string{"env": "staging"}
+		require.NoError(t, ds.CreateProduct(ctx, p2))
+
+		sel := catalog.LabelSelector{MatchLabels: map[string]string{"env": "prod"}}
+		result, err := ds.ListProductsByLabelSelector(ctx, ns, sel)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, p1.UID, result[0].UID)
+	})
+
+	t.Run("ListProductsByLabelSelector/NoMatch", func(t *testing.T) {
+		ns := "sel-nomatch-" + newID()[:8]
+		p := newProduct()
+		p.Namespace = ns
+		p.Name = "product-" + newID()[:6]
+		p.Labels = map[string]string{"env": "dev"}
+		require.NoError(t, ds.CreateProduct(ctx, p))
+
+		sel := catalog.LabelSelector{MatchLabels: map[string]string{"env": "prod"}}
+		result, err := ds.ListProductsByLabelSelector(ctx, ns, sel)
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	t.Run("ListProductsByLabelSelector/EmptySelector", func(t *testing.T) {
+		ns := "sel-empty-" + newID()[:8]
+		p := newProduct()
+		p.Namespace = ns
+		p.Name = "product-" + newID()[:6]
+		p.Labels = map[string]string{"env": "prod"}
+		require.NoError(t, ds.CreateProduct(ctx, p))
+
+		sel := catalog.LabelSelector{}
+		result, err := ds.ListProductsByLabelSelector(ctx, ns, sel)
+		require.NoError(t, err)
+		assert.Empty(t, result)
 	})
 
 	// ── Namespace ─────────────────────────────────────────────────────────────

--- a/gitstore-api/tests/contract/datastore/pagination_test.go
+++ b/gitstore-api/tests/contract/datastore/pagination_test.go
@@ -187,43 +187,41 @@ func RunPaginationSuite(t *testing.T, ds datastore.Datastore) {
 
 	t.Run("Collections/ForwardPagination", func(t *testing.T) {
 		ctx := context.Background()
+		ns := "pag-coll-" + newID()[:8]
 
-		// Use a far-future base so these items sort before any pre-existing rows
-		// (DESC order) and a cursor from item[1] scopes the second page to only
-		// these four items, regardless of how many pre-existing rows are in BucketAll.
 		base := time.Now().Add(24 * time.Hour)
 		items := make([]*datastore.Collection, 4)
 		for i := range 4 {
 			items[i] = newCollection()
-			items[i].CreatedAt = base.Add(time.Duration(i) * time.Second)
+			items[i].Namespace = ns
+			items[i].CreationTimestamp = base.Add(time.Duration(i) * time.Second)
 			require.NoError(t, ds.CreateCollection(ctx, items[i]))
 		}
 
-		// Cursor at items[2] (third-newest): verify items[1] and items[0] appear in the page.
-		// Global-table tests share state across -count runs, so we check membership by ID
-		// rather than exact length to avoid counting pre-existing rows from earlier runs.
-		cursor := encodeCursor(items[2].CreatedAt, items[2].ID)
-		page2, err := ds.ListCollections(ctx, datastore.PageParams{First: 10, After: cursor})
+		cursor := encodeCursor(items[2].CreationTimestamp, items[2].UID)
+		page2, err := ds.ListCollections(ctx, ns, datastore.PageParams{First: 10, After: cursor})
 		require.NoError(t, err)
 		assert.True(t, page2.HasPrevious)
 		ids := make(map[string]bool, len(page2.Items))
 		for _, it := range page2.Items {
-			ids[it.ID] = true
+			ids[it.UID] = true
 		}
-		assert.True(t, ids[items[1].ID], "expected items[1] in page")
-		assert.True(t, ids[items[0].ID], "expected items[0] in page")
+		assert.True(t, ids[items[1].UID], "expected items[1] in page")
+		assert.True(t, ids[items[0].UID], "expected items[0] in page")
 	})
 
 	t.Run("Collections/BackwardPagination", func(t *testing.T) {
 		ctx := context.Background()
+		ns := "pag-coll-bwd-" + newID()[:8]
 
 		for i := range 4 {
 			c := newCollection()
-			c.CreatedAt = time.Now().Add(time.Duration(i) * time.Second)
+			c.Namespace = ns
+			c.CreationTimestamp = time.Now().Add(time.Duration(i) * time.Second)
 			require.NoError(t, ds.CreateCollection(ctx, c))
 		}
 
-		result, err := ds.ListCollections(ctx, datastore.PageParams{Last: 2})
+		result, err := ds.ListCollections(ctx, ns, datastore.PageParams{Last: 2})
 		require.NoError(t, err)
 		assert.Len(t, result.Items, 2)
 		assert.False(t, result.HasNext)

--- a/shared/schemas/category.graphqls
+++ b/shared/schemas/category.graphqls
@@ -182,6 +182,7 @@ Controller-computed category hierarchy metadata.
 """
 type ResolvedCategoryTaxonomy {
   depth: Int!
+  # TODO: Change to 'path: [String!]!'
   ancestorPath: String!
   childCount: Int!
   productCount: Int!

--- a/shared/schemas/schema.graphqls
+++ b/shared/schemas/schema.graphqls
@@ -143,8 +143,19 @@ input CategoryNamespacePath {
 Selector for looking up a collection by exactly one unique key.
 """
 input CollectionBy @oneOf {
+  """Look up by globally unique Relay ID (encodes the collection UID)."""
   id: ID
-  slug: String
+
+  """Look up by namespace identifier + collection name."""
+  namespacePath: CollectionNamespacePath
+}
+
+"""
+Composite selector: namespace identifier + collection name.
+"""
+input CollectionNamespacePath {
+  namespace: String!
+  name: String!
 }
 
 """

--- a/specs/022-collection-resource-contract/checklists/requirements.md
+++ b/specs/022-collection-resource-contract/checklists/requirements.md
@@ -1,0 +1,42 @@
+# Specification Quality Checklist: Collection Resource Contract with Label Selectors
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-07
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All items pass. 5 clarifications recorded in session 2026-06-07:
+1. `status.resolved` stores only `memberCount`; products exposed via `collection.products` connection
+2. `collection.products` uses snapshot-at-query-time cursor semantics
+3. Empty/absent `spec.selector` yields zero membership
+4. `collection.products` is the authoritative live source; `memberCount` is a cached hint
+5. Deleting a Collection has no effect on member products
+6. `collection.products` inherits Collection-level access control
+
+Ready to proceed to `/speckit.plan`.

--- a/specs/022-collection-resource-contract/contracts/collection.graphqls
+++ b/specs/022-collection-resource-contract/contracts/collection.graphqls
@@ -1,5 +1,15 @@
-# Collection Entity GraphQL Types (Kubernetes-style resource envelope)
-# Replaces the legacy flat collection schema.
+# Contract: Collection GraphQL Schema
+#
+# Replaces shared/schemas/collection.graphqls entirely.
+# Legacy mutations (createCollection, updateCollection, deleteCollection,
+# reorderCollections) become stubs returning an informative error.
+#
+# New shared types (LabelSelector, LabelSelectorRequirement, LabelSelectorOperator)
+# are added to shared/schemas/schema.graphqls alongside existing shared input types.
+
+# ============================================================================
+# Queries
+# ============================================================================
 
 extend type Query {
   """
@@ -8,10 +18,9 @@ extend type Query {
   collection(by: CollectionBy!): Collection
 
   """
-  List collections with Relay cursor-based pagination, scoped to a namespace.
+  List collections with Relay cursor-based pagination, scoped to the current namespace.
   """
   collections(
-    namespace: String!
     first: Int
     after: String
     last: Int
@@ -19,25 +28,9 @@ extend type Query {
   ): CollectionConnection!
 }
 
-extend type Mutation {
-  """
-  Deprecated: Collection resources are managed via git push.
-  This mutation always returns an informative error.
-  """
-  createCollection(input: CreateCollectionInput!): CreateCollectionPayload!
-
-  """
-  Deprecated: Collection resources are managed via git push.
-  This mutation always returns an informative error.
-  """
-  updateCollection(input: UpdateCollectionInput!): UpdateCollectionPayload!
-
-  """
-  Deprecated: Collection resources are managed via git push.
-  This mutation always returns an informative error.
-  """
-  deleteCollection(input: DeleteCollectionInput!): DeleteCollectionPayload!
-}
+# ============================================================================
+# Collection Resource Envelope
+# ============================================================================
 
 """
 A Collection is a namespace-scoped catalog resource that groups products via
@@ -70,7 +63,7 @@ type Collection implements Node {
   spec: CollectionSpec!
 
   """
-  System-computed status: conditions and member count.
+  System-computed status: conditions, member count, and resolved media.
   """
   status: CollectionStatus
 
@@ -81,6 +74,9 @@ type Collection implements Node {
 
   """
   Paginated connection of products matched by this collection's label selector.
+  Uses snapshot-at-query-time cursor semantics: all pages in a single traversal
+  reflect membership as evaluated when the first page was requested.
+  Access control: same as reading the Collection itself.
   """
   products(
     first: Int
@@ -89,6 +85,10 @@ type Collection implements Node {
     before: String
   ): ProductConnection!
 }
+
+# ============================================================================
+# CollectionObjectMeta
+# ============================================================================
 
 """
 System-managed identity fields for a Collection resource.
@@ -106,7 +106,7 @@ type CollectionObjectMeta {
   namespace: String
 
   """
-  Globally unique system-generated identifier.
+  Globally unique system-generated identifier (UUID, encoded as Relay ID).
   """
   uid: ID!
 
@@ -139,7 +139,16 @@ type CollectionObjectMeta {
   Author-supplied annotations.
   """
   annotations: [KeyValuePair!]!
+
+  """
+  Owner references (reserved for future controller use).
+  """
+  ownerReferences: [OwnerReference!]!
 }
+
+# ============================================================================
+# CollectionSpec
+# ============================================================================
 
 """
 Author-controlled specification for a Collection resource.
@@ -161,6 +170,10 @@ type CollectionSpec {
   """
   media: [MediaDefinition!]!
 }
+
+# ============================================================================
+# LabelSelector (shared — also added to schema.graphqls)
+# ============================================================================
 
 """
 A label selector that matches products by their labels.
@@ -203,11 +216,30 @@ type LabelSelectorRequirement {
 Operators supported in a LabelSelectorRequirement.
 """
 enum LabelSelectorOperator {
+  """
+  Label value must be in the values list.
+  """
   IN
+
+  """
+  Label value must not be in the values list.
+  """
   NOT_IN
+
+  """
+  Label key must be present (any value).
+  """
   EXISTS
+
+  """
+  Label key must be absent.
+  """
   DOES_NOT_EXIST
 }
+
+# ============================================================================
+# CollectionStatus
+# ============================================================================
 
 """
 System-computed status for a Collection resource.
@@ -224,12 +256,13 @@ type CollectionStatus {
   lastAppliedRevision: String
 
   """
-  Condition set written at admission time.
+  Condition set: SelectorAccepted, MembersResolved, Ready.
   """
   conditions: [CollectionCondition!]!
 
   """
-  Resolved membership snapshot (cached hint; collection.products is authoritative).
+  Resolved membership snapshot computed at last admission.
+  memberCount is a cached hint; collection.products is the authoritative live source.
   """
   resolved: ResolvedCollectionDefinition
 }
@@ -238,22 +271,80 @@ type CollectionStatus {
 A single status condition on a Collection resource.
 """
 type CollectionCondition {
+  """
+  Condition type: SelectorAccepted | MembersResolved | Ready.
+  """
   type: String!
+
+  """
+  True or False.
+  """
   status: String!
+
+  """
+  Generation at which this condition was last evaluated.
+  """
   observedGeneration: Int
+
+  """
+  Machine-readable reason token.
+  """
   reason: String
+
+  """
+  Human-readable detail message.
+  """
   message: String
 }
 
 """
-Resolved membership information cached at last admission.
+Resolved membership information computed at last admission.
+memberCount may lag behind the live collection.products count
+if products were relabelled after the last push.
 """
 type ResolvedCollectionDefinition {
   """
-  Cached count of matching products at last admission.
+  Number of products that satisfied the selector at last admission.
+  Cached hint — collection.products is authoritative.
   """
   memberCount: Int!
+
+  """
+  Resolved media entries (URLs populated by the file resolver).
+  """
+  media: [ResolvedFileDefinition!]!
 }
+
+# ============================================================================
+# CollectionBy / CollectionNamespacePath
+# ============================================================================
+
+"""
+Selector for looking up a collection by exactly one unique key.
+"""
+input CollectionBy @oneOf {
+  """
+  Look up by globally unique Relay ID (encodes the collection UID).
+  """
+  id: ID
+
+  """
+  Look up by namespace identifier + collection name.
+  """
+  namespacePath: CollectionNamespacePath
+}
+
+"""
+Composite selector: namespace identifier + collection name.
+"""
+input CollectionNamespacePath {
+  namespace: String!
+  name: String!
+}
+
+# ============================================================================
+# Connection / Edge
+# ============================================================================
 
 """
 Edge type for Collection connection (Relay pattern).
@@ -273,8 +364,30 @@ type CollectionConnection {
 }
 
 # ============================================================================
-# Minimal stub inputs (legacy mutations deprecated — managed via git push)
+# Legacy mutation stubs (collection mutations managed via git push)
 # ============================================================================
+
+extend type Mutation {
+  """
+  Deprecated: Collection resources are managed via git push.
+  This mutation always returns an error.
+  """
+  createCollection(input: CreateCollectionInput!): CreateCollectionPayload!
+
+  """
+  Deprecated: Collection resources are managed via git push.
+  This mutation always returns an error.
+  """
+  updateCollection(input: UpdateCollectionInput!): UpdateCollectionPayload!
+
+  """
+  Deprecated: Collection resources are managed via git push.
+  This mutation always returns an error.
+  """
+  deleteCollection(input: DeleteCollectionInput!): DeleteCollectionPayload!
+}
+
+# Minimal stub inputs to preserve schema compatibility.
 
 input CreateCollectionInput {
   name: String!
@@ -290,11 +403,6 @@ input UpdateCollectionInput {
 
 type UpdateCollectionPayload {
   collection: Collection
-  conflict: CollectionOptimisticLockConflict
-}
-
-type CollectionOptimisticLockConflict {
-  current: Collection!
 }
 
 input DeleteCollectionInput {
@@ -303,34 +411,4 @@ input DeleteCollectionInput {
 
 type DeleteCollectionPayload {
   deletedCollectionId: ID
-}
-
-# ============================================================================
-# Publish / CatalogVersion (kept here for schema continuity)
-# ============================================================================
-
-input PublishCatalogInput {
-  clientMutationId: String
-  version: String!
-  message: String!
-}
-
-type PublishCatalogPayload {
-  clientMutationId: String
-  catalogVersion: CatalogVersion
-}
-
-type CatalogVersion {
-  tag: String!
-  commit: String!
-  publishedAt: DateTime!
-  message: String
-  stats: CatalogStats!
-}
-
-type CatalogStats {
-  productCount: Int!
-  categoryCount: Int!
-  collectionCount: Int!
-  orphanedReferences: Int!
 }

--- a/specs/022-collection-resource-contract/data-model.md
+++ b/specs/022-collection-resource-contract/data-model.md
@@ -1,0 +1,218 @@
+# Data Model: Collection Resource Contract with Label Selectors
+
+**Branch**: `022-collection-resource-contract` | **Phase**: 1 | **Date**: 2026-06-07
+
+---
+
+## Entities
+
+### `Collection` (Datastore Entity)
+
+Replaces the legacy flat `Collection` struct. Follows the `CategoryTaxonomy` Kubernetes-style envelope pattern.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `UID` | `string` (UUID) | System-generated unique identifier |
+| `Namespace` | `string` | Namespace identifier (human-readable slug) |
+| `Name` | `string` | DNS-label name, unique within namespace |
+| `APIVersion` | `string` | Always `catalog.gitstore.dev/v1beta1` |
+| `Kind` | `string` | Always `Collection` |
+| `Generation` | `int64` | Increments on every spec change |
+| `ResourceVersion` | `string` | Opaque concurrency token |
+| `CreationTimestamp` | `time.Time` | Set once on first admission |
+| `Revision` | `string` | Git ref + SHA, e.g. `main@sha1:abc123` |
+| `Labels` | `map[string]string` | Author-supplied key-value labels |
+| `Annotations` | `map[string]string` | Author-supplied annotations |
+| `GitCommitSHA` | `string` | Commit SHA of the admitting push |
+| `GitRef` | `string` | Branch/ref of the admitting push |
+| `Spec` | `json.RawMessage` | JSON-encoded `CollectionSpec` |
+| `Body` | `string` | Markdown content (collection description) |
+| `Status` | `json.RawMessage` | JSON-encoded `CollectionStatus` |
+
+**Identity**: `(Namespace, Name)` is the unique business key. `UID` is the stable system key.
+
+**State transitions**:
+- Created on first push admission → `Status.Conditions[Ready] = False` until selector evaluated.
+- Updated on subsequent pushes → `Generation` incremented; `ResourceVersion` updated.
+- Deleted via git delete (out of scope for this spec).
+
+---
+
+### `CollectionSpec` (Catalog Parse Type — Go)
+
+Parsed from YAML frontmatter during `ParseResource`. Stored as JSON in the `Spec` column.
+
+| Field | Type | Validation |
+|-------|------|-----------|
+| `Title` | `string` | Required, non-empty |
+| `Selector` | `*LabelSelector` | Optional; absent = zero members |
+| `Media` | `[]MediaDefinition` | Optional; reuses existing `MediaDefinition` type |
+
+---
+
+### `LabelSelector` (Catalog Parse Type — Go)
+
+| Field | Type | Validation |
+|-------|------|-----------|
+| `MatchLabels` | `map[string]string` | Optional; all entries must match (AND) |
+| `MatchExpressions` | `[]LabelSelectorRequirement` | Optional; all entries must match (AND) |
+
+**Evaluation semantics**:
+- Empty `LabelSelector` (both fields nil/empty) → zero members.
+- `matchLabels` entries AND `matchExpressions` entries are combined with logical AND.
+- A product is a member if and only if it satisfies all constraints.
+
+---
+
+### `LabelSelectorRequirement` (Catalog Parse Type — Go)
+
+| Field | Type | Validation |
+|-------|------|-----------|
+| `Key` | `string` | Required |
+| `Operator` | `string` | Required; one of `In`, `NotIn`, `Exists`, `DoesNotExist` |
+| `Values` | `[]string` | Required non-empty for `In`/`NotIn`; must be empty for `Exists`/`DoesNotExist` |
+
+---
+
+### `ResolvedCollectionDefinition` (Status Sub-type — Go)
+
+Stored as part of `CollectionStatus` JSON. Written at admission time.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `MemberCount` | `int64` | Count of products satisfying the selector at last reconciliation |
+| `Media` | `[]ResolvedFileDefinition` | Resolved media entries (reuses existing type) |
+
+**Note**: `productRefs` is intentionally absent. Products are queried live via `collection.products(...)`.
+
+---
+
+### `CollectionStatus` (Status Envelope — Go)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ObservedGeneration` | `int64` | Generation at which status was last computed |
+| `LastAppliedRevision` | `string` | Git revision of last successful admission |
+| `Conditions` | `[]Condition` | `SelectorAccepted`, `MembersResolved`, `Ready` |
+| `Resolved` | `*ResolvedCollectionDefinition` | Computed membership count and media |
+
+**Condition types**:
+
+| Type | True when | False when |
+|------|-----------|-----------|
+| `SelectorAccepted` | Selector is syntactically valid | Selector has invalid operator or constraint violation |
+| `MembersResolved` | Member count successfully computed | Datastore error during evaluation |
+| `Ready` | Both above conditions True | Either above condition False |
+
+---
+
+## Datastore Interface
+
+New methods added to the `Datastore` interface in `gitstore-api/internal/datastore/datastore.go`:
+
+```
+CreateCollection(ctx, *Collection) error
+GetCollection(ctx, uid string) (*Collection, error)
+GetCollectionByName(ctx, namespace, name string) (*Collection, error)
+ListCollections(ctx, namespace string, page PageParams) (*PageResult[Collection], error)
+UpdateCollection(ctx, *Collection) error
+```
+
+**`ListProductsByLabelSelector`** — new method for evaluating label selectors at query time:
+
+```
+ListProductsByLabelSelector(ctx, namespace string, selector LabelSelector) ([]*Product, error)
+```
+
+Returns all products in the namespace whose `Labels` satisfy the given `LabelSelector`. Used both at admission (to compute `memberCount`) and at `collection.products` query time (for paginated results).
+
+---
+
+## ScyllaDB Schema (Migration `003`)
+
+Three tables following the `category_taxonomy` three-table pattern:
+
+### `collection` (primary listing table)
+
+```sql
+PRIMARY KEY ((namespace), creation_timestamp DESC, uid DESC)
+```
+
+Columns: all fields from `Collection` entity above. `spec` and `status` stored as `text` (JSON).
+
+### `collection_by_name` (lookup by namespace + name)
+
+```sql
+PRIMARY KEY ((namespace), name)
+```
+
+Columns: `namespace`, `name`, `uid`, `creation_timestamp`. Enables O(1) `GetCollectionByName`.
+
+### `collection_by_uid` (lookup by UID)
+
+```sql
+PRIMARY KEY (uid)
+```
+
+Columns: `uid`, `namespace`, `creation_timestamp`. Enables O(1) `GetCollectionByUID`.
+
+---
+
+## Memdb Schema (Development)
+
+Table `collection` with indexes:
+
+| Index name | Fields | Unique |
+|------------|--------|--------|
+| `id` | `UID` | Yes |
+| `name_namespace` | `Name`, `Namespace` | Yes |
+| `namespace` | `Namespace` | No |
+
+---
+
+## `ParsedResource` Extension
+
+`gitstore-api/internal/validate/validator.go`:
+
+```go
+type ParsedResource struct {
+    Kind             string
+    Product          *catalog.ProductResource
+    CategoryTaxonomy *catalog.CategoryTaxonomyResource
+    Collection       *catalog.CollectionResource       // NEW
+}
+```
+
+`case "Collection":` added to `ParseResource` switch. Validates `CollectionSpec` using `validateCollectionSpec` (title required, selector operator/values constraints, media reuse).
+
+---
+
+## Label Selector Evaluation
+
+Implemented in `gitstore-api/internal/catalog/selector.go` (new file):
+
+```
+// MatchesLabels reports whether the given labels satisfy the selector.
+// An empty selector matches nothing (returns false).
+func MatchesLabels(selector LabelSelector, labels map[string]string) bool
+```
+
+Called from:
+1. `admitCollection` in `cataloggrpc/server.go` — to compute `memberCount` at admission.
+2. `ListProductsByLabelSelector` in datastore implementations — to filter products at query time.
+3. Unit tests — directly testable without datastore.
+
+---
+
+## Relationships
+
+```
+Namespace
+  └── Collection (namespace-scoped)
+        └── products(...) ──► Product[] (live label-selector query, not stored)
+```
+
+- A `Collection` belongs to exactly one `Namespace`.
+- A `Product` may be a member of zero or more `Collection`s simultaneously.
+- Deleting a `Collection` has no effect on any `Product`.
+- `collection.products` is a live query; results reflect current product labels, not a stored list.

--- a/specs/022-collection-resource-contract/plan.md
+++ b/specs/022-collection-resource-contract/plan.md
@@ -1,0 +1,161 @@
+# Implementation Plan: Collection Resource Contract with Label Selectors
+
+**Branch**: `022-collection-resource-contract` | **Date**: 2026-06-07 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/022-collection-resource-contract/spec.md`
+
+## Summary
+
+Replace the legacy flat `Collection` entity with a Kubernetes-style git-backed `Collection` resource following the `CategoryTaxonomy` envelope pattern. Authors define collections via YAML frontmatter with a `LabelSelector` that determines product membership. The GraphQL API exposes `collection(by: ...)`, paginated `collections`, and a `collection.products(first, last, ...)` connection with snapshot-at-query-time cursor semantics. Legacy mutations become stubs. Label selector evaluation is implemented in pure Go with no new external dependencies.
+
+## Technical Context
+
+**Language/Version**: Go 1.25 (`gitstore-api`); Rust edition 2021 MSRV 1.82 (`gitstore-git-service` — no changes needed)
+**Primary Dependencies**: `gqlgen v0.17.90`, `go-memdb v1.3.5` (dev), `gocqlx/v3 v3.0.4` + `gocql` (ScyllaDB prod), `go-playground/validator/v10`, `go.uber.org/zap`, `github.com/adrg/frontmatter v0.2.0`, `gopkg.in/yaml.v3`
+**Storage**: ScyllaDB 5.x+ (prod) via three-table pattern; `go-memdb` (dev/test)
+**Testing**: `go test ./...`; contract tests in `tests/contract/datastore/`; integration tests in `tests/integration/`
+**Target Platform**: Linux server (Docker Compose / Kubernetes)
+**Performance Goals**: `collection.products(first: 20)` under 2 seconds for namespaces with up to 10,000 products
+**Constraints**: No new external Go dependencies; label selector evaluation in pure Go
+**Scale/Scope**: Up to 10,000 products per namespace; up to 50 collections per namespace (SC-005)
+
+## Constitution Check
+
+| Principle | Gate | Status |
+|-----------|------|--------|
+| I. Test-First | Contract + unit tests written before implementation | ✅ Pass — tasks ordered test-first |
+| II. API-First | GraphQL schema defined before resolvers | ✅ Pass — contract in `contracts/collection.graphqls` |
+| III. Clear Contracts | Schema follows additive evolution; legacy mutations stubbed | ✅ Pass |
+| IV. Observability | Admission and query logging follow existing `zap` pattern | ✅ Pass |
+| V. User Story Driven | All tasks labelled US1–US4 | ✅ Pass |
+| VI. Incremental Delivery | P1 (push + query) shippable before P2 (selector membership) | ✅ Pass |
+| VII. Simplicity | No new deps; selector eval ~150 lines pure Go | ✅ Pass |
+
+No violations. Complexity tracking section not required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/022-collection-resource-contract/
+├── plan.md              ← this file
+├── research.md          ← Phase 0 output
+├── data-model.md        ← Phase 1 output
+├── quickstart.md        ← Phase 1 output
+├── contracts/
+│   └── collection.graphqls   ← Phase 1 output
+├── checklists/
+│   └── requirements.md
+└── tasks.md             ← Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+gitstore-api/
+├── internal/
+│   ├── catalog/
+│   │   ├── collection.go          # NEW — CollectionResource, CollectionSpec, LabelSelector types
+│   │   └── selector.go            # NEW — MatchesLabels evaluation function
+│   ├── validate/
+│   │   └── validator.go           # MODIFIED — add Collection case to ParseResource
+│   ├── datastore/
+│   │   ├── entities.go            # MODIFIED — replace flat Collection with K8s-style struct
+│   │   ├── datastore.go           # MODIFIED — add Collection + ListProductsByLabelSelector methods
+│   │   ├── instrumented.go        # MODIFIED — wrap new methods
+│   │   ├── memdb/
+│   │   │   ├── schema.go          # MODIFIED — rebuild collection table with name_namespace index
+│   │   │   └── backend.go         # MODIFIED — implement Collection CRUD + selector query
+│   │   └── scylla/
+│   │       ├── migrations/
+│   │       │   └── 003_collection_kubernetes_schema.cql  # NEW
+│   │       ├── models.go          # MODIFIED — add CollectionRow, CollectionByNameRow, CollectionByUIDRow
+│   │       └── backend.go         # MODIFIED — implement Collection CRUD + selector query
+│   ├── cataloggrpc/
+│   │   └── server.go              # MODIFIED — add Collection admission branch
+│   └── graph/
+│       ├── collection.resolvers.go  # MODIFIED — replace legacy resolvers with K8s-style
+│       └── converters.go            # MODIFIED — DatastoreCollectionToGraphQL
+├── tests/
+│   ├── contract/datastore/
+│   │   └── contract_test.go       # MODIFIED — add Collection CRUD contract tests
+│   └── integration/
+│       └── collection_test.go     # NEW — E2E push + query integration tests
+shared/
+└── schemas/
+    ├── collection.graphqls        # REWRITTEN — K8s envelope schema
+    └── schema.graphqls            # MODIFIED — add LabelSelector, LabelSelectorRequirement, LabelSelectorOperator, CollectionBy, CollectionNamespacePath
+```
+
+## Phase 0: Research
+
+**Status**: ✅ Complete — see [research.md](research.md)
+
+Key decisions:
+- Replace (not migrate) the legacy `Collection` entity.
+- Label selector in pure Go, no external dependency.
+- Snapshot cursor: ordered UID list encoded in opaque cursor token, server-side LRU cache.
+- Three-table ScyllaDB pattern mirroring `category_taxonomy`.
+- `collection.products` is a live query; `memberCount` is a cached admission-time hint.
+
+## Phase 1: Design & Contracts
+
+**Status**: ✅ Complete
+
+| Artifact | Path | Status |
+|----------|------|--------|
+| Data model | [data-model.md](data-model.md) | ✅ Done |
+| GraphQL contract | [contracts/collection.graphqls](contracts/collection.graphqls) | ✅ Done |
+| Quickstart | [quickstart.md](quickstart.md) | ✅ Done |
+
+### Post-Design Constitution Check
+
+All principles pass. No new complexity introduced beyond what `CategoryTaxonomy` already established.
+
+## Implementation Sequence
+
+Tasks are ordered: **foundational → US1 (P1) → US2 (P1) → US3 (P2) → US4 (P2) → polish**.
+
+### Foundation (blocks all user stories)
+
+1. `catalog/collection.go` — `CollectionResource`, `CollectionSpec`, `LabelSelector`, `LabelSelectorRequirement` structs with YAML tags and validator annotations.
+2. `catalog/selector.go` — `MatchesLabels` pure-Go evaluation function (unit-tested first).
+3. `validate/validator.go` — add `Collection` to `ParsedResource` and `ParseResource` switch with `validateCollectionSpec`.
+4. `datastore/entities.go` — replace flat `Collection` struct with K8s-style entity.
+5. `datastore/datastore.go` — add `CreateCollection`, `GetCollection`, `GetCollectionByName`, `ListCollections`, `UpdateCollection`, `ListProductsByLabelSelector`.
+6. `datastore/memdb/schema.go` + `backend.go` — rebuild memdb Collection table and implement all new methods.
+7. `migrations/003_collection_kubernetes_schema.cql` — three-table ScyllaDB schema.
+8. `datastore/scylla/models.go` + `backend.go` — ScyllaDB Collection CRUD and `ListProductsByLabelSelector`.
+9. `datastore/instrumented.go` — wrap new Datastore methods.
+
+### US1: Define a Collection via git push (P1)
+
+10. `cataloggrpc/server.go` — add `Collection` admission branch: parse, validate, upsert, compute `memberCount` from selector, write status.
+11. Contract test: `tests/contract/datastore/contract_test.go` — Collection CRUD.
+12. Integration test: `tests/integration/collection_test.go` — push valid Collection, verify admission.
+13. Integration test: push invalid Collection (missing title), verify rejection.
+
+### US2: Query a Collection (P1)
+
+14. `shared/schemas/collection.graphqls` — rewrite with K8s envelope (from `contracts/collection.graphqls`).
+15. `shared/schemas/schema.graphqls` — add `LabelSelector`, `LabelSelectorRequirement`, `LabelSelectorOperator`, `CollectionBy`, `CollectionNamespacePath`.
+16. `gqlgen` code generation — run `go generate ./internal/graph/...`.
+17. `graph/converters.go` — `DatastoreCollectionToGraphQL` converter.
+18. `graph/collection.resolvers.go` — `Collection`, `Collections` query resolvers; legacy mutation stubs.
+19. Integration test: query `collection(by: namespacePath)` → verify metadata, spec, status.
+
+### US3: Selector-driven membership + `collection.products` (P1/P2)
+
+20. `graph/collection.resolvers.go` — `collection.Products` resolver with snapshot-cursor pagination.
+21. `internal/graph/service.go` — `ListProductsBySelector` service wrapper.
+22. Unit tests: `catalog/selector_test.go` — all four operators, combined matchLabels + matchExpressions.
+23. Integration test: verify `collection.products` returns only labelled products; `memberCount` correct.
+
+### US4: Update a Collection (P2)
+
+24. Integration test: push updated Collection with narrowed selector; verify `memberCount` decreases and `collection.products` reflects new set.
+
+### Polish
+
+25. `graph/category_resolver_test.go` pattern — add `graph/collection_resolver_test.go` unit tests for resolver logic.
+26. `docs/products/collection.md` — author guide following `category-taxonomy.md` pattern.

--- a/specs/022-collection-resource-contract/quickstart.md
+++ b/specs/022-collection-resource-contract/quickstart.md
@@ -1,0 +1,184 @@
+# Quickstart: Collection Resource Contract
+
+**Branch**: `022-collection-resource-contract` | **Date**: 2026-06-07
+
+This guide shows how to author, push, and query a `Collection` resource end-to-end using the git-backed workflow.
+
+---
+
+## Prerequisites
+
+- Running GitStore stack (`make dev` or `make compose`)
+- A namespace and repository already bootstrapped (`make bootstrap`)
+- A valid bearer token (`make bootstrap-token ADMIN_PASSWORD=<password>`)
+- `git` clone of the catalog repository
+
+---
+
+## Step 1 — Author a Collection document
+
+Create a Markdown file in your catalog repository. The filename becomes part of the git history but the canonical name is `metadata.name`.
+
+```markdown
+---
+apiVersion: catalog.gitstore.dev/v1beta1
+kind: Collection
+metadata:
+  name: apple-laptops
+  namespace: gitstore-test
+  labels:
+    gitstore.dev/featured: "true"
+spec:
+  title: Apple Laptops
+  media:
+  - fileRef:
+      name: collection-hero
+      kind: File
+      optional: true
+  selector:
+    matchLabels:
+      gitstore.dev/brand: apple
+    matchExpressions:
+    - key: gitstore.dev/product-type
+      operator: In
+      values:
+      - laptop
+      - notebook
+---
+
+A curated selection of Apple laptop computers for professional and personal use.
+```
+
+Save as `collections/apple-laptops.md` in your catalog repository.
+
+---
+
+## Step 2 — Push to the catalog repository
+
+```bash
+git add collections/apple-laptops.md
+git commit -m "feat(catalog): add apple-laptops collection"
+git push origin main
+```
+
+The pre-receive hook validates the document. If `spec.title` is missing or the selector has invalid operators, the push is rejected with a descriptive error.
+
+---
+
+## Step 3 — Query the Collection via GraphQL
+
+```graphql
+query {
+  collection(by: { namespacePath: { namespace: "gitstore-test", name: "apple-laptops" } }) {
+    id
+    metadata {
+      name
+      namespace
+      uid
+      generation
+      creationTimestamp
+      labels { key value }
+    }
+    spec {
+      title
+      selector {
+        matchLabels { key value }
+        matchExpressions { key operator values }
+      }
+      media {
+        fileRef { name kind optional }
+      }
+    }
+    status {
+      observedGeneration
+      conditions { type status reason message }
+      resolved {
+        memberCount
+      }
+    }
+  }
+}
+```
+
+---
+
+## Step 4 — Paginate matched products
+
+```graphql
+query {
+  collection(by: { namespacePath: { namespace: "gitstore-test", name: "apple-laptops" } }) {
+    metadata { name }
+    status { resolved { memberCount } }
+    products(first: 20) {
+      edges {
+        node {
+          id
+          metadata { name }
+          spec { title }
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+}
+```
+
+Subsequent pages pass `after: "<endCursor>"`. All pages in a single traversal reflect membership as evaluated when the first page was requested (snapshot-at-query-time semantics).
+
+---
+
+## Step 5 — Update the selector
+
+Edit `collections/apple-laptops.md` to narrow the selector:
+
+```yaml
+spec:
+  selector:
+    matchLabels:
+      gitstore.dev/brand: apple
+      gitstore.dev/product-type: laptop
+```
+
+Push the change:
+
+```bash
+git add collections/apple-laptops.md
+git commit -m "feat(catalog): narrow apple-laptops selector to laptops only"
+git push origin main
+```
+
+After push, `status.resolved.memberCount` will decrease to reflect the narrower selector.
+
+---
+
+## Validation Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `spec.title is required` | `spec.title` missing or empty | Add `title:` to `spec` |
+| `kind "Collection" is not a recognized catalog resource type` | Wrong `kind` value | Use `kind: Collection` |
+| `matchExpressions[0].operator must be one of In, NotIn, Exists, DoesNotExist` | Invalid operator | Use a supported operator |
+| `matchExpressions[0].values must be non-empty for operator In` | `In` with empty values | Add at least one value |
+| `spec.selector.targetRef.kind must be Product` | Unsupported target kind | Remove `targetRef` or set `kind: Product` |
+
+---
+
+## Example Collection with no selector
+
+A collection with no selector admits successfully but always resolves to zero members:
+
+```markdown
+---
+apiVersion: catalog.gitstore.dev/v1beta1
+kind: Collection
+metadata:
+  name: placeholder-collection
+spec:
+  title: Placeholder (no members yet)
+---
+```
+
+This is useful for creating a named collection before products with matching labels exist.

--- a/specs/022-collection-resource-contract/research.md
+++ b/specs/022-collection-resource-contract/research.md
@@ -1,0 +1,147 @@
+# Research: Collection Resource Contract with Label Selectors
+
+**Branch**: `022-collection-resource-contract` | **Phase**: 0 | **Date**: 2026-06-07
+
+## Summary
+
+This document resolves all unknowns identified during Technical Context analysis before Phase 1 design begins.
+
+---
+
+## R-001: Migration Strategy — Existing `Collection` Entity
+
+**Question**: Should the existing flat `Collection` entity be migrated in place or replaced entirely?
+
+**Decision**: Replace entirely following the `CategoryTaxonomy` pattern.
+
+**Rationale**: The current `Collection` entity (`ID`, `Name`, `Slug`, `DisplayOrder`, `ProductIDs`, `CreatedAt`, `UpdatedAt`, `Body`) shares no fields with a Kubernetes-style resource envelope. A selective ALTER would leave ambiguous legacy columns. The `category_taxonomy` precedent shows the team replaces rather than mutates incompatible entities.
+
+**Alternatives considered**:
+- ALTER existing table: rejected — legacy columns (`slug`, `display_order`, `product_ids`) have no mapping in the new model; mixed-state table increases maintenance burden.
+- Dual-write migration: rejected — no consumers of the current `Collection` entity in production paths require continuity; stubs returning errors (as done for CategoryTaxonomy mutations) are sufficient.
+
+**Impact**: `shared/schemas/collection.graphqls` is a full rewrite. Legacy mutations (`createCollection`, `updateCollection`, `deleteCollection`, `reorderCollections`) become stubs returning `"collection mutations are managed via git push"`.
+
+---
+
+## R-002: Label Selector Implementation
+
+**Question**: How should `LabelSelector` / `matchLabels` / `matchExpressions` be implemented? No existing pattern in the codebase.
+
+**Decision**: Implement a minimal Kubernetes-compatible label selector in the Go `catalog` package, evaluated in-memory during reconciliation and at query time for `collection.products`.
+
+**Rationale**: The Kubernetes label selector semantics are well-specified (KEP-0000, `k8s.io/apimachinery/pkg/labels`) and widely understood. Building a minimal compatible subset in pure Go (no external dependency) is ~150 lines and directly testable. Using an external library would add a heavyweight dependency for straightforward logic.
+
+**Selector evaluation rules**:
+- `matchLabels`: Each key-value pair must match exactly — logical AND across all entries.
+- `matchExpressions`:
+  - `In`: label value must be in `values` list.
+  - `NotIn`: label value must not be in `values` list.
+  - `Exists`: label key must be present (any value); `values` ignored.
+  - `DoesNotExist`: label key must be absent; `values` ignored.
+- Both `matchLabels` and `matchExpressions` present: logical AND across both.
+- Empty/absent `spec.selector`: evaluates to zero members (not universal).
+
+**Stored as JSON in `spec` column** — same pattern as `CategoryTaxonomySpec`. Evaluation happens at admission (for validation) and at query time (for `collection.products`).
+
+**Alternatives considered**:
+- `k8s.io/apimachinery/pkg/labels`: rejected — pulls in large Kubernetes dependency tree for a self-contained catalog service.
+- SQL/CQL WHERE clause for selector evaluation: rejected — ScyllaDB has no native JSON path + label-matching; requires full namespace product scan + in-process filter (acceptable given SC-002's 10,000-product bound).
+
+---
+
+## R-003: `collection.products` Snapshot Cursor Semantics
+
+**Question**: How are snapshot-at-query-time cursor semantics implemented without a dedicated snapshot store?
+
+**Decision**: At first-page request, evaluate the label selector against all products in the namespace to produce an ordered list of UIDs. Encode this ordered UID list (or a hash + server-side cache entry) in the opaque cursor. Subsequent pages decode the cursor to retrieve the same ordered UID list and slice into it.
+
+**Rationale**: This is the same strategy used for paginating stable result sets in any cursor-based system where the underlying data can change. The UID list is compact (UUIDs, ~36 bytes each, 10,000 products ≈ 360KB before encoding) and can be stored transiently in the server process (in-memory LRU keyed by cursor token) with a configurable TTL (e.g., 5 minutes). No persistent snapshot infrastructure required.
+
+**Alternatives considered**:
+- Re-evaluate selector on every page: rejected — would cause skips/duplicates when labels change mid-traversal (violates clarified requirement).
+- ScyllaDB materialized view: rejected — ScyllaDB MVs do not support arbitrary in-row JSON label evaluation.
+- Store resolved UID list in `status`: rejected — explicitly ruled out in clarification (products accumulate fast; status stores only `memberCount`).
+
+---
+
+## R-004: ScyllaDB Schema for `collection` Tables
+
+**Decision**: Three-table pattern mirroring `category_taxonomy`:
+
+```
+collection              — PRIMARY KEY ((namespace), creation_timestamp DESC, uid DESC)
+collection_by_name      — PRIMARY KEY ((namespace), name)
+collection_by_uid       — PRIMARY KEY (uid)
+```
+
+**Rationale**: Identical to `category_taxonomy` / `products_by_namespace` patterns already in the codebase. Namespace-partitioned primary table enables efficient `ListCollections` scans. Lookup tables enable O(1) `GetCollectionByName` and `GetCollectionByUID` without secondary indexes (which require coordinator round-trips in ScyllaDB).
+
+**Columns for primary table**: `namespace`, `creation_timestamp`, `uid`, `api_version`, `kind`, `name`, `generation`, `resource_version`, `revision`, `labels map<text,text>`, `annotations map<text,text>`, `git_commit_sha`, `git_ref`, `spec text` (JSON), `body text`, `status text` (JSON).
+
+**No `selector` column** — selector is stored inside `spec` JSON. No `product_ids` column — membership is derived from label evaluation, not stored.
+
+---
+
+## R-005: `ParseResource` Extension for `Collection`
+
+**Decision**: Add `case "Collection":` to the `ParseResource` switch in `gitstore-api/internal/validate/validator.go`, alongside a new `catalog.CollectionResource` / `CollectionSpec` struct in `gitstore-api/internal/catalog/collection.go`.
+
+**Validation rules**:
+- `apiVersion`: must equal `catalog.gitstore.dev/v1beta1`
+- `kind`: must equal `Collection`
+- `metadata.name`: required, DNS label format (reuse existing `validateMetadataName`)
+- `spec.title`: required, non-empty string
+- `spec.selector.targetRef.kind`: if present, must equal `Product`
+- `spec.selector.matchExpressions[*].operator`: must be one of `In`, `NotIn`, `Exists`, `DoesNotExist`
+- `spec.selector.matchExpressions[*].values`: must be non-empty for `In`/`NotIn`; must be empty for `Exists`/`DoesNotExist`
+- `spec.media`: zero or more `MediaDefinition` entries (reuse existing validation)
+
+**No cycle detection needed** — Collections are flat (no parent/child hierarchy).
+
+---
+
+## R-006: Admission Dispatch for Collection
+
+**Decision**: Add a `Collection` branch in `AdmitResources` in `gitstore-api/internal/cataloggrpc/server.go`, after the existing `CategoryTaxonomy` / `Product` dispatch. Collections have no intra-push ordering dependency (no parent refs), so they can be admitted in any order or in parallel with products.
+
+**Admission steps** (per collection):
+1. Upsert `Collection` entity to datastore (create or update).
+2. Evaluate `spec.selector` against all products currently in the namespace → compute `memberCount`.
+3. Write `status.resolved.memberCount` and `status.conditions` (`SelectorAccepted`, `MembersResolved`, `Ready`).
+
+**Alternatives considered**:
+- Defer member resolution to a separate controller reconciliation loop: deferred to a future spec (mirrors the CategoryTaxonomy → controller split in #244). For this spec, synchronous admission-time resolution is sufficient.
+
+---
+
+## R-007: GraphQL Schema Strategy
+
+**Decision**: Replace `shared/schemas/collection.graphqls` entirely with a Kubernetes-style envelope matching the `Category` shape. Legacy mutation stubs return `"collection mutations are managed via git push"`.
+
+**New top-level types**:
+- `Collection implements Node` — resource envelope with `metadata: CollectionObjectMeta`, `spec: CollectionSpec`, `status: CollectionStatus`, `body`, `products(...)`.
+- `CollectionObjectMeta` — mirrors `CategoryObjectMeta` (uid, name, namespace, labels, annotations, resourceVersion, generation, creationTimestamp, revision).
+- `CollectionSpec` — `title`, `selector: LabelSelector`, `media: [MediaDefinition!]!`.
+- `LabelSelector` — `matchLabels: [KeyValuePair!]`, `matchExpressions: [LabelSelectorRequirement!]`.
+- `LabelSelectorRequirement` — `key`, `operator: LabelSelectorOperator`, `values: [String!]`.
+- `LabelSelectorOperator` — enum: `IN`, `NOT_IN`, `EXISTS`, `DOES_NOT_EXIST`.
+- `CollectionStatus` — `conditions`, `observedGeneration`, `lastAppliedRevision`, `resolved: ResolvedCollectionDefinition`.
+- `ResolvedCollectionDefinition` — `memberCount: Int!`, `media: [ResolvedFileDefinition!]!` (no `productRefs`).
+- `CollectionBy @oneOf` — `id: ID`, `namespacePath: CollectionNamespacePath`.
+
+**`LabelSelector` and `LabelSelectorRequirement` are new shared types** defined in `shared/schemas/schema.graphqls` (alongside `CategoryBy`, `ProductBy`, etc.) to enable reuse when other resources adopt label selectors.
+
+---
+
+## Constitution Compliance Check
+
+| Principle | Status |
+|-----------|--------|
+| I. Test-First | ✅ — contract + unit tests written before implementation |
+| II. API-First | ✅ — GraphQL schema contract defined in Phase 1 before any resolver |
+| III. Clear Contracts & Versioning | ✅ — schema follows additive evolution; mutations stubbed not removed |
+| IV. Observability | ✅ — admission logging follows existing pattern |
+| V. User Story Driven | ✅ — all tasks map to US1–US4 |
+| VI. Incremental Delivery | ✅ — P1 (push + query) deliverable independently of P2 (selector membership) |
+| VII. Simplicity | ✅ — no new external dependencies; selector evaluation in pure Go |

--- a/specs/022-collection-resource-contract/spec.md
+++ b/specs/022-collection-resource-contract/spec.md
@@ -1,0 +1,145 @@
+# Feature Specification: Collection Resource Contract with Label Selectors
+
+**Feature Branch**: `022-collection-resource-contract`
+**Created**: 2026-06-07
+**Status**: Closed
+**Input**: User description: "Collection Resource Contract with Label Selectors"
+
+## Clarifications
+
+### Session 2026-06-07
+
+- Q: Should resolved product references be stored inline in `status.resolved`? → A: No. `status.resolved` stores only `memberCount` (like product/category status counts). Resolved products are exposed via a paginated `collection.products(first, last, ...)` GraphQL connection, not stored in status.
+- Q: When membership changes mid-pagination of `collection.products`, how should the cursor behave? → A: Snapshot-at-query-time. The cursor is point-in-time; pages reflect membership as evaluated when the first page was fetched, preventing skips or ghost products across pages.
+- Q: When `spec.selector` is omitted entirely, what does the Collection match? → A: No products. An empty or absent selector yields zero membership; an operator must provide a non-empty selector for any products to be included.
+- Q: When `memberCount` diverges from the live `collection.products` count, which is authoritative? → A: `collection.products` is the authoritative live source. `memberCount` in `status.resolved` is a cached hint that may lag until the next reconciliation cycle.
+- Q: When a Collection is deleted, what happens to its member products? → A: Products are unaffected. They exist independently and remain in the catalog; a Collection does not own its members.
+- Q: Does `collection.products` require separate access control beyond reading the Collection? → A: No. `collection.products` inherits the same namespace-scoped access as the Collection itself; no additional per-field ACL is applied.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Define a Collection via git push (Priority: P1)
+
+A store operator authors a `Collection` Markdown file with a `kind: Collection` frontmatter envelope, commits it to the catalog repository, and pushes. The system validates the document and admits it as a `Collection` resource, making it queryable by name.
+
+**Why this priority**: This is the foundational capability — no other collection behaviour is meaningful unless a Collection can be authored and persisted.
+
+**Independent Test**: Push a single valid `Collection` document and verify it appears in the `collections` GraphQL query with correct `metadata`, `spec.title`, and an empty or absent `spec.selector`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid `Collection` frontmatter document with `kind: Collection`, `metadata.name`, and `spec.title`, **When** it is pushed to the catalog repository, **Then** the system admits the resource and it is retrievable by name with all authored fields preserved.
+2. **Given** a document whose `kind` is `Collection` but `spec.title` is missing, **When** it is pushed, **Then** the push is rejected with a descriptive validation error referencing the missing field.
+3. **Given** a document with an unrecognised `kind`, **When** it is pushed alongside a valid Collection, **Then** only the unrecognised document is rejected; the valid Collection is admitted.
+
+---
+
+### User Story 2 — Query a Collection and its members (Priority: P1)
+
+A storefront developer queries the GraphQL API for a `Collection` by name. The response includes the collection metadata, spec (title, selector, media), status with a `memberCount`, and a paginated `products` connection for traversing matched products.
+
+**Why this priority**: Without queryability the authored resource has no consumer-facing value.
+
+**Independent Test**: Query `collection(by: {namespacePath: {namespace: "...", name: "..."}})` and assert that `spec.title`, `spec.selector`, `status.resolved.memberCount`, and the `products(first: 10)` connection edges are present and correct.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Collection whose selector matches two products in the namespace, **When** queried via GraphQL, **Then** `status.resolved.memberCount` equals 2 and `collection.products(first: 10)` returns both products.
+2. **Given** a Collection whose selector matches no products, **When** queried, **Then** `status.resolved.memberCount` is 0 and `collection.products(first: 10).edges` is empty.
+3. **Given** a Collection with `spec.media` entries, **When** queried, **Then** `spec.media` is returned with each `fileRef.name`, `fileRef.kind`, and `fileRef.optional` value intact.
+
+---
+
+### User Story 3 — Selector-driven membership (Priority: P2)
+
+An operator uses `spec.selector.matchLabels` and `spec.selector.matchExpressions` to declare which products belong to a collection. Products labelled appropriately are included; unlabelled products are excluded.
+
+**Why this priority**: Label-selector membership is the core differentiator of this resource type over a manually curated list, but the P1 stories already deliver a usable collection without it.
+
+**Independent Test**: Create a Collection with `matchLabels: {gitstore.dev/brand: apple}`, push products with and without that label, then verify only labelled products appear via `collection.products(first: 10)` and `memberCount` equals the matching count.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `matchLabels` selector and products with matching labels in the same namespace, **When** the Collection is reconciled, **Then** only products whose labels satisfy every key-value pair are included.
+2. **Given** a `matchExpressions` entry with operator `In` and a set of values, **When** the Collection is reconciled, **Then** products whose label value appears in the set are included; others are excluded.
+3. **Given** a `matchExpressions` entry with operator `NotIn`, **When** reconciled, **Then** products whose label value appears in the set are excluded.
+4. **Given** both `matchLabels` and `matchExpressions` present, **When** reconciled, **Then** a product must satisfy all constraints to be included (logical AND).
+
+---
+
+### User Story 4 — Update and re-validate a Collection (Priority: P2)
+
+An operator edits the Collection document (changes title, selector, or media), pushes the update, and the system re-validates and re-resolves members.
+
+**Why this priority**: Collections will be updated frequently as merchandising strategy changes.
+
+**Independent Test**: Push an updated Collection with a narrower selector and verify `status.resolved.memberCount` decreases accordingly and `collection.products(first: 10)` returns only the narrowed set.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing Collection, **When** the operator narrows the selector and pushes, **Then** `memberCount` decreases and `collection.products(first: ...)` reflects only the products satisfying the new selector.
+2. **Given** an existing Collection, **When** the operator changes `spec.title` and pushes, **Then** the updated title is returned in GraphQL without affecting resolved members.
+
+---
+
+### Edge Cases
+
+- What happens when `spec.selector.targetRef` references a kind other than `Product`?
+- Deleting a Collection has no effect on its member products — products are independent resources not owned by the Collection.
+- How does the system behave when a `matchExpressions` entry has an empty `values` list with operator `In`?
+- What happens when the same product matches multiple Collections — is it included in all of them?
+- How does resolution behave when a Collection and several of its matched products are created in the same push?
+- What is returned for `status.resolved` and `collection.products` before any reconciliation has occurred?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST accept a `Collection` Markdown document with valid `apiVersion: catalog.gitstore.dev/v1beta1`, `kind: Collection`, `metadata.name`, and `spec.title` via git push.
+- **FR-002**: System MUST reject a `Collection` document missing `spec.title` at push time with a descriptive error message.
+- **FR-003**: System MUST reject a `Collection` document with an invalid `apiVersion` or mismatched `kind`.
+- **FR-004**: System MUST persist `spec.selector.matchLabels` and `spec.selector.matchExpressions` without modification.
+- **FR-005**: System MUST resolve collection membership by evaluating `spec.selector` against all products in the same namespace and store the resolved `memberCount` in `status.resolved`. A Collection with no `spec.selector` (omitted or empty) MUST resolve to zero members.
+- **FR-006**: System MUST support `matchExpressions` operators `In`, `NotIn`, `Exists`, and `DoesNotExist`.
+- **FR-007**: When both `matchLabels` and `matchExpressions` are present, System MUST apply them as a logical AND; a product must satisfy all constraints to be a member.
+- **FR-008**: System MUST expose a `collection(by: ...)` GraphQL query supporting lookup by namespace + name and by globally unique ID.
+- **FR-009**: System MUST expose a paginated `collections` GraphQL listing scoped to a namespace, using cursor-based pagination.
+- **FR-010**: System MUST persist `spec.media` entries and return them in GraphQL responses with `fileRef.name`, `fileRef.kind`, and `fileRef.optional`.
+- **FR-011**: System MUST expose a paginated `collection.products(first, last, after, before)` GraphQL connection that returns the products matched by the Collection's selector. The connection MUST use snapshot-at-query-time cursor semantics: all pages in a single traversal reflect membership as evaluated when the first page was requested. `collection.products` is the authoritative live source for membership; `status.resolved.memberCount` is a cached hint that may lag until the next reconciliation cycle.
+- **FR-012**: System MUST write `status.conditions` entries for `SelectorAccepted`, `MembersResolved`, and `Ready` on each reconciliation.
+- **FR-013**: `spec.selector.targetRef`, when present, MUST only accept `kind: Product`; other target kinds MUST be rejected at push time.
+
+### Key Entities
+
+- **Collection**: A named, namespace-scoped catalog resource that groups products via a declarative label selector. Carries `metadata`, `spec` (title, selector, media), and `status` (conditions, memberCount).
+- **LabelSelector**: A selector composed of `matchLabels` (exact key-value pairs) and `matchExpressions` (set-based expressions), evaluated against product labels to determine membership.
+- **LabelSelectorRequirement**: A single expression with `key`, `operator` (`In`, `NotIn`, `Exists`, `DoesNotExist`), and `values`.
+- **ResolvedCollectionDefinition**: The computed status snapshot containing `memberCount` (a cached hint, may lag reconciliation) and resolved `media`. Matched products are not stored here; they are queried live via the `collection.products` connection, which is the authoritative membership source.
+- **CollectionStatus**: The full status envelope including `conditions`, `observedGeneration`, `lastAppliedRevision`, and `resolved`.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A valid Collection document pushed to the catalog repository is admitted and queryable within the same request-response cycle as the push acknowledgement.
+- **SC-002**: `collection.products(first: 20)` returns correct results for a namespace containing up to 10,000 products within 2 seconds.
+- **SC-003**: All four `matchExpressions` operators (`In`, `NotIn`, `Exists`, `DoesNotExist`) are verified by automated tests covering both matching and non-matching cases.
+- **SC-004**: Invalid Collection documents (missing title, wrong kind, unsupported target) are rejected at push time in 100% of cases with a human-readable error message.
+- **SC-005**: The `collections` GraphQL listing returns consistent, non-duplicated results across all pages for a namespace with at least 50 collections.
+
+## Assumptions
+
+- Label keys and values follow the same conventions as product labels already in use (`gitstore.dev/` prefix for system keys).
+- `targetRef` in `CollectionSpec` defaults to `kind: Product`; other target kinds are out of scope.
+- Resolution is computed during the reconciliation cycle after a push; near-realtime staleness is acceptable.
+- `matchExpressions` with operator `Exists` or `DoesNotExist` ignore the `values` field.
+- An absent or empty `spec.selector` yields zero membership; it is not treated as a universal selector.
+- Collections are namespace-scoped; cross-namespace selectors are out of scope.
+- `collection.products` inherits the same access control as the Collection resource itself; no separate per-field authorization is applied.
+- `collection.products` evaluates the selector at query time using snapshot-at-query-time cursor semantics; membership changes between pages of a single traversal are not reflected mid-pagination.
+
+## Dependencies
+
+- GH#84: Parent Collection initiative (selector schema and overall design)
+- GH#40: ObjectMeta, Condition, and ObjectReference contracts (shared envelope types)
+- Spec 021 (`021-category-taxonomy`): Established the Kubernetes-style resource envelope pattern this spec follows

--- a/specs/022-collection-resource-contract/tasks.md
+++ b/specs/022-collection-resource-contract/tasks.md
@@ -1,0 +1,234 @@
+# Tasks: Collection Resource Contract with Label Selectors
+
+**Input**: Design documents from `/specs/022-collection-resource-contract/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/ ✅, quickstart.md ✅
+
+**Tests**: Test-First Development (Constitution Principle I — NON-NEGOTIABLE). Tests MUST be written before implementation.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+**User input applied**:
+- ScyllaDB migration replaces `collections` table inline in `001_initial_schema.cql` (no `003` migration file).
+- Status fields (`MembersResolved`, `Ready`, `observedGeneration`, `resolved`) are computed by the controller reconciliation loop (deferred to spec #244). Only `AdmissionAccepted` condition is populated at admission time.
+- Black-box integration tests live in `tests/integration/` at the repository root.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1–US4)
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: New catalog type scaffolding — independent of user story work.
+
+- [ ] T001 Create `gitstore-api/internal/catalog/collection.go` with `CollectionResource`, `CollectionSpec`, `LabelSelector`, `LabelSelectorRequirement` structs and YAML + validate tags
+- [ ] T002 [P] Create `gitstore-api/internal/catalog/selector.go` with `MatchesLabels(selector LabelSelector, labels map[string]string) bool` pure-Go evaluation function
+- [ ] T003 [P] Create unit tests `gitstore-api/internal/catalog/selector_test.go` covering all four operators (`In`, `NotIn`, `Exists`, `DoesNotExist`), combined `matchLabels` + `matchExpressions`, and empty-selector → false
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core infrastructure that MUST be complete before ANY user story can be implemented.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [ ] T004 Replace the `collections` table DDL in `gitstore-api/internal/datastore/scylla/migrations/001_initial_schema.cql`: remove the legacy flat table and add the three Kubernetes-style tables — `collection` (namespace-partitioned), `collection_by_name`, `collection_by_uid` — following the `category_taxonomy` pattern; also remove the `collections_by_id` and `collections_by_slug` index entries from `002_add_initial_indices.cql`
+- [ ] T005 Replace the legacy `Collection` struct in `gitstore-api/internal/datastore/entities.go` with the Kubernetes-style entity (all fields from data-model.md: `UID`, `Namespace`, `Name`, `APIVersion`, `Kind`, `Generation`, `ResourceVersion`, `CreationTimestamp`, `Revision`, `Labels`, `Annotations`, `GitCommitSHA`, `GitRef`, `Spec json.RawMessage`, `Body`, `Status json.RawMessage`)
+- [ ] T006 Add five new `Datastore` interface methods to `gitstore-api/internal/datastore/datastore.go`: `CreateCollection`, `GetCollection`, `UpdateCollection`, `GetCollectionByName`, `ListCollections`; also add `ListProductsByLabelSelector(ctx, namespace string, selector catalog.LabelSelector) ([]*Product, error)`
+- [ ] T007 Rebuild the `collection` memdb table in `gitstore-api/internal/datastore/memdb/schema.go`: replace `id`+`slug` indexes with `id` (UUID), `name_namespace` (compound unique on `Name`+`Namespace`), and `namespace` (non-unique) indexes
+- [ ] T008 Implement all six new Datastore methods for the memdb backend in `gitstore-api/internal/datastore/memdb/backend.go`, following the `CategoryTaxonomy` implementation pattern
+- [ ] T009 Add `CollectionRow`, `CollectionByNameRow`, `CollectionByUIDRow` structs to `gitstore-api/internal/datastore/scylla/models.go`
+- [ ] T010 Implement all six new Datastore methods for the ScyllaDB backend in `gitstore-api/internal/datastore/scylla/backend.go`, following the `CategoryTaxonomy` three-table pattern
+- [ ] T011 Wrap all six new Datastore methods in `gitstore-api/internal/datastore/instrumented.go` with `InstrumentedDatastore`
+- [ ] T012 Extend `gitstore-api/internal/validate/validator.go`: add `Collection *catalog.CollectionResource` to `ParsedResource`; add `case "Collection":` to `ParseResource` switch with `validateCollectionSpec` (title required, operator enum, values constraints for `In`/`NotIn`, `targetRef.kind == "Product"` if present)
+- [ ] T013 Write datastore contract tests for all Collection CRUD methods in `gitstore-api/tests/contract/datastore/contract_test.go`, covering `CreateCollection`, `GetCollectionByName`, `GetCollection` (by UID), `ListCollections` (pagination), `UpdateCollection`, and `ListProductsByLabelSelector` for both memdb and ScyllaDB backends
+
+**Checkpoint**: Foundation ready — user story implementation can now begin in parallel.
+
+---
+
+## Phase 3: User Story 1 — Define a Collection via git push (Priority: P1) 🎯 MVP
+
+**Goal**: A valid `Collection` document pushed to the catalog repository is admitted, persisted, and the push is rejected for invalid documents.
+
+**Independent Test**: Push a single valid `Collection` document; verify it is stored and the pre-receive hook rejects an invalid one (missing title).
+
+### Tests for User Story 1
+
+> **Write these tests FIRST, ensure they FAIL before implementation.**
+
+- [ ] T014 [P] [US1] Write integration test in `tests/integration/collection_test.go`: push a valid `Collection` document and assert the push succeeds (exit 0) and no error appears in pre-receive output
+- [ ] T015 [P] [US1] Write integration test in `tests/integration/collection_test.go`: push a `Collection` document with missing `spec.title` and assert the push is rejected with a descriptive error message
+- [ ] T016 [P] [US1] Write integration test in `tests/integration/collection_test.go`: push a `Collection` with `spec.selector.targetRef.kind` set to `Category` and assert rejection
+
+### Implementation for User Story 1
+
+- [ ] T017 [US1] Add `Collection` admission branch to `gitstore-api/internal/cataloggrpc/server.go` in `AdmitResources`: parse via `ParseResource`, upsert via `CreateCollection`/`UpdateCollection`, write `AdmissionAccepted` condition to `status.conditions` at admission time; defer `MembersResolved`/`Ready`/`resolved.memberCount` to controller reconciliation (spec #244)
+- [ ] T018 [US1] Add `DatastoreCollectionToGraphQL` converter function to `gitstore-api/internal/graph/converters.go` that maps the `Collection` entity to `model.Collection`, including `spec.selector` and `spec.media` hydration from `Spec json.RawMessage`
+
+**Checkpoint**: At this point a valid Collection push is admitted and persisted. Invalid pushes are rejected.
+
+---
+
+## Phase 4: User Story 2 — Query a Collection (Priority: P1)
+
+**Goal**: A storefront developer can query a Collection by name or ID and retrieve metadata, spec, status, and an empty `products` connection placeholder.
+
+**Independent Test**: Query `collection(by: {namespacePath: ...})` for a pushed Collection and assert `spec.title`, `spec.selector`, `status.conditions[AdmissionAccepted]` are present.
+
+### Tests for User Story 2
+
+> **Write these tests FIRST, ensure they FAIL before implementation.**
+
+- [ ] T019 [P] [US2] Write integration test in `tests/integration/collection_test.go`: push a Collection and query it via GraphQL `collection(by: namespacePath)`; assert `metadata.name`, `spec.title`, `spec.selector.matchLabels`, and `status.conditions` are correct
+- [ ] T020 [P] [US2] Write integration test in `tests/integration/collection_test.go`: query `collections(first: 10)` and assert the pushed Collection appears in the connection edges
+
+### Implementation for User Story 2
+
+- [ ] T021 [US2] Rewrite `shared/schemas/collection.graphqls` from the contract in `specs/022-collection-resource-contract/contracts/collection.graphqls`: Kubernetes-style `Collection` type with `CollectionObjectMeta`, `CollectionSpec`, `LabelSelector`, `LabelSelectorRequirement`, `LabelSelectorOperator`, `CollectionStatus`, `CollectionCondition`, `ResolvedCollectionDefinition`, `CollectionBy @oneOf`, `CollectionNamespacePath`, `CollectionConnection`, `CollectionEdge`; legacy mutation stubs
+- [ ] T022 [US2] Add shared types to `shared/schemas/schema.graphqls`: `LabelSelector`, `LabelSelectorRequirement`, `LabelSelectorOperator` (enum), `CollectionBy`, `CollectionNamespacePath`
+- [ ] T023 [US2] Run gqlgen code generation: `go generate ./internal/graph/...` in `gitstore-api/`
+- [ ] T024 [US2] Replace legacy collection resolvers in `gitstore-api/internal/graph/collection.resolvers.go`: implement `Collection` (lookup by ID or namespacePath via `@oneOf`), `Collections` (paginated listing), and stub legacy mutations to return `"collection mutations are managed via git push"`
+- [ ] T025 [US2] Add `GetCollectionByUID`, `GetCollectionByName`, `ListCollections` service wrappers to `gitstore-api/internal/graph/service.go`
+
+**Checkpoint**: `collection(by: ...)` and `collections(...)` queries work end-to-end. Legacy mutations return informative errors.
+
+---
+
+## Phase 5: User Story 3 — Selector-driven membership via `collection.products` (Priority: P2)
+
+**Goal**: `collection.products(first, last, ...)` returns products whose labels satisfy the collection's selector, using snapshot-at-query-time cursor semantics.
+
+**Independent Test**: Push a Collection with `matchLabels: {gitstore.dev/brand: apple}`, push products with and without that label, query `collection.products(first: 10)`, and assert only matching products are returned.
+
+### Tests for User Story 3
+
+> **Write these tests FIRST, ensure they FAIL before implementation.**
+
+- [ ] T026 [P] [US3] Write integration test in `tests/integration/collection_test.go`: push a Collection with `matchLabels`, push two products (one matching, one not), query `collection.products(first: 10)`, assert only the matching product is returned
+- [ ] T027 [P] [US3] Write integration test in `tests/integration/collection_test.go`: verify snapshot cursor — fetch page 1, relabel a product to no longer match, fetch page 2 using the page-1 cursor, assert the previously matching product is still returned on page 2 (snapshot semantics)
+- [ ] T028 [P] [US3] Write integration test in `tests/integration/collection_test.go`: push a Collection with no `spec.selector`; assert `collection.products(first: 10).edges` is empty
+
+### Implementation for User Story 3
+
+- [ ] T029 [US3] Implement `ListProductsByLabelSelector` in `gitstore-api/internal/datastore/memdb/backend.go`: fetch all products in the namespace, filter using `catalog.MatchesLabels`, return ordered slice
+- [ ] T030 [US3] Implement `ListProductsByLabelSelector` in `gitstore-api/internal/datastore/scylla/backend.go`: scan `products_by_namespace` partition, filter using `catalog.MatchesLabels`, return ordered slice
+- [ ] T031 [US3] Add `ListProductsBySelector` service wrapper to `gitstore-api/internal/graph/service.go`
+- [ ] T032 [US3] Implement `collection.Products` resolver in `gitstore-api/internal/graph/collection.resolvers.go` with snapshot-at-query-time cursor: on first page, evaluate selector via `ListProductsBySelector`, encode ordered UID list into opaque cursor; on subsequent pages, decode cursor and slice; build `ProductConnection` via `BuildProductConnection`
+
+**Checkpoint**: `collection.products` returns correctly filtered products with stable pagination.
+
+---
+
+## Phase 6: User Story 4 — Update and re-validate a Collection (Priority: P2)
+
+**Goal**: Pushing an updated Collection re-validates the document and updates the persisted spec; `AdmissionAccepted` condition is refreshed.
+
+**Independent Test**: Push a Collection, then push an updated version with a changed title; query and assert the updated title is returned and `AdmissionAccepted` reflects the new revision.
+
+### Tests for User Story 4
+
+> **Write these tests FIRST, ensure they FAIL before implementation.**
+
+- [ ] T033 [P] [US4] Write integration test in `tests/integration/collection_test.go`: push a Collection, then push the same Collection with a changed `spec.title`; query and assert `spec.title` reflects the update and `metadata.generation` has incremented
+- [ ] T034 [P] [US4] Write integration test in `tests/integration/collection_test.go`: push a Collection with a wide selector (many matches), then push with a narrower selector; assert `collection.products(first: 50)` reflects only the narrowed set after the second push
+
+### Implementation for User Story 4
+
+- [ ] T035 [US4] Verify `AdmitResources` in `gitstore-api/internal/cataloggrpc/server.go` correctly uses `UpdateCollection` for an existing `(namespace, name)` pair (upsert logic): increment `Generation`, update `ResourceVersion`, set `Revision` to new git SHA, refresh `AdmissionAccepted` condition timestamp
+
+**Checkpoint**: Collection updates are idempotent and correctly increment generation.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+- [ ] T036 [P] Add unit tests for `DatastoreCollectionToGraphQL` in `gitstore-api/internal/graph/converters_test.go`: spec media hydration, nil-spec → empty media, nil input → nil output, selector hydration
+- [ ] T037 [P] Add unit tests for `Collection` and `Collections` resolvers in `gitstore-api/internal/graph/collection_resolver_test.go` following the pattern in `category_resolver_test.go`
+- [ ] T038 [P] Write author guide `docs/products/collection.md` documenting Collection frontmatter schema, selector syntax, `collection.products` semantics, and example documents (model on `docs/products/category-taxonomy.md`)
+- [ ] T039 Run `make pr-ready` (build + test + lint + license-check) and resolve all failures
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately; T002 and T003 can run in parallel with T001.
+- **Phase 2 (Foundational)**: Depends on Phase 1 completion. T004–T013 can proceed: T004/T005 parallel, T006 after T005, T007–T008 after T006, T009–T010 after T006, T011 after T006/T008/T010, T012 after T001, T013 after T008/T010/T011.
+- **Phase 3 (US1)**: Depends on Phase 2 completion. T014–T016 (tests) written first; T017–T018 implement.
+- **Phase 4 (US2)**: Depends on Phase 3. T019–T020 (tests) first; T021–T022 can run in parallel; T023 after T021/T022; T024–T025 after T023.
+- **Phase 5 (US3)**: Depends on Phase 4 (needs `collection.products` field in schema). T026–T028 (tests) first; T029/T030 [P]; T031–T032 after T029/T030.
+- **Phase 6 (US4)**: Depends on Phase 3 foundation (upsert logic). T033/T034 [P]; T035 implementation.
+- **Phase 7 (Polish)**: Depends on all prior phases. T036/T037/T038 [P].
+
+### User Story Dependencies
+
+- **US1 (P1)**: Depends only on Foundational (Phase 2) — no cross-story dependency.
+- **US2 (P1)**: Depends on US1 (entity admitted before it can be queried).
+- **US3 (P2)**: Depends on US2 (schema + resolver scaffolding needed for `collection.products` field).
+- **US4 (P2)**: Depends on US1 (upsert path must exist).
+
+### Parallel Opportunities
+
+- T002 + T003 (selector impl + selector tests) in parallel after T001.
+- T004 + T005 in parallel (different files in foundational phase).
+- T007 + T009 in parallel (memdb schema + scylla models, different files).
+- T008 + T010 in parallel (memdb backend + scylla backend).
+- T014 + T015 + T016 in parallel (all integration test stubs for US1).
+- T019 + T020 in parallel (integration test stubs for US2).
+- T021 + T022 in parallel (schema rewrites in different files).
+- T026 + T027 + T028 in parallel (integration test stubs for US3).
+- T029 + T030 in parallel (memdb + scylla selector implementations).
+- T033 + T034 in parallel (integration test stubs for US4).
+- T036 + T037 + T038 in parallel (polish).
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Write tests first (all in parallel):
+T014: "push valid Collection → assert success"
+T015: "push Collection missing title → assert rejection"
+T016: "push Collection with bad targetRef → assert rejection"
+
+# Then implement (sequential):
+T017: AdmitResources Collection branch (depends on T014–T016 failing)
+T018: DatastoreCollectionToGraphQL converter
+```
+
+---
+
+## Implementation Strategy
+
+### MVP (User Stories 1 + 2)
+
+1. Complete Phase 1 (Setup) — T001–T003
+2. Complete Phase 2 (Foundational) — T004–T013
+3. Complete Phase 3 (US1: push admission) — T014–T018
+4. Complete Phase 4 (US2: query) — T019–T025
+5. **STOP and VALIDATE**: push a Collection and query it via GraphQL
+6. Demo / ship P1 increment
+
+### Incremental Delivery
+
+1. Setup + Foundational → entity + datastore ready
+2. US1 → push admission working
+3. US2 → query working → **P1 complete, shippable**
+4. US3 → `collection.products` with selector → P2 membership
+5. US4 → update handling → P2 complete
+6. Polish → docs + coverage
+
+---
+
+## Notes
+
+- `AdmissionAccepted` is the only status condition populated at admission time. `MembersResolved`, `Ready`, `observedGeneration`, and `resolved.memberCount` are set by the controller reconciliation loop (deferred to spec #244 / GH#244).
+- ScyllaDB migration replaces the legacy `collections` table inline in `001_initial_schema.cql` — no separate `003` migration file needed.
+- Black-box integration tests live in `tests/integration/` at the repository root (not inside `gitstore-api/`).
+- `collection.products` snapshot cursor: encode ordered UID list (result of selector evaluation) into an opaque token on the first page; subsequent pages decode and slice — no external cache needed for correctness, though an LRU can be added later as an optimisation.
+- Each task should be committed after completion or as a logical group; run `make test` before each commit.


### PR DESCRIPTION
## Summary

- Replaces the legacy `Collection` entity with a Kubernetes-style resource envelope (`UID`/`Namespace`/`Name`/`APIVersion`/`Kind`/`Generation`/`ResourceVersion`/`CreationTimestamp`)
- Collections declare membership via a `spec.selector` (matchLabels + matchExpressions); `collection.products` resolves live membership through `ListProductsByLabelSelector`
- Three-table ScyllaDB layout (`collection`, `collection_by_name`, `collection_by_uid`) mirrors the CategoryTaxonomy pattern
- `ParseResource` dispatcher extended with a `Collection` kind; admission hook writes only the `AdmissionAccepted` condition; remaining status fields are left for controller reconciliation
- New `catalog` package exports `LabelSelector`, `LabelSelectorRequirement`, `MatchesLabels`, and `CollectionResource` (frontmatter schema)
- GraphQL schema rewritten to K8s envelope (`CollectionObjectMeta`, `CollectionSpec`, `LabelSelector`, `CollectionStatus`); legacy mutation stubs return a deprecation error; `collection.products` is a paginated connection
- `CollectionBy` now accepts `namespacePath: {namespace, name}` instead of the legacy `slug`
- Datastore contract tests cover `GetByName`, `DuplicateNameReturnsAlreadyExists`, `ListByNamespace`, and `ListProductsByLabelSelector` (match/no-match/empty-selector)

## Test plan

- [ ] `go test ./internal/...` — all unit and contract tests pass
- [ ] `go test ./tests/contract/datastore/...` — datastore contract suite green
- [ ] `make pr-ready` — build + lint + license-check pass
- [ ] Manual: push a Collection YAML via git, query `collection { metadata { name } spec { selector { matchLabels { key value } } } }` and verify response shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)