### PR TITLE
refactor(graph): move resolvers into subpackage

### DIFF
--- a/gitstore-api/cmd/server/main.go
+++ b/gitstore-api/cmd/server/main.go
@@ -25,8 +25,8 @@ import (
 	dsfactory "github.com/gitstore-dev/gitstore/api/internal/datastore/factory"
 	"github.com/gitstore-dev/gitstore/api/internal/gitclient"
 	"github.com/gitstore-dev/gitstore/api/internal/githttp"
-	"github.com/gitstore-dev/gitstore/api/internal/graph"
 	"github.com/gitstore-dev/gitstore/api/internal/graph/generated"
+	"github.com/gitstore-dev/gitstore/api/internal/graph/resolver"
 	"github.com/gitstore-dev/gitstore/api/internal/handler"
 	"github.com/gitstore-dev/gitstore/api/internal/health"
 	"github.com/gitstore-dev/gitstore/api/internal/logger"
@@ -191,10 +191,10 @@ func main() {
 	logger.Log.Info("Server stopped")
 }
 
-func newGraphQLHandler(store datastore.Datastore, writer graph.GitWriter, log *zap.Logger, authMiddleware *middleware.AuthMiddleware) http.Handler {
-	resolver := graph.NewResolver(store, writer, log)
-	resolver.WithAuthMiddleware(authMiddleware)
-	schema := generated.NewExecutableSchema(generated.Config{Resolvers: resolver})
+func newGraphQLHandler(store datastore.Datastore, writer resolver.GitWriter, log *zap.Logger, authMiddleware *middleware.AuthMiddleware) http.Handler {
+	rootResolver := resolver.NewResolver(store, writer, log)
+	rootResolver.WithAuthMiddleware(authMiddleware)
+	schema := generated.NewExecutableSchema(generated.Config{Resolvers: rootResolver})
 	gqlServer := gqlhandler.NewDefaultServer(schema)
 
 	gqlHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/gitstore-api/gqlgen.yml
+++ b/gitstore-api/gqlgen.yml
@@ -40,14 +40,14 @@ model:
 
 # Where should the resolver implementations go?
 resolver:
-  package: graph
+  package: resolver
   layout: follow-schema # Only other option is "single-file."
 
   # Only for single-file layout:
   # filename: graph/resolver.go
 
   # Only for follow-schema layout:
-  dir: internal/graph
+  dir: internal/graph/resolver
   filename_template: "{name}.resolvers.go"
 
   # Optional: turn on to not generate template comments above resolvers

--- a/gitstore-api/internal/graph/resolver/auth.resolvers.go
+++ b/gitstore-api/internal/graph/resolver/auth.resolvers.go
@@ -1,4 +1,4 @@
-package graph
+package resolver
 
 // This file will be automatically regenerated based on the schema, any resolver
 // implementations

--- a/gitstore-api/internal/graph/resolver/category.resolvers.go
+++ b/gitstore-api/internal/graph/resolver/category.resolvers.go
@@ -1,4 +1,4 @@
-package graph
+package resolver
 
 // This file will be automatically regenerated based on the schema, any resolver
 // implementations

--- a/gitstore-api/internal/graph/resolver/category_resolver_test.go
+++ b/gitstore-api/internal/graph/resolver/category_resolver_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (c) 2026 GitStore contributors
 
-package graph
+package resolver
 
 import (
 	"context"

--- a/gitstore-api/internal/graph/resolver/collection.resolvers.go
+++ b/gitstore-api/internal/graph/resolver/collection.resolvers.go
@@ -1,4 +1,4 @@
-package graph
+package resolver
 
 // This file will be automatically regenerated based on the schema, any resolver
 // implementations

--- a/gitstore-api/internal/graph/resolver/converters.go
+++ b/gitstore-api/internal/graph/resolver/converters.go
@@ -3,7 +3,7 @@
 
 // Type converters between datastore and GraphQL models
 
-package graph
+package resolver
 
 import (
 	"encoding/json"

--- a/gitstore-api/internal/graph/resolver/converters_test.go
+++ b/gitstore-api/internal/graph/resolver/converters_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (c) 2026 GitStore contributors
 
-package graph
+package resolver
 
 import (
 	"encoding/json"

--- a/gitstore-api/internal/graph/resolver/diff.go
+++ b/gitstore-api/internal/graph/resolver/diff.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (c) 2026 GitStore contributors
 
-package graph
+package resolver
 
 import (
 	"fmt"

--- a/gitstore-api/internal/graph/resolver/diff_test.go
+++ b/gitstore-api/internal/graph/resolver/diff_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (c) 2026 GitStore contributors
 
-package graph
+package resolver
 
 import (
 	"testing"

--- a/gitstore-api/internal/graph/resolver/global_id.go
+++ b/gitstore-api/internal/graph/resolver/global_id.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (c) 2026 GitStore contributors
 
-package graph
+package resolver
 
 import (
 	"encoding/base64"

--- a/gitstore-api/internal/graph/resolver/global_id_test.go
+++ b/gitstore-api/internal/graph/resolver/global_id_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (c) 2026 GitStore contributors
 
-package graph
+package resolver
 
 import (
 	"encoding/base64"

--- a/gitstore-api/internal/graph/resolver/helpers.go
+++ b/gitstore-api/internal/graph/resolver/helpers.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (c) 2026 GitStore contributors
 
-package graph
+package resolver
 
 import (
 	"context"

--- a/gitstore-api/internal/graph/resolver/keyset_cursor.go
+++ b/gitstore-api/internal/graph/resolver/keyset_cursor.go
@@ -3,7 +3,7 @@
 
 // Keyset cursor encoding and decoding for stable, opaque Relay pagination
 
-package graph
+package resolver
 
 import (
 	"encoding/base64"

--- a/gitstore-api/internal/graph/resolver/keyset_cursor_test.go
+++ b/gitstore-api/internal/graph/resolver/keyset_cursor_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (c) 2026 GitStore contributors
 
-package graph
+package resolver
 
 import (
 	"testing"

--- a/gitstore-api/internal/graph/resolver/namespace.resolvers.go
+++ b/gitstore-api/internal/graph/resolver/namespace.resolvers.go
@@ -1,4 +1,4 @@
-package graph
+package resolver
 
 // This file will be automatically regenerated based on the schema, any resolver
 // implementations

--- a/gitstore-api/internal/graph/resolver/namespace_service_test.go
+++ b/gitstore-api/internal/graph/resolver/namespace_service_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (c) 2026 GitStore contributors
 
-package graph_test
+package resolver_test
 
 import (
 	"context"

--- a/gitstore-api/internal/graph/resolver/oneof_lookup_validation_test.go
+++ b/gitstore-api/internal/graph/resolver/oneof_lookup_validation_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (c) 2026 GitStore contributors
 
-package graph
+package resolver
 
 import (
 	"fmt"

--- a/gitstore-api/internal/graph/resolver/pagination.go
+++ b/gitstore-api/internal/graph/resolver/pagination.go
@@ -3,7 +3,7 @@
 
 // Relay-style connection builders powered by generic datastore.PageResult.
 
-package graph
+package resolver
 
 import (
 	"github.com/gitstore-dev/gitstore/api/internal/datastore"

--- a/gitstore-api/internal/graph/resolver/product.resolvers.go
+++ b/gitstore-api/internal/graph/resolver/product.resolvers.go
@@ -1,4 +1,4 @@
-package graph
+package resolver
 
 // This file will be automatically regenerated based on the schema, any resolver
 // implementations

--- a/gitstore-api/internal/graph/resolver/product_resolver_test.go
+++ b/gitstore-api/internal/graph/resolver/product_resolver_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (c) 2026 GitStore contributors
 
-package graph
+package resolver
 
 import (
 	"context"

--- a/gitstore-api/internal/graph/resolver/product_variant.resolvers.go
+++ b/gitstore-api/internal/graph/resolver/product_variant.resolvers.go
@@ -1,4 +1,4 @@
-package graph
+package resolver
 
 // This file will be automatically regenerated based on the schema, any resolver
 // implementations

--- a/gitstore-api/internal/graph/resolver/query_helpers.go
+++ b/gitstore-api/internal/graph/resolver/query_helpers.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (c) 2026 GitStore contributors
 
-package graph
+package resolver
 
 import (
 	"context"

--- a/gitstore-api/internal/graph/resolver/repository.resolvers.go
+++ b/gitstore-api/internal/graph/resolver/repository.resolvers.go
@@ -1,4 +1,4 @@
-package graph
+package resolver
 
 // This file will be automatically regenerated based on the schema, any resolver
 // implementations

--- a/gitstore-api/internal/graph/resolver/repository_resolver_test.go
+++ b/gitstore-api/internal/graph/resolver/repository_resolver_test.go
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (c) 2026 GitStore contributors
 
-package graph_test
+package resolver_test
 
 import (
 	"context"
 	"testing"
 
 	"github.com/gitstore-dev/gitstore/api/internal/datastore"
-	"github.com/gitstore-dev/gitstore/api/internal/graph"
+	"github.com/gitstore-dev/gitstore/api/internal/graph/resolver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -18,7 +18,7 @@ const (
 	testNsID2 = "01960000-0000-7000-8000-000000000011"
 )
 
-func svcStore(t *testing.T, svc *graph.Service) datastore.Datastore {
+func svcStore(t *testing.T, svc *resolver.Service) datastore.Datastore {
 	t.Helper()
 	return svc.Store()
 }

--- a/gitstore-api/internal/graph/resolver/resolver.go
+++ b/gitstore-api/internal/graph/resolver/resolver.go
@@ -3,7 +3,7 @@
 
 // Base GraphQL resolver
 
-package graph
+package resolver
 
 import (
 	"github.com/gitstore-dev/gitstore/api/internal/datastore"

--- a/gitstore-api/internal/graph/resolver/resolver_global_id_test.go
+++ b/gitstore-api/internal/graph/resolver/resolver_global_id_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (c) 2026 GitStore contributors
 
-package graph
+package resolver
 
 import (
 	"context"

--- a/gitstore-api/internal/graph/resolver/schema.resolvers.go
+++ b/gitstore-api/internal/graph/resolver/schema.resolvers.go
@@ -1,4 +1,4 @@
-package graph
+package resolver
 
 // This file will be automatically regenerated based on the schema, any resolver
 // implementations

--- a/gitstore-api/internal/graph/resolver/service.go
+++ b/gitstore-api/internal/graph/resolver/service.go
@@ -4,7 +4,7 @@
 // Service layer for GraphQL resolvers
 // Handles CRUD operations via the datastore abstraction layer.
 
-package graph
+package resolver
 
 import (
 	"context"

--- a/gitstore-api/internal/graph/resolver/service_mutations_test.go
+++ b/gitstore-api/internal/graph/resolver/service_mutations_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (c) 2026 GitStore contributors
 
-package graph_test
+package resolver_test
 
 import (
 	"context"
@@ -11,13 +11,13 @@ import (
 	"github.com/gitstore-dev/gitstore/api/internal/datastore"
 	"github.com/gitstore-dev/gitstore/api/internal/datastore/memdb"
 	"github.com/gitstore-dev/gitstore/api/internal/gitclient"
-	"github.com/gitstore-dev/gitstore/api/internal/graph"
+	"github.com/gitstore-dev/gitstore/api/internal/graph/resolver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 
-// mockGitWriter implements graph.GitWriter for testing.
+// mockGitWriter implements resolver.GitWriter for testing.
 type mockGitWriter struct {
 	mu             sync.Mutex
 	commitCalls    []gitclient.CommitFileParams
@@ -78,18 +78,18 @@ func (m *mockGitWriter) CreateTag(_ context.Context, p gitclient.CreateTagParams
 }
 
 // newTestSvc builds a Service backed by an in-memory datastore.
-func newTestSvc(t *testing.T, writer *mockGitWriter) *graph.Service {
+func newTestSvc(t *testing.T, writer *mockGitWriter) *resolver.Service {
 	t.Helper()
 	store, err := memdb.New()
 	require.NoError(t, err)
-	return graph.NewServiceWithWriter(store, writer, zap.NewNop())
+	return resolver.NewServiceWithWriter(store, writer, zap.NewNop())
 }
 
 func TestServiceDeleteProductRemovesFromDatastore(t *testing.T) {
 	ctx := context.Background()
 	store, err := memdb.New()
 	require.NoError(t, err)
-	svc := graph.NewServiceWithWriter(store, &mockGitWriter{}, zap.NewNop())
+	svc := resolver.NewServiceWithWriter(store, &mockGitWriter{}, zap.NewNop())
 
 	uid := "a0000000-0000-0000-0000-000000000001"
 	require.NoError(t, store.CreateProduct(ctx, &datastore.Product{

--- a/gitstore-api/internal/graph/resolver/version_check.go
+++ b/gitstore-api/internal/graph/resolver/version_check.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (c) 2026 GitStore contributors
 
-package graph
+package resolver
 
 import (
 	"crypto/sha256"

--- a/gitstore-api/internal/graph/resolver/version_check_test.go
+++ b/gitstore-api/internal/graph/resolver/version_check_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (c) 2026 GitStore contributors
 
-package graph
+package resolver
 
 import (
 	"strings"


### PR DESCRIPTION
## Summary
- move handwritten GraphQL resolver code and tests into internal/graph/resolver
- update gqlgen resolver output to target the resolver subpackage
- update server wiring to import the new resolver package

## Verification
- make pr-ready
- cd gitstore-api && go generate ./...
- cd gitstore-api && go test ./...