### PR TITLE
refactor(api): introduce manual dependency injection

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,6 +53,12 @@ The API gateway (`gitstore-api`) and the Git server (`gitstore-git-service`) com
 `gitstore-git-service` serves one port:
 - Port `50051` — gRPC only
 
+### Go API Composition
+
+`gitstore-api` uses explicit manual dependency injection. Runtime wiring is centralized in `gitstore-api/internal/app`, and `cmd/server/main.go` is limited to configuration loading, logger construction, server startup, and signal-driven shutdown.
+
+Business packages receive dependencies through plain `Deps` structs rather than package globals or a DI framework. Shared infrastructure seams such as clocks, ID generators, catalog parsers, Git clients, auth services, and loggers are passed into constructors so tests can use deterministic time, IDs, and token expiry behavior.
+
 Key environment variables:
 
 | Service                | Variable                   | Purpose                                                          |

--- a/gitstore-api/cmd/server/main.go
+++ b/gitstore-api/cmd/server/main.go
@@ -8,31 +8,15 @@ package main
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
 
-	"net"
-
-	gqlhandler "github.com/99designs/gqlgen/graphql/handler"
-	"github.com/99designs/gqlgen/graphql/playground"
-	catalogv1 "github.com/gitstore-dev/gitstore/api/gen/gitstore/catalog/v1"
-	"github.com/gitstore-dev/gitstore/api/internal/cataloggrpc"
+	"github.com/gitstore-dev/gitstore/api/internal/app"
 	"github.com/gitstore-dev/gitstore/api/internal/config"
-	"github.com/gitstore-dev/gitstore/api/internal/datastore"
-	dsfactory "github.com/gitstore-dev/gitstore/api/internal/datastore/factory"
-	"github.com/gitstore-dev/gitstore/api/internal/gitclient"
-	"github.com/gitstore-dev/gitstore/api/internal/githttp"
-	"github.com/gitstore-dev/gitstore/api/internal/graph/generated"
-	"github.com/gitstore-dev/gitstore/api/internal/graph/resolver"
-	"github.com/gitstore-dev/gitstore/api/internal/handler"
-	"github.com/gitstore-dev/gitstore/api/internal/health"
 	"github.com/gitstore-dev/gitstore/api/internal/logger"
-	"github.com/gitstore-dev/gitstore/api/internal/middleware"
 	"go.uber.org/zap"
-	"google.golang.org/grpc"
 )
 
 func main() {
@@ -42,164 +26,36 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := logger.InitLogger(cfg.Log.Level, cfg.Log.Format); err != nil {
+	log, err := logger.InitLogger(cfg.Log.Level, cfg.Log.Format)
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to initialize logger: %v\n", err)
 		os.Exit(1)
 	}
-	defer logger.Sync()
+	defer func() { _ = log.Sync() }()
 
-	logger.Log.Info("Starting GitStore GraphQL API",
+	log.Info("Starting GitStore GraphQL API",
 		zap.Int("port", cfg.Api.Port),
 		zap.String("git.grpc.uri", cfg.Git.Grpc.Uri),
 		zap.String("datastore_backend", cfg.Datastore.Backend),
 	)
 
-	// Create datastore backed by configured backend
-	store, err := dsfactory.NewDatastore(cfg.Datastore, logger.Log)
+	server, err := app.NewServer(cfg, log)
 	if err != nil {
-		logger.Log.Fatal("Failed to create datastore", zap.Error(err))
+		log.Fatal("Failed to create server", zap.Error(err))
 	}
-	store = datastore.NewInstrumentedDatastore(store, cfg.Datastore.Backend, logger.Log)
-	defer store.Close()
-
-	// Dial git-service via gRPC
-	gitClient, err := gitclient.NewClientWithAddr(cfg.Git.Grpc.Uri)
-	if err != nil {
-		logger.Log.Fatal("Failed to connect to git-service", zap.Error(err))
-	}
-	defer gitClient.Close()
-
-	// Create auth middleware
-	authMiddleware, err := middleware.NewAuthMiddleware(
-		cfg.Auth.Admin.Username,
-		cfg.Auth.Admin.Password,
-		cfg.Auth.JWT.Secret,
-		cfg.Auth.JWT.Duration,
-		cfg.Auth.JWT.Issuer,
-	)
-	if err != nil {
-		logger.Log.Fatal("Failed to create auth middleware", zap.Error(err))
-	}
-
-	// Create GraphQL resolver
-	gqlHandler := newGraphQLHandler(store, gitClient, logger.Log, authMiddleware)
-
-	// Create health check handler
-	healthHandler := health.NewHandler(store, logger.Log, "1.0.0")
-
-	// Create HTTP server
-	mux := http.NewServeMux()
-
-	loginHandler := handler.NewLoginHandler(authMiddleware, logger.Log)
-	mux.Handle("/api/login", loginHandler)
-	mux.Handle("/graphql", gqlHandler)
-	mux.Handle("/playground", playground.Handler("GraphQL Playground", "/graphql"))
-	mux.HandleFunc("/health", healthHandler.Health)
-	mux.HandleFunc("/ready", healthHandler.Ready)
-
-	var httpHandler http.Handler = mux
-	httpHandler = middleware.CORSMiddleware(httpHandler)
-	httpHandler = middleware.RequestIDMiddleware(httpHandler)
-
-	srv := &http.Server{
-		Addr:         fmt.Sprintf(":%d", cfg.Api.Port),
-		Handler:      httpHandler,
-		ReadTimeout:  15 * time.Second,
-		WriteTimeout: 15 * time.Second,
-		IdleTimeout:  60 * time.Second,
-	}
-
-	go func() {
-		logger.Log.Info("GraphQL API server starting", zap.Int("port", cfg.Api.Port))
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			logger.Log.Fatal("Server error", zap.Error(err))
-		}
-	}()
-
-	// Git smart HTTP server on port cfg.Api.GitPort
-	gitResolver := func(namespace, repo string) (string, bool) {
-		ctx := context.Background()
-		ns, err := store.GetNamespaceByIdentifier(ctx, namespace)
-		if err != nil || ns == nil {
-			return "", false
-		}
-		mapping, err := store.LookupRepository(ctx, ns.ID, repo)
-		if err != nil || mapping == nil {
-			return "", false
-		}
-		return mapping.RepoID, true
-	}
-
-	gitMux := githttp.NewMux(gitClient, gitResolver, logger.Log, http.HandlerFunc(healthHandler.Health))
-	gitSrv := &http.Server{
-		Addr:         fmt.Sprintf(":%d", cfg.Api.GitPort),
-		Handler:      middleware.RequestIDMiddleware(gitMux),
-		ReadTimeout:  0,
-		WriteTimeout: 0,
-		IdleTimeout:  60 * time.Second,
-	}
-
-	go func() {
-		logger.Log.Info("Git smart HTTP server starting", zap.Int("port", cfg.Api.GitPort))
-		if err := gitSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			logger.Log.Error("Git HTTP server error", zap.Error(err))
-		}
-	}()
-
-	// CatalogService gRPC server — receives hook pipeline callouts from gitstore-git-service.
-	grpcLis, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.Api.GrpcPort))
-	if err != nil {
-		logger.Log.Fatal("Failed to listen on gRPC port", zap.Int("port", cfg.Api.GrpcPort), zap.Error(err))
-	}
-	grpcServer := grpc.NewServer()
-	catalogv1.RegisterCatalogServiceServer(grpcServer, cataloggrpc.NewServerWithLogger(store, gitClient, logger.Log))
-	go func() {
-		logger.Log.Info("CatalogService gRPC server starting", zap.Int("port", cfg.Api.GrpcPort))
-		if err := grpcServer.Serve(grpcLis); err != nil {
-			logger.Log.Error("CatalogService gRPC server error", zap.Error(err))
-		}
-	}()
-
-	logger.Log.Info("Server ready",
-		zap.String("graphql", fmt.Sprintf("http://localhost:%d/graphql", cfg.Api.Port)),
-		zap.String("playground", fmt.Sprintf("http://localhost:%d/playground", cfg.Api.Port)),
-		zap.String("health", fmt.Sprintf("http://localhost:%d/health", cfg.Api.Port)),
-		zap.String("ready", fmt.Sprintf("http://localhost:%d/ready", cfg.Api.Port)),
-		zap.String("git_http", fmt.Sprintf("http://localhost:%d", cfg.Api.GitPort)),
-		zap.String("catalog_grpc", fmt.Sprintf("localhost:%d", cfg.Api.GrpcPort)),
-	)
+	defer server.Close()
+	server.Start()
 
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 	<-sigChan
 
-	logger.Log.Info("Shutting down gracefully...")
+	log.Info("Shutting down gracefully...")
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	if err := srv.Shutdown(shutdownCtx); err != nil {
-		logger.Log.Error("Server shutdown error", zap.Error(err))
-	}
+	server.Shutdown(shutdownCtx)
 
-	if err := gitSrv.Shutdown(shutdownCtx); err != nil {
-		logger.Log.Error("Git HTTP server shutdown error", zap.Error(err))
-	}
-
-	grpcServer.GracefulStop()
-
-	logger.Log.Info("Server stopped")
-}
-
-func newGraphQLHandler(store datastore.Datastore, writer resolver.GitWriter, log *zap.Logger, authMiddleware *middleware.AuthMiddleware) http.Handler {
-	rootResolver := resolver.NewResolver(store, writer, log)
-	rootResolver.WithAuthMiddleware(authMiddleware)
-	schema := generated.NewExecutableSchema(generated.Config{Resolvers: rootResolver})
-	gqlServer := gqlhandler.NewDefaultServer(schema)
-
-	gqlHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gqlServer.ServeHTTP(w, r)
-	})
-
-	return authMiddleware.OptionalAuth(gqlHandler)
+	log.Info("Server stopped")
 }

--- a/gitstore-api/cmd/server/main_test.go
+++ b/gitstore-api/cmd/server/main_test.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/gitstore-dev/gitstore/api/internal/app"
 	"github.com/gitstore-dev/gitstore/api/internal/datastore/memdb"
 	"github.com/gitstore-dev/gitstore/api/internal/gitclient"
 	"github.com/gitstore-dev/gitstore/api/internal/middleware"
@@ -62,10 +63,17 @@ func TestGraphQLHandlerAcceptsBearerTokenForNamespaceMutation(t *testing.T) {
 
 	hash, err := middleware.HashPassword("admin123")
 	require.NoError(t, err)
-	authMiddleware, err := middleware.NewAuthMiddleware("admin", hash, "dev-secret", "2h", "gitstore")
+	authMiddleware, err := middleware.NewAuthMiddleware(middleware.AuthDeps{
+		AdminUsername:     "admin",
+		AdminPasswordHash: hash,
+		JWTSecret:         "dev-secret",
+		JWTDuration:       "2h",
+		JWTIssuer:         "gitstore",
+	})
 	require.NoError(t, err)
 
-	handler := newGraphQLHandler(store, &mockGitWriter{}, zap.NewNop(), authMiddleware)
+	handler, err := app.NewGraphQLHandler(store, &mockGitWriter{}, zap.NewNop(), authMiddleware, nil, nil)
+	require.NoError(t, err)
 
 	loginReq := httptest.NewRequest(http.MethodPost, "/graphql", strings.NewReader(`{
 		"query": "mutation { login(input: { username: \"admin\", password: \"admin123\" }) { session { token user { username isAdmin } } } }"
@@ -167,10 +175,17 @@ func TestGraphQLHandlerRejectsNamespaceMutationWithoutBearerToken(t *testing.T) 
 
 	hash, err := middleware.HashPassword("admin123")
 	require.NoError(t, err)
-	authMiddleware, err := middleware.NewAuthMiddleware("admin", hash, "dev-secret", "2h", "gitstore")
+	authMiddleware, err := middleware.NewAuthMiddleware(middleware.AuthDeps{
+		AdminUsername:     "admin",
+		AdminPasswordHash: hash,
+		JWTSecret:         "dev-secret",
+		JWTDuration:       "2h",
+		JWTIssuer:         "gitstore",
+	})
 	require.NoError(t, err)
 
-	handler := newGraphQLHandler(store, &mockGitWriter{}, zap.NewNop(), authMiddleware)
+	handler, err := app.NewGraphQLHandler(store, &mockGitWriter{}, zap.NewNop(), authMiddleware, nil, nil)
+	require.NoError(t, err)
 	req := httptest.NewRequest(http.MethodPost, "/graphql", strings.NewReader(`{
 		"query": "mutation { createNamespace(input: { identifier: \"alice\", tier: USER }) { namespace { identifier } } }"
 	}`))

--- a/gitstore-api/internal/app/server.go
+++ b/gitstore-api/internal/app/server.go
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	gqlhandler "github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/playground"
+	catalogv1 "github.com/gitstore-dev/gitstore/api/gen/gitstore/catalog/v1"
+	"github.com/gitstore-dev/gitstore/api/internal/cataloggrpc"
+	"github.com/gitstore-dev/gitstore/api/internal/config"
+	"github.com/gitstore-dev/gitstore/api/internal/datastore"
+	dsfactory "github.com/gitstore-dev/gitstore/api/internal/datastore/factory"
+	"github.com/gitstore-dev/gitstore/api/internal/gitclient"
+	"github.com/gitstore-dev/gitstore/api/internal/githttp"
+	"github.com/gitstore-dev/gitstore/api/internal/graph/generated"
+	"github.com/gitstore-dev/gitstore/api/internal/graph/resolver"
+	"github.com/gitstore-dev/gitstore/api/internal/handler"
+	"github.com/gitstore-dev/gitstore/api/internal/health"
+	"github.com/gitstore-dev/gitstore/api/internal/middleware"
+	apiruntime "github.com/gitstore-dev/gitstore/api/internal/runtime"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+)
+
+const version = "1.0.0"
+
+// Server is the composed API runtime.
+type Server struct {
+	cfg          *config.Config
+	log          *zap.Logger
+	store        datastore.Datastore
+	gitClient    *gitclient.Client
+	httpServer   *http.Server
+	gitServer    *http.Server
+	grpcServer   *grpc.Server
+	grpcListener net.Listener
+}
+
+// NewServer builds the API, Git HTTP, and catalog gRPC servers from config.
+func NewServer(cfg *config.Config, log *zap.Logger) (*Server, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("app: config is required")
+	}
+	if log == nil {
+		return nil, fmt.Errorf("app: logger is required")
+	}
+	clock := apiruntime.SystemClock{}
+
+	store, err := dsfactory.NewDatastore(cfg.Datastore, log)
+	if err != nil {
+		return nil, fmt.Errorf("create datastore: %w", err)
+	}
+	store = datastore.NewInstrumentedDatastore(store, cfg.Datastore.Backend, log)
+
+	gitClient, err := gitclient.NewClientWithAddr(cfg.Git.Grpc.Uri)
+	if err != nil {
+		store.Close()
+		return nil, fmt.Errorf("connect git-service: %w", err)
+	}
+
+	authMiddleware, err := middleware.NewAuthMiddleware(middleware.AuthDeps{
+		AdminUsername:     cfg.Auth.Admin.Username,
+		AdminPasswordHash: cfg.Auth.Admin.Password,
+		JWTSecret:         cfg.Auth.JWT.Secret,
+		JWTDuration:       cfg.Auth.JWT.Duration,
+		JWTIssuer:         cfg.Auth.JWT.Issuer,
+	})
+	if err != nil {
+		gitClient.Close()
+		store.Close()
+		return nil, fmt.Errorf("create auth middleware: %w", err)
+	}
+
+	gqlHandler, err := NewGraphQLHandler(store, gitClient, log, authMiddleware, clock, nil)
+	if err != nil {
+		gitClient.Close()
+		store.Close()
+		return nil, err
+	}
+
+	healthHandler := health.NewHandler(health.HandlerDeps{
+		Store:   store,
+		Logger:  log,
+		Version: version,
+		Clock:   clock,
+	})
+
+	mux := http.NewServeMux()
+	mux.Handle("/api/login", handler.NewLoginHandler(handler.LoginHandlerDeps{
+		Auth:   authMiddleware,
+		Logger: log,
+		Clock:  clock,
+	}))
+	mux.Handle("/graphql", gqlHandler)
+	mux.Handle("/playground", playground.Handler("GraphQL Playground", "/graphql"))
+	mux.HandleFunc("/health", healthHandler.Health)
+	mux.HandleFunc("/ready", healthHandler.Ready)
+
+	var httpHandler http.Handler = mux
+	httpHandler = middleware.CORSMiddleware(httpHandler)
+	httpHandler = middleware.RequestIDMiddleware(httpHandler)
+
+	httpServer := &http.Server{
+		Addr:         fmt.Sprintf(":%d", cfg.Api.Port),
+		Handler:      httpHandler,
+		ReadTimeout:  15 * time.Second,
+		WriteTimeout: 15 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+
+	gitResolver := func(namespace, repo string) (string, bool) {
+		ctx := context.Background()
+		ns, err := store.GetNamespaceByIdentifier(ctx, namespace)
+		if err != nil || ns == nil {
+			return "", false
+		}
+		mapping, err := store.LookupRepository(ctx, ns.ID, repo)
+		if err != nil || mapping == nil {
+			return "", false
+		}
+		return mapping.RepoID, true
+	}
+	gitMux := githttp.NewMux(gitClient, gitResolver, log, http.HandlerFunc(healthHandler.Health))
+	gitServer := &http.Server{
+		Addr:         fmt.Sprintf(":%d", cfg.Api.GitPort),
+		Handler:      middleware.RequestIDMiddleware(gitMux),
+		ReadTimeout:  0,
+		WriteTimeout: 0,
+		IdleTimeout:  60 * time.Second,
+	}
+
+	grpcListener, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.Api.GrpcPort))
+	if err != nil {
+		gitClient.Close()
+		store.Close()
+		return nil, fmt.Errorf("listen on catalog gRPC port %d: %w", cfg.Api.GrpcPort, err)
+	}
+	grpcServer := grpc.NewServer()
+	catalogServer, err := cataloggrpc.NewServer(cataloggrpc.ServerDeps{
+		Store:     store,
+		GitClient: gitClient,
+		Logger:    log,
+		Clock:     clock,
+	})
+	if err != nil {
+		grpcListener.Close()
+		gitClient.Close()
+		store.Close()
+		return nil, err
+	}
+	catalogv1.RegisterCatalogServiceServer(grpcServer, catalogServer)
+
+	return &Server{
+		cfg:          cfg,
+		log:          log,
+		store:        store,
+		gitClient:    gitClient,
+		httpServer:   httpServer,
+		gitServer:    gitServer,
+		grpcServer:   grpcServer,
+		grpcListener: grpcListener,
+	}, nil
+}
+
+// NewGraphQLHandler builds a GraphQL HTTP handler.
+func NewGraphQLHandler(store datastore.Datastore, writer resolver.GitWriter, log *zap.Logger, authMiddleware *middleware.AuthMiddleware, clock apiruntime.Clock, ids apiruntime.IDGenerator) (http.Handler, error) {
+	rootResolver, err := resolver.NewResolver(resolver.ResolverDeps{
+		Store:       store,
+		GitWriter:   writer,
+		Logger:      log,
+		Clock:       clock,
+		IDGenerator: ids,
+	})
+	if err != nil {
+		return nil, err
+	}
+	rootResolver.WithAuthMiddleware(authMiddleware)
+	schema := generated.NewExecutableSchema(generated.Config{Resolvers: rootResolver})
+	gqlServer := gqlhandler.NewDefaultServer(schema)
+
+	gqlHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gqlServer.ServeHTTP(w, r)
+	})
+
+	return authMiddleware.OptionalAuth(gqlHandler), nil
+}
+
+// Start starts all servers in background goroutines.
+func (s *Server) Start() {
+	go func() {
+		s.log.Info("GraphQL API server starting", zap.Int("port", s.cfg.Api.Port))
+		if err := s.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			s.log.Fatal("Server error", zap.Error(err))
+		}
+	}()
+
+	go func() {
+		s.log.Info("Git smart HTTP server starting", zap.Int("port", s.cfg.Api.GitPort))
+		if err := s.gitServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			s.log.Error("Git HTTP server error", zap.Error(err))
+		}
+	}()
+
+	go func() {
+		s.log.Info("CatalogService gRPC server starting", zap.Int("port", s.cfg.Api.GrpcPort))
+		if err := s.grpcServer.Serve(s.grpcListener); err != nil {
+			s.log.Error("CatalogService gRPC server error", zap.Error(err))
+		}
+	}()
+
+	s.log.Info("Server ready",
+		zap.String("graphql", fmt.Sprintf("http://localhost:%d/graphql", s.cfg.Api.Port)),
+		zap.String("playground", fmt.Sprintf("http://localhost:%d/playground", s.cfg.Api.Port)),
+		zap.String("health", fmt.Sprintf("http://localhost:%d/health", s.cfg.Api.Port)),
+		zap.String("ready", fmt.Sprintf("http://localhost:%d/ready", s.cfg.Api.Port)),
+		zap.String("git_http", fmt.Sprintf("http://localhost:%d", s.cfg.Api.GitPort)),
+		zap.String("catalog_grpc", fmt.Sprintf("localhost:%d", s.cfg.Api.GrpcPort)),
+	)
+}
+
+// Shutdown gracefully stops all network servers.
+func (s *Server) Shutdown(ctx context.Context) {
+	if err := s.httpServer.Shutdown(ctx); err != nil {
+		s.log.Error("Server shutdown error", zap.Error(err))
+	}
+	if err := s.gitServer.Shutdown(ctx); err != nil {
+		s.log.Error("Git HTTP server shutdown error", zap.Error(err))
+	}
+	s.grpcServer.GracefulStop()
+}
+
+// Close releases non-server resources.
+func (s *Server) Close() {
+	if s.grpcListener != nil {
+		_ = s.grpcListener.Close()
+	}
+	if s.gitClient != nil {
+		s.gitClient.Close()
+	}
+	if s.store != nil {
+		s.store.Close()
+	}
+}

--- a/gitstore-api/internal/auth/session.go
+++ b/gitstore-api/internal/auth/session.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	apiruntime "github.com/gitstore-dev/gitstore/api/internal/runtime"
 	"github.com/golang-jwt/jwt/v5"
 )
 
@@ -32,27 +33,56 @@ type SessionManager struct {
 	secretKey     []byte
 	tokenDuration time.Duration
 	issuer        string
+	clock         apiruntime.Clock
+}
+
+// SessionManagerDeps contains the dependencies and configuration for a session manager.
+type SessionManagerDeps struct {
+	Secret   string
+	Duration string
+	Issuer   string
+	Clock    apiruntime.Clock
 }
 
 // NewSessionManager creates a new session manager from explicit config values.
-func NewSessionManager(secret, durationStr, issuer string) (*SessionManager, error) {
+func NewSessionManager(deps SessionManagerDeps) (*SessionManager, error) {
+	if deps.Secret == "" {
+		return nil, fmt.Errorf("auth: session manager secret is required")
+	}
+	if deps.Issuer == "" {
+		return nil, fmt.Errorf("auth: session manager issuer is required")
+	}
 	duration := 24 * time.Hour
-	if durationStr != "" {
-		if d, err := time.ParseDuration(durationStr); err == nil {
-			duration = d
+	if deps.Duration != "" {
+		d, err := time.ParseDuration(deps.Duration)
+		if err != nil {
+			return nil, fmt.Errorf("auth: invalid token duration %q: %w", deps.Duration, err)
 		}
+		duration = d
+	}
+	clock := deps.Clock
+	if clock == nil {
+		clock = apiruntime.SystemClock{}
 	}
 
 	return &SessionManager{
-		secretKey:     []byte(secret),
+		secretKey:     []byte(deps.Secret),
 		tokenDuration: duration,
-		issuer:        issuer,
+		issuer:        deps.Issuer,
+		clock:         clock,
 	}, nil
+}
+
+func (sm *SessionManager) now() time.Time {
+	if sm.clock == nil {
+		return time.Now()
+	}
+	return sm.clock.Now()
 }
 
 // GenerateToken creates a new JWT token for a user
 func (sm *SessionManager) GenerateToken(username string, isAdmin bool) (string, error) {
-	now := time.Now()
+	now := sm.now()
 	expiresAt := now.Add(sm.tokenDuration)
 
 	claims := Claims{
@@ -88,7 +118,7 @@ func (sm *SessionManager) ValidateToken(tokenString string) (*Claims, error) {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
 		return sm.secretKey, nil
-	})
+	}, jwt.WithTimeFunc(sm.now))
 
 	if err != nil {
 		if errors.Is(err, jwt.ErrTokenExpired) {
@@ -114,13 +144,13 @@ func (sm *SessionManager) RefreshToken(tokenString string) (string, error) {
 			// Parse without validation to check expiry time
 			token, _ := jwt.ParseWithClaims(tokenString, &Claims{}, func(token *jwt.Token) (interface{}, error) {
 				return sm.secretKey, nil
-			})
+			}, jwt.WithoutClaimsValidation())
 
 			if token != nil {
 				if claims, ok := token.Claims.(*Claims); ok {
 					// Check if token expired within grace period
 					gracePeriod := 7 * 24 * time.Hour
-					if time.Since(claims.ExpiresAt.Time) > gracePeriod {
+					if sm.now().Sub(claims.ExpiresAt.Time) > gracePeriod {
 						return "", fmt.Errorf("token expired beyond grace period")
 					}
 					// Generate new token

--- a/gitstore-api/internal/auth/session_test.go
+++ b/gitstore-api/internal/auth/session_test.go
@@ -7,14 +7,33 @@ import (
 	"testing"
 	"time"
 
+	apiruntime "github.com/gitstore-dev/gitstore/api/internal/runtime"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+var fixedNow = time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+
+func newTestSessionManager(t *testing.T, duration string, now time.Time) *SessionManager {
+	t.Helper()
+	sm, err := NewSessionManager(SessionManagerDeps{
+		Secret:   "dev-secret-change-in-production",
+		Duration: duration,
+		Issuer:   "gitstore",
+		Clock:    apiruntime.NewFixedClock(now),
+	})
+	require.NoError(t, err)
+	return sm
+}
+
 func TestNewSessionManager(t *testing.T) {
 	t.Run("should create with provided settings", func(t *testing.T) {
-		sm, err := NewSessionManager("dev-secret-change-in-production", "24h", "gitstore")
+		sm, err := NewSessionManager(SessionManagerDeps{
+			Secret:   "dev-secret-change-in-production",
+			Duration: "24h",
+			Issuer:   "gitstore",
+		})
 		require.NoError(t, err)
 		require.NotNil(t, sm)
 		assert.Equal(t, 24*time.Hour, sm.tokenDuration)
@@ -22,16 +41,34 @@ func TestNewSessionManager(t *testing.T) {
 	})
 
 	t.Run("should use injected duration and issuer", func(t *testing.T) {
-		sm, err := NewSessionManager("test-secret-key", "2h", "test-issuer")
+		sm, err := NewSessionManager(SessionManagerDeps{
+			Secret:   "test-secret-key",
+			Duration: "2h",
+			Issuer:   "test-issuer",
+		})
 		require.NoError(t, err)
 		assert.Equal(t, 2*time.Hour, sm.tokenDuration)
 		assert.Equal(t, "test-issuer", sm.issuer)
 	})
+
+	t.Run("should reject missing secret", func(t *testing.T) {
+		_, err := NewSessionManager(SessionManagerDeps{Duration: "24h", Issuer: "gitstore"})
+		require.ErrorContains(t, err, "secret is required")
+	})
+
+	t.Run("should reject missing issuer", func(t *testing.T) {
+		_, err := NewSessionManager(SessionManagerDeps{Secret: "secret", Duration: "24h"})
+		require.ErrorContains(t, err, "issuer is required")
+	})
+
+	t.Run("should reject invalid duration", func(t *testing.T) {
+		_, err := NewSessionManager(SessionManagerDeps{Secret: "secret", Duration: "soon", Issuer: "gitstore"})
+		require.ErrorContains(t, err, "invalid token duration")
+	})
 }
 
 func TestGenerateToken(t *testing.T) {
-	sm, err := NewSessionManager("dev-secret-change-in-production", "24h", "gitstore")
-	require.NoError(t, err)
+	sm := newTestSessionManager(t, "24h", fixedNow)
 
 	t.Run("should generate valid JWT token", func(t *testing.T) {
 		token, err := sm.GenerateToken("testuser", true)
@@ -63,19 +100,16 @@ func TestGenerateToken(t *testing.T) {
 		claims, err := sm.ValidateToken(token)
 		require.NoError(t, err)
 
-		// Check expiration is approximately 24 hours from now
-		expectedExpiry := time.Now().Add(24 * time.Hour)
-		diff := claims.ExpiresAt.Time.Sub(expectedExpiry)
-		assert.Less(t, diff.Abs(), 5*time.Second)
+		assert.Equal(t, fixedNow.Add(24*time.Hour), claims.ExpiresAt.Time.UTC())
 	})
 
 	t.Run("should generate different tokens for same user", func(t *testing.T) {
-		token1, err := sm.GenerateToken("testuser", true)
+		firstSM := newTestSessionManager(t, "24h", fixedNow)
+		token1, err := firstSM.GenerateToken("testuser", true)
 		require.NoError(t, err)
 
-		time.Sleep(1100 * time.Millisecond) // JWT timestamps are in seconds, need to wait > 1s
-
-		token2, err := sm.GenerateToken("testuser", true)
+		secondSM := newTestSessionManager(t, "24h", fixedNow.Add(2*time.Second))
+		token2, err := secondSM.GenerateToken("testuser", true)
 		require.NoError(t, err)
 
 		// Different tokens due to different issued-at times
@@ -84,8 +118,7 @@ func TestGenerateToken(t *testing.T) {
 }
 
 func TestValidateToken(t *testing.T) {
-	sm, err := NewSessionManager("dev-secret-change-in-production", "24h", "gitstore")
-	require.NoError(t, err)
+	sm := newTestSessionManager(t, "24h", fixedNow)
 
 	t.Run("should validate correct token", func(t *testing.T) {
 		token, err := sm.GenerateToken("testuser", true)
@@ -115,6 +148,7 @@ func TestValidateToken(t *testing.T) {
 			secretKey:     []byte("wrong-secret"),
 			tokenDuration: 24 * time.Hour,
 			issuer:        "gitstore",
+			clock:         apiruntime.NewFixedClock(fixedNow),
 		}
 		token, err := wrongSM.GenerateToken("testuser", true)
 		require.NoError(t, err)
@@ -130,15 +164,14 @@ func TestValidateToken(t *testing.T) {
 			secretKey:     sm.secretKey,
 			tokenDuration: 1 * time.Millisecond,
 			issuer:        "gitstore",
+			clock:         apiruntime.NewFixedClock(fixedNow),
 		}
 
 		token, err := shortSM.GenerateToken("testuser", true)
 		require.NoError(t, err)
 
-		// Wait for token to expire
-		time.Sleep(10 * time.Millisecond)
-
-		_, err = sm.ValidateToken(token)
+		expiredValidator := newTestSessionManager(t, "24h", fixedNow.Add(10*time.Millisecond))
+		_, err = expiredValidator.ValidateToken(token)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, ErrExpiredToken)
 	})
@@ -149,7 +182,7 @@ func TestValidateToken(t *testing.T) {
 			Username: "testuser",
 			IsAdmin:  true,
 			RegisteredClaims: jwt.RegisteredClaims{
-				ExpiresAt: jwt.NewNumericDate(time.Now().Add(1 * time.Hour)),
+				ExpiresAt: jwt.NewNumericDate(fixedNow.Add(1 * time.Hour)),
 			},
 		}
 
@@ -164,22 +197,20 @@ func TestValidateToken(t *testing.T) {
 }
 
 func TestRefreshToken(t *testing.T) {
-	sm, err := NewSessionManager("dev-secret-change-in-production", "24h", "gitstore")
-	require.NoError(t, err)
+	sm := newTestSessionManager(t, "24h", fixedNow)
 
 	t.Run("should refresh valid token", func(t *testing.T) {
 		originalToken, err := sm.GenerateToken("testuser", true)
 		require.NoError(t, err)
 
-		time.Sleep(1100 * time.Millisecond) // JWT timestamps are in seconds, need to wait > 1s
-
-		newToken, err := sm.RefreshToken(originalToken)
+		refreshSM := newTestSessionManager(t, "24h", fixedNow.Add(2*time.Second))
+		newToken, err := refreshSM.RefreshToken(originalToken)
 		require.NoError(t, err)
 		assert.NotEmpty(t, newToken)
 		assert.NotEqual(t, originalToken, newToken)
 
 		// Validate new token
-		claims, err := sm.ValidateToken(newToken)
+		claims, err := refreshSM.ValidateToken(newToken)
 		require.NoError(t, err)
 		assert.Equal(t, "testuser", claims.Username)
 		assert.True(t, claims.IsAdmin)
@@ -191,20 +222,20 @@ func TestRefreshToken(t *testing.T) {
 			secretKey:     sm.secretKey,
 			tokenDuration: 1 * time.Millisecond,
 			issuer:        "gitstore",
+			clock:         apiruntime.NewFixedClock(fixedNow),
 		}
 
 		expiredToken, err := shortSM.GenerateToken("testuser", false)
 		require.NoError(t, err)
 
-		time.Sleep(10 * time.Millisecond)
-
 		// Should allow refresh within grace period
-		newToken, err := sm.RefreshToken(expiredToken)
+		refreshSM := newTestSessionManager(t, "24h", fixedNow.Add(10*time.Millisecond))
+		newToken, err := refreshSM.RefreshToken(expiredToken)
 		require.NoError(t, err)
 		assert.NotEmpty(t, newToken)
 
 		// New token should be valid
-		claims, err := sm.ValidateToken(newToken)
+		claims, err := refreshSM.ValidateToken(newToken)
 		require.NoError(t, err)
 		assert.Equal(t, "testuser", claims.Username)
 	})
@@ -216,8 +247,7 @@ func TestRefreshToken(t *testing.T) {
 }
 
 func TestGetTokenExpiry(t *testing.T) {
-	sm, err := NewSessionManager("dev-secret-change-in-production", "24h", "gitstore")
-	require.NoError(t, err)
+	sm := newTestSessionManager(t, "24h", fixedNow)
 
 	t.Run("should return token expiry time", func(t *testing.T) {
 		token, err := sm.GenerateToken("testuser", true)
@@ -226,10 +256,7 @@ func TestGetTokenExpiry(t *testing.T) {
 		expiry, err := sm.GetTokenExpiry(token)
 		require.NoError(t, err)
 
-		// Should be approximately 24 hours from now
-		expectedExpiry := time.Now().Add(24 * time.Hour)
-		diff := expiry.Sub(expectedExpiry)
-		assert.Less(t, diff.Abs(), 5*time.Second)
+		assert.Equal(t, fixedNow.Add(24*time.Hour), expiry.UTC())
 	})
 
 	t.Run("should return error for invalid token", func(t *testing.T) {
@@ -239,8 +266,7 @@ func TestGetTokenExpiry(t *testing.T) {
 }
 
 func TestRevokeToken(t *testing.T) {
-	sm, err := NewSessionManager("dev-secret-change-in-production", "24h", "gitstore")
-	require.NoError(t, err)
+	sm := newTestSessionManager(t, "24h", fixedNow)
 
 	t.Run("should revoke valid token", func(t *testing.T) {
 		token, err := sm.GenerateToken("testuser", true)
@@ -260,8 +286,7 @@ func TestRevokeToken(t *testing.T) {
 }
 
 func TestGetTokenDuration(t *testing.T) {
-	sm, err := NewSessionManager("dev-secret-change-in-production", "24h", "gitstore")
-	require.NoError(t, err)
+	sm := newTestSessionManager(t, "24h", fixedNow)
 
 	duration := sm.GetTokenDuration()
 	assert.Equal(t, 24*time.Hour, duration)

--- a/gitstore-api/internal/cataloggrpc/server.go
+++ b/gitstore-api/internal/cataloggrpc/server.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 	"time"
@@ -19,9 +20,9 @@ import (
 	"github.com/gitstore-dev/gitstore/api/internal/catalog"
 	"github.com/gitstore-dev/gitstore/api/internal/datastore"
 	"github.com/gitstore-dev/gitstore/api/internal/gitclient"
+	apiruntime "github.com/gitstore-dev/gitstore/api/internal/runtime"
 	"github.com/gitstore-dev/gitstore/api/internal/validate"
 	"github.com/google/cel-go/cel"
-	"github.com/google/uuid"
 	"go.uber.org/zap"
 )
 
@@ -30,6 +31,11 @@ import (
 type GitReader interface {
 	ListFiles(ctx context.Context, repositoryID, prefix, ref string) ([]string, error)
 	ReadFile(ctx context.Context, repositoryID, path, ref string) ([]byte, error)
+}
+
+// ResourceParser is the parser behavior required by the CatalogService server.
+type ResourceParser interface {
+	ParseResource(r io.Reader) (*validate.ParsedResource, []byte, error)
 }
 
 // gitClientReader wraps *gitclient.Client to satisfy GitReader.
@@ -57,10 +63,26 @@ func (r *gitClientReader) ReadFile(ctx context.Context, repositoryID, path, ref 
 // Server implements catalogv1.CatalogServiceServer.
 type Server struct {
 	catalogv1.UnimplementedCatalogServiceServer
-	store  datastore.Datastore
-	git    GitReader
-	log    *zap.Logger
+	store datastore.Datastore
+	git   GitReader
+	log   *zap.Logger
+
+	parser ResourceParser
+	clock  apiruntime.Clock
+	ids    apiruntime.IDGenerator
 	celEnv *cel.Env // shared, constructed once; nil means CEL unavailable (skip rather than reject)
+}
+
+// ServerDeps contains dependencies for the CatalogService gRPC server.
+type ServerDeps struct {
+	Store       datastore.Datastore
+	GitReader   GitReader
+	GitClient   *gitclient.Client
+	Logger      *zap.Logger
+	Parser      ResourceParser
+	Clock       apiruntime.Clock
+	IDGenerator apiruntime.IDGenerator
+	CELEnv      *cel.Env
 }
 
 // newCELEnv constructs a CEL environment for syntax-checking price eligibility expressions.
@@ -74,27 +96,54 @@ func newCELEnv() *cel.Env {
 }
 
 // NewServer creates a new CatalogService gRPC server.
-// store and gitClient may be nil for unit tests that only call ValidateResources.
-func NewServer(store datastore.Datastore, gitClient *gitclient.Client) *Server {
-	var git GitReader
-	if gitClient != nil {
-		git = &gitClientReader{c: gitClient}
+func NewServer(deps ServerDeps) (*Server, error) {
+	if deps.Store == nil {
+		return nil, fmt.Errorf("cataloggrpc: datastore is required")
 	}
-	return &Server{store: store, git: git, log: zap.NewNop(), celEnv: newCELEnv()}
+	if deps.Logger == nil {
+		return nil, fmt.Errorf("cataloggrpc: logger is required")
+	}
+	git := deps.GitReader
+	if git == nil && deps.GitClient != nil {
+		git = &gitClientReader{c: deps.GitClient}
+	}
+	parser := deps.Parser
+	if parser == nil {
+		parser = validate.NewParser()
+	}
+	clock := deps.Clock
+	if clock == nil {
+		clock = apiruntime.SystemClock{}
+	}
+	ids := deps.IDGenerator
+	if ids == nil {
+		ids = apiruntime.UUIDGenerator{}
+	}
+	celEnv := deps.CELEnv
+	if celEnv == nil {
+		celEnv = newCELEnv()
+	}
+	return &Server{
+		store:  deps.Store,
+		git:    git,
+		log:    deps.Logger,
+		parser: parser,
+		clock:  clock,
+		ids:    ids,
+		celEnv: celEnv,
+	}, nil
 }
 
-// NewServerWithLogger creates a new server with a custom logger.
-func NewServerWithLogger(store datastore.Datastore, gitClient *gitclient.Client, log *zap.Logger) *Server {
-	var git GitReader
-	if gitClient != nil {
-		git = &gitClientReader{c: gitClient}
+func (s *Server) newUID(kind, name string) (string, bool) {
+	uid, err := s.ids.NewV7ID()
+	if err != nil {
+		s.log.Error("admit_resources: generate UID failed",
+			zap.String("kind", kind),
+			zap.String("name", name),
+			zap.Error(err))
+		return "", false
 	}
-	return &Server{store: store, git: git, log: log, celEnv: newCELEnv()}
-}
-
-// NewServerForTest creates a server with a mock GitReader for unit tests.
-func NewServerForTest(store datastore.Datastore, git GitReader) *Server {
-	return &Server{store: store, git: git, log: zap.NewNop(), celEnv: newCELEnv()}
+	return uid, true
 }
 
 // ValidateResources validates resource blobs extracted from an incoming push commit.
@@ -112,7 +161,7 @@ func (s *Server) ValidateResources(
 			continue
 		}
 
-		_, _, err := validate.ParseResource(bytes.NewReader(blob.Content))
+		_, _, err := s.parser.ParseResource(bytes.NewReader(blob.Content))
 		if err == nil {
 			continue
 		}
@@ -244,7 +293,7 @@ func (s *Server) AdmitResources(
 	// Extract branch name from ref: "refs/heads/main" → "main"
 	branch := strings.TrimPrefix(req.RefName, "refs/heads/")
 	revision := branch + "@sha1:" + req.CommitSha
-	now := time.Now().UTC()
+	now := s.clock.Now().UTC()
 
 	// Build the admission context once so every per-file admit helper can read
 	// namespace, commit SHA, ref, and wall-clock time without re-querying the DB.
@@ -272,7 +321,7 @@ func (s *Server) AdmitResources(
 				zap.String("path", path), zap.Error(err))
 			continue
 		}
-		parsed, body, err := validate.ParseResource(bytes.NewReader(content))
+		parsed, body, err := s.parser.ParseResource(bytes.NewReader(content))
 		if err != nil || parsed == nil {
 			if err != nil {
 				s.log.Error("admit_resources: parse failed",
@@ -423,8 +472,12 @@ func (s *Server) admitProduct(
 	existing, getErr := s.store.GetProductByName(ctx, namespace, resource.Metadata.Name)
 
 	if getErr != nil || existing == nil {
+		uid, ok := s.newUID(resource.Kind, resource.Metadata.Name)
+		if !ok {
+			return
+		}
 		p := &datastore.Product{
-			UID:               uuid.Must(uuid.NewV7()).String(),
+			UID:               uid,
 			Namespace:         namespace,
 			Name:              resource.Metadata.Name,
 			APIVersion:        resource.APIVersion,
@@ -487,8 +540,12 @@ func (s *Server) admitCollection(
 	existing, getErr := s.store.GetCollectionByName(ctx, namespace, resource.Metadata.Name)
 
 	if getErr != nil || existing == nil {
+		uid, ok := s.newUID(resource.Kind, resource.Metadata.Name)
+		if !ok {
+			return
+		}
 		c := &datastore.Collection{
-			UID:               uuid.Must(uuid.NewV7()).String(),
+			UID:               uid,
 			Namespace:         namespace,
 			Name:              resource.Metadata.Name,
 			APIVersion:        resource.APIVersion,
@@ -613,8 +670,12 @@ func (s *Server) admitProductVariant(
 		}
 
 		statusJSON := variantAdmissionStatus(1, admCtx.Revision, admCtx.Now, admitResult)
+		uid, ok := s.newUID(resource.Kind, resource.Metadata.Name)
+		if !ok {
+			return
+		}
 		v := &datastore.ProductVariant{
-			UID:               uuid.Must(uuid.NewV7()).String(),
+			UID:               uid,
 			Namespace:         namespace,
 			Name:              resource.Metadata.Name,
 			APIVersion:        resource.APIVersion,
@@ -736,8 +797,12 @@ func (s *Server) admitCategoryTaxonomyWithContext(
 	statusJSON := categoryAdmissionStatusFull(1, admCtx.Revision, admCtx.Now, parentResolved, inCycle)
 
 	if getErr != nil || existing == nil {
+		uid, ok := s.newUID(resource.Kind, name)
+		if !ok {
+			return
+		}
 		c := &datastore.CategoryTaxonomy{
-			UID:               uuid.Must(uuid.NewV7()).String(),
+			UID:               uid,
 			Namespace:         namespace,
 			Name:              name,
 			APIVersion:        resource.APIVersion,

--- a/gitstore-api/internal/cataloggrpc/server_test.go
+++ b/gitstore-api/internal/cataloggrpc/server_test.go
@@ -12,17 +12,75 @@ import (
 	"time"
 
 	catalogv1 "github.com/gitstore-dev/gitstore/api/gen/gitstore/catalog/v1"
+	"github.com/gitstore-dev/gitstore/api/internal/catalog"
 	"github.com/gitstore-dev/gitstore/api/internal/cataloggrpc"
 	"github.com/gitstore-dev/gitstore/api/internal/datastore"
 	"github.com/gitstore-dev/gitstore/api/internal/datastore/memdb"
+	apiruntime "github.com/gitstore-dev/gitstore/api/internal/runtime"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 // testRepoID is a fixed UUID used as the repository ID in AdmitResources tests.
 // The memdb UUIDFieldIndex requires exactly 36 characters.
 const testRepoID = "00000000-0000-0000-0000-000000000001"
+
+func newCatalogServer(t *testing.T, store datastore.Datastore, git cataloggrpc.GitReader, opts ...func(*cataloggrpc.ServerDeps)) *cataloggrpc.Server {
+	t.Helper()
+	if store == nil {
+		var err error
+		store, err = memdb.New()
+		require.NoError(t, err)
+	}
+	deps := cataloggrpc.ServerDeps{
+		Store:     store,
+		GitReader: git,
+		Logger:    zap.NewNop(),
+	}
+	for _, opt := range opts {
+		opt(&deps)
+	}
+	srv, err := cataloggrpc.NewServer(deps)
+	require.NoError(t, err)
+	return srv
+}
+
+func TestNewServerRequiresDatastore(t *testing.T) {
+	_, err := cataloggrpc.NewServer(cataloggrpc.ServerDeps{Logger: zap.NewNop()})
+	require.ErrorContains(t, err, "datastore is required")
+}
+
+func TestNewServerRequiresLogger(t *testing.T) {
+	store, err := memdb.New()
+	require.NoError(t, err)
+	defer store.Close()
+
+	_, err = cataloggrpc.NewServer(cataloggrpc.ServerDeps{Store: store})
+	require.ErrorContains(t, err, "logger is required")
+}
+
+func TestNewServerDefaultsOptionalDependencies(t *testing.T) {
+	store, err := memdb.New()
+	require.NoError(t, err)
+	defer store.Close()
+
+	srv, err := cataloggrpc.NewServer(cataloggrpc.ServerDeps{
+		Store:  store,
+		Logger: zap.NewNop(),
+	})
+	require.NoError(t, err)
+
+	resp, err := srv.ValidateResources(context.Background(), &catalogv1.ValidateResourcesRequest{
+		RepositoryId: testRepoID,
+		Blobs: []*catalogv1.ResourceBlob{
+			{Path: "products/widget.md", BlobOid: "abc", Content: []byte(validProduct)},
+		},
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Accepted)
+}
 
 // validProduct is a minimal valid product YAML frontmatter blob.
 const validProduct = `---
@@ -40,7 +98,7 @@ A test product.
 
 // T011a: blob with valid frontmatter → accepted=true, empty errors
 func TestValidateResources_ValidBlob_Accepted(t *testing.T) {
-	srv := cataloggrpc.NewServer(nil, nil)
+	srv := newCatalogServer(t, nil, nil)
 	resp, err := srv.ValidateResources(context.Background(), &catalogv1.ValidateResourcesRequest{
 		RepositoryId: testRepoID,
 		Blobs: []*catalogv1.ResourceBlob{
@@ -66,7 +124,7 @@ status:
   phase: ready
 ---
 `
-	srv := cataloggrpc.NewServer(nil, nil)
+	srv := newCatalogServer(t, nil, nil)
 	resp, err := srv.ValidateResources(context.Background(), &catalogv1.ValidateResourcesRequest{
 		RepositoryId: testRepoID,
 		Blobs: []*catalogv1.ResourceBlob{
@@ -85,7 +143,7 @@ status:
 func TestValidateResources_TitleTooLong_Rejected(t *testing.T) {
 	longTitle := strings.Repeat("x", 201)
 	content := "---\napiVersion: catalog.gitstore.dev/v1beta1\nkind: Product\nmetadata:\n  name: long\n  namespace: gitstore\nspec:\n  title: " + longTitle + "\n---\n"
-	srv := cataloggrpc.NewServer(nil, nil)
+	srv := newCatalogServer(t, nil, nil)
 	resp, err := srv.ValidateResources(context.Background(), &catalogv1.ValidateResourcesRequest{
 		RepositoryId: testRepoID,
 		Blobs: []*catalogv1.ResourceBlob{
@@ -114,7 +172,7 @@ status:
   phase: ready
 ---
 `
-	srv := cataloggrpc.NewServer(nil, nil)
+	srv := newCatalogServer(t, nil, nil)
 	resp, err := srv.ValidateResources(context.Background(), &catalogv1.ValidateResourcesRequest{
 		RepositoryId: testRepoID,
 		Blobs: []*catalogv1.ResourceBlob{
@@ -133,7 +191,7 @@ status:
 // T011e: blob without `---` prefix → treated as no-op, no error
 func TestValidateResources_NonfrontmatterBlob_NoError(t *testing.T) {
 	content := []byte("This is a plain README without frontmatter.\n")
-	srv := cataloggrpc.NewServer(nil, nil)
+	srv := newCatalogServer(t, nil, nil)
 	resp, err := srv.ValidateResources(context.Background(), &catalogv1.ValidateResourcesRequest{
 		RepositoryId: testRepoID,
 		Blobs: []*catalogv1.ResourceBlob{
@@ -166,7 +224,7 @@ func containsSubstring(msgs []string, sub string) bool {
 
 // TestValidateResources_EmptyBlobs ensures empty input is accepted with no errors.
 func TestValidateResources_EmptyBlobs_Accepted(t *testing.T) {
-	srv := cataloggrpc.NewServer(nil, nil)
+	srv := newCatalogServer(t, nil, nil)
 	resp, err := srv.ValidateResources(context.Background(), &catalogv1.ValidateResourcesRequest{
 		RepositoryId: testRepoID,
 		Blobs:        nil,
@@ -202,6 +260,8 @@ func makeProduct(name string) []byte {
 // T020a: valid commit_sha with one product file → CreateProduct called with correct spec fields
 func TestAdmitResources_NewProduct_Created(t *testing.T) {
 	memStore := newTestDatastore(t)
+	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	const uid = "11111111-1111-7111-8111-111111111111"
 	git := &mockGitReader{
 		listFilesFunc: func(_ context.Context, _, _, _ string) ([]string, error) {
 			return []string{"products/widget.md"}, nil
@@ -211,7 +271,10 @@ func TestAdmitResources_NewProduct_Created(t *testing.T) {
 		},
 	}
 
-	srv := cataloggrpc.NewServerForTest(memStore, git)
+	srv := newCatalogServer(t, memStore, git, func(deps *cataloggrpc.ServerDeps) {
+		deps.Clock = apiruntime.NewFixedClock(now)
+		deps.IDGenerator = apiruntime.NewSequenceIDGenerator(uid)
+	})
 	_, err := srv.AdmitResources(context.Background(), &catalogv1.AdmitResourcesRequest{
 		RepositoryId: testRepoID,
 		CommitSha:    strings.Repeat("a", 40),
@@ -223,9 +286,18 @@ func TestAdmitResources_NewProduct_Created(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "widget", p.Name)
 	assert.Equal(t, int64(1), p.Generation)
-	assert.NotEmpty(t, p.UID)
-	assert.False(t, p.CreationTimestamp.IsZero())
-	assert.Contains(t, p.Revision, "main@sha1:")
+	assert.Equal(t, uid, p.UID)
+	assert.Equal(t, now, p.CreationTimestamp)
+	assert.Equal(t, "main@sha1:"+strings.Repeat("a", 40), p.Revision)
+
+	var status catalog.ProductStatus
+	require.NoError(t, json.Unmarshal(p.Status, &status))
+	assert.Equal(t, int64(1), status.ObservedGeneration)
+	assert.Equal(t, p.Revision, status.LastAppliedRevision)
+	require.Len(t, status.Conditions, 1)
+	assert.Equal(t, catalog.ConditionAdmissionAccepted, status.Conditions[0].Type)
+	assert.Equal(t, catalog.ConditionTrue, status.Conditions[0].Status)
+	assert.Equal(t, now, status.Conditions[0].LastTransitionTime)
 }
 
 // T020b: product already exists → UpdateProduct called; uid and creationTimestamp preserved,
@@ -241,7 +313,7 @@ func TestAdmitResources_ExistingProduct_Updated(t *testing.T) {
 		},
 	}
 
-	srv := cataloggrpc.NewServerForTest(memStore, git)
+	srv := newCatalogServer(t, memStore, git)
 
 	// First admission — creates the product
 	_, err := srv.AdmitResources(context.Background(), &catalogv1.AdmitResourcesRequest{
@@ -287,7 +359,7 @@ func TestAdmitResources_TwoProducts_BothStored(t *testing.T) {
 		},
 	}
 
-	srv := cataloggrpc.NewServerForTest(memStore, git)
+	srv := newCatalogServer(t, memStore, git)
 	_, err := srv.AdmitResources(context.Background(), &catalogv1.AdmitResourcesRequest{
 		RepositoryId: testRepoID,
 		CommitSha:    strings.Repeat("a", 40),
@@ -317,7 +389,7 @@ func TestAdmitResources_OneParseFailure_OtherStored(t *testing.T) {
 		},
 	}
 
-	srv := cataloggrpc.NewServerForTest(memStore, git)
+	srv := newCatalogServer(t, memStore, git)
 	_, err := srv.AdmitResources(context.Background(), &catalogv1.AdmitResourcesRequest{
 		RepositoryId: testRepoID,
 		CommitSha:    strings.Repeat("a", 40),
@@ -344,7 +416,7 @@ func TestAdmitResources_AdmissionAcceptedConditionSet(t *testing.T) {
 		},
 	}
 
-	srv := cataloggrpc.NewServerForTest(memStore, git)
+	srv := newCatalogServer(t, memStore, git)
 	_, err := srv.AdmitResources(context.Background(), &catalogv1.AdmitResourcesRequest{
 		RepositoryId: testRepoID,
 		CommitSha:    strings.Repeat("a", 40),
@@ -392,7 +464,7 @@ A category for electronic products.
 `
 
 func TestValidateResources_CategoryTaxonomy_Accepted(t *testing.T) {
-	srv := cataloggrpc.NewServer(nil, nil)
+	srv := newCatalogServer(t, nil, nil)
 	resp, err := srv.ValidateResources(context.Background(), &catalogv1.ValidateResourcesRequest{
 		RepositoryId: testRepoID,
 		Blobs: []*catalogv1.ResourceBlob{
@@ -414,7 +486,7 @@ metadata:
 spec: {}
 ---
 `
-	srv := cataloggrpc.NewServer(nil, nil)
+	srv := newCatalogServer(t, nil, nil)
 	resp, err := srv.ValidateResources(context.Background(), &catalogv1.ValidateResourcesRequest{
 		RepositoryId: testRepoID,
 		Blobs: []*catalogv1.ResourceBlob{
@@ -437,7 +509,7 @@ spec:
   title: Electronics
 ---
 `
-	srv := cataloggrpc.NewServer(nil, nil)
+	srv := newCatalogServer(t, nil, nil)
 	resp, err := srv.ValidateResources(context.Background(), &catalogv1.ValidateResourcesRequest{
 		RepositoryId: testRepoID,
 		Blobs: []*catalogv1.ResourceBlob{
@@ -463,7 +535,7 @@ status:
   phase: ready
 ---
 `
-	srv := cataloggrpc.NewServer(nil, nil)
+	srv := newCatalogServer(t, nil, nil)
 	resp, err := srv.ValidateResources(context.Background(), &catalogv1.ValidateResourcesRequest{
 		RepositoryId: testRepoID,
 		Blobs: []*catalogv1.ResourceBlob{
@@ -486,7 +558,7 @@ spec:
   title: Foo
 ---
 `
-	srv := cataloggrpc.NewServer(nil, nil)
+	srv := newCatalogServer(t, nil, nil)
 	resp, err := srv.ValidateResources(context.Background(), &catalogv1.ValidateResourcesRequest{
 		RepositoryId: testRepoID,
 		Blobs: []*catalogv1.ResourceBlob{
@@ -500,7 +572,7 @@ spec:
 }
 
 func TestValidateResources_ProductAndCategoryTaxonomy_BothValidated(t *testing.T) {
-	srv := cataloggrpc.NewServer(nil, nil)
+	srv := newCatalogServer(t, nil, nil)
 	resp, err := srv.ValidateResources(context.Background(), &catalogv1.ValidateResourcesRequest{
 		RepositoryId: testRepoID,
 		Blobs: []*catalogv1.ResourceBlob{
@@ -543,7 +615,7 @@ func TestAdmitResources_CategoryTaxonomy_Created(t *testing.T) {
 		},
 	}
 
-	srv := cataloggrpc.NewServerForTest(memStore, git)
+	srv := newCatalogServer(t, memStore, git)
 	_, err := srv.AdmitResources(context.Background(), &catalogv1.AdmitResourcesRequest{
 		RepositoryId: testRepoID,
 		CommitSha:    strings.Repeat("a", 40),
@@ -570,7 +642,7 @@ func TestAdmitResources_CategoryTaxonomy_Updated(t *testing.T) {
 		},
 	}
 
-	srv := cataloggrpc.NewServerForTest(memStore, git)
+	srv := newCatalogServer(t, memStore, git)
 
 	// First admission
 	_, err := srv.AdmitResources(context.Background(), &catalogv1.AdmitResourcesRequest{
@@ -610,7 +682,7 @@ func TestAdmitResources_CategoryTaxonomy_AdmissionAcceptedCondition(t *testing.T
 		},
 	}
 
-	srv := cataloggrpc.NewServerForTest(memStore, git)
+	srv := newCatalogServer(t, memStore, git)
 	_, err := srv.AdmitResources(context.Background(), &catalogv1.AdmitResourcesRequest{
 		RepositoryId: testRepoID,
 		CommitSha:    strings.Repeat("a", 40),
@@ -649,7 +721,7 @@ func TestAdmitResources_CategoryTaxonomy_RootAncestorPath(t *testing.T) {
 		},
 	}
 
-	srv := cataloggrpc.NewServerForTest(memStore, git)
+	srv := newCatalogServer(t, memStore, git)
 	_, err := srv.AdmitResources(context.Background(), &catalogv1.AdmitResourcesRequest{
 		RepositoryId: testRepoID,
 		CommitSha:    strings.Repeat("a", 40),
@@ -697,7 +769,7 @@ func TestAdmitResources_IntraPushCycle_BothStoredWithAcyclicFalse(t *testing.T) 
 		},
 	}
 
-	srv := cataloggrpc.NewServerForTest(memStore, git)
+	srv := newCatalogServer(t, memStore, git)
 	_, err := srv.AdmitResources(context.Background(), &catalogv1.AdmitResourcesRequest{
 		RepositoryId: testRepoID,
 		CommitSha:    strings.Repeat("a", 40),
@@ -746,7 +818,7 @@ func TestAdmitResources_ValidChain_BothStoredWithAcyclicTrue(t *testing.T) {
 		},
 	}
 
-	srv := cataloggrpc.NewServerForTest(memStore, git)
+	srv := newCatalogServer(t, memStore, git)
 	_, err := srv.AdmitResources(context.Background(), &catalogv1.AdmitResourcesRequest{
 		RepositoryId: testRepoID,
 		CommitSha:    strings.Repeat("a", 40),
@@ -794,7 +866,7 @@ func TestAdmitResources_RootCategory_AncestorPathEqualsName(t *testing.T) {
 			return makeCategoryTaxonomy("electronics"), nil
 		},
 	}
-	srv := cataloggrpc.NewServerForTest(memStore, git)
+	srv := newCatalogServer(t, memStore, git)
 	_, err := srv.AdmitResources(context.Background(), &catalogv1.AdmitResourcesRequest{
 		RepositoryId: testRepoID,
 		CommitSha:    strings.Repeat("a", 40),
@@ -819,7 +891,7 @@ func TestAdmitResources_ChildWithStoredParent_AncestorPathInherited(t *testing.T
 			return makeCategoryTaxonomy("electronics"), nil
 		},
 	}
-	srv := cataloggrpc.NewServerForTest(memStore, git1)
+	srv := newCatalogServer(t, memStore, git1)
 	_, err := srv.AdmitResources(context.Background(), &catalogv1.AdmitResourcesRequest{
 		RepositoryId: testRepoID,
 		CommitSha:    strings.Repeat("a", 40),
@@ -836,7 +908,7 @@ func TestAdmitResources_ChildWithStoredParent_AncestorPathInherited(t *testing.T
 			return makeCategoryTaxonomyWithParent("computers", "electronics"), nil
 		},
 	}
-	srv2 := cataloggrpc.NewServerForTest(memStore, git2)
+	srv2 := newCatalogServer(t, memStore, git2)
 	_, err = srv2.AdmitResources(context.Background(), &catalogv1.AdmitResourcesRequest{
 		RepositoryId: testRepoID,
 		CommitSha:    strings.Repeat("b", 40),
@@ -864,7 +936,7 @@ func TestAdmitResources_CoCreation_ParentAndChildInSamePush(t *testing.T) {
 			return files[path], nil
 		},
 	}
-	srv := cataloggrpc.NewServerForTest(memStore, git)
+	srv := newCatalogServer(t, memStore, git)
 	_, err := srv.AdmitResources(context.Background(), &catalogv1.AdmitResourcesRequest{
 		RepositoryId: testRepoID,
 		CommitSha:    strings.Repeat("a", 40),
@@ -887,7 +959,7 @@ func TestAdmitResources_ChildWithMissingParent_TentativeRoot_ParentResolvedFalse
 			return makeCategoryTaxonomyWithParent("computers", "electronics"), nil
 		},
 	}
-	srv := cataloggrpc.NewServerForTest(memStore, git)
+	srv := newCatalogServer(t, memStore, git)
 	_, err := srv.AdmitResources(context.Background(), &catalogv1.AdmitResourcesRequest{
 		RepositoryId: testRepoID,
 		CommitSha:    strings.Repeat("a", 40),
@@ -937,7 +1009,7 @@ func TestAdmitResources_DeepCoCreation_GrandchildAncestorPath(t *testing.T) {
 			return files[path], nil
 		},
 	}
-	srv := cataloggrpc.NewServerForTest(memStore, git)
+	srv := newCatalogServer(t, memStore, git)
 	_, err := srv.AdmitResources(context.Background(), &catalogv1.AdmitResourcesRequest{
 		RepositoryId: testRepoID,
 		CommitSha:    strings.Repeat("a", 40),
@@ -971,7 +1043,7 @@ func TestAdmitResources_TailCycle_AllMembersMarkedAcyclicFalse(t *testing.T) {
 			return files[path], nil
 		},
 	}
-	srv := cataloggrpc.NewServerForTest(memStore, git)
+	srv := newCatalogServer(t, memStore, git)
 	_, err := srv.AdmitResources(context.Background(), &catalogv1.AdmitResourcesRequest{
 		RepositoryId: testRepoID,
 		CommitSha:    strings.Repeat("a", 40),
@@ -1024,7 +1096,7 @@ spec:
 
 body
 `
-	srv := cataloggrpc.NewServer(nil, nil)
+	srv := newCatalogServer(t, nil, nil)
 	resp, err := srv.ValidateResources(context.Background(), &catalogv1.ValidateResourcesRequest{
 		RepositoryId: testRepoID,
 		Blobs:        []*catalogv1.ResourceBlob{{Path: "products/widget.md", Content: []byte(blob)}},
@@ -1049,7 +1121,7 @@ spec:
 ---
 body
 `
-	srv := cataloggrpc.NewServer(nil, nil)
+	srv := newCatalogServer(t, nil, nil)
 	resp, err := srv.ValidateResources(context.Background(), &catalogv1.ValidateResourcesRequest{
 		RepositoryId: testRepoID,
 		Blobs:        []*catalogv1.ResourceBlob{{Path: "products/widget.md", Content: []byte(blob)}},
@@ -1072,7 +1144,7 @@ spec:
 ---
 body
 `
-	srv := cataloggrpc.NewServer(nil, nil)
+	srv := newCatalogServer(t, nil, nil)
 	resp, err := srv.ValidateResources(context.Background(), &catalogv1.ValidateResourcesRequest{
 		RepositoryId: testRepoID,
 		Blobs:        []*catalogv1.ResourceBlob{{Path: "products/widget.md", Content: []byte(blob)}},
@@ -1111,7 +1183,7 @@ body
 			return []byte(blob), nil
 		},
 	}
-	srv := cataloggrpc.NewServerForTest(store, git)
+	srv := newCatalogServer(t, store, git)
 	_, err := srv.AdmitResources(context.Background(), &catalogv1.AdmitResourcesRequest{
 		RepositoryId: testRepoID,
 		CommitSha:    "abc123",
@@ -1165,7 +1237,7 @@ body
 			return []byte(blob), nil
 		},
 	}
-	srv := cataloggrpc.NewServerForTest(store, git)
+	srv := newCatalogServer(t, store, git)
 	_, err := srv.AdmitResources(context.Background(), &catalogv1.AdmitResourcesRequest{
 		RepositoryId: testRepoID,
 		CommitSha:    "abc123",
@@ -1203,7 +1275,7 @@ body
 			return []byte(blob), nil
 		},
 	}
-	srv := cataloggrpc.NewServerForTest(store, git)
+	srv := newCatalogServer(t, store, git)
 	_, err := srv.AdmitResources(context.Background(), &catalogv1.AdmitResourcesRequest{
 		RepositoryId: testRepoID,
 		CommitSha:    "abc123",

--- a/gitstore-api/internal/graph/resolver/auth.resolvers.go
+++ b/gitstore-api/internal/graph/resolver/auth.resolvers.go
@@ -7,7 +7,6 @@ package resolver
 
 import (
 	"context"
-	"time"
 
 	"github.com/gitstore-dev/gitstore/api/internal/graph/model"
 	"github.com/vektah/gqlparser/v2/gqlerror"
@@ -37,7 +36,7 @@ func (r *mutationResolver) Login(ctx context.Context, input model.LoginInput) (*
 		return nil, gqlerror.Errorf("internal server error")
 	}
 
-	expiresAt := time.Now().Add(r.authMiddleware.GetTokenDuration())
+	expiresAt := r.clock.Now().Add(r.authMiddleware.GetTokenDuration())
 	return &model.LoginPayload{
 		ClientMutationID: input.ClientMutationID,
 		Session: &model.AuthSession{

--- a/gitstore-api/internal/graph/resolver/category_resolver_test.go
+++ b/gitstore-api/internal/graph/resolver/category_resolver_test.go
@@ -21,7 +21,8 @@ func newCategoryResolverEnv(t *testing.T) (*queryResolver, datastore.Datastore) 
 	t.Helper()
 	store, err := memdb.New()
 	require.NoError(t, err)
-	r := NewResolver(store, nil, zap.NewNop())
+	r, err := NewResolver(ResolverDeps{Store: store, Logger: zap.NewNop()})
+	require.NoError(t, err)
 	return &queryResolver{Resolver: r}, store
 }
 

--- a/gitstore-api/internal/graph/resolver/product_resolver_test.go
+++ b/gitstore-api/internal/graph/resolver/product_resolver_test.go
@@ -21,7 +21,8 @@ func newProductResolverEnv(t *testing.T) (*queryResolver, datastore.Datastore) {
 	t.Helper()
 	store, err := memdb.New()
 	require.NoError(t, err)
-	r := NewResolver(store, nil, zap.NewNop())
+	r, err := NewResolver(ResolverDeps{Store: store, Logger: zap.NewNop()})
+	require.NoError(t, err)
 	return &queryResolver{Resolver: r}, store
 }
 

--- a/gitstore-api/internal/graph/resolver/resolver.go
+++ b/gitstore-api/internal/graph/resolver/resolver.go
@@ -6,10 +6,15 @@
 package resolver
 
 import (
+	"errors"
+
 	"github.com/gitstore-dev/gitstore/api/internal/datastore"
 	"github.com/gitstore-dev/gitstore/api/internal/middleware"
+	apiruntime "github.com/gitstore-dev/gitstore/api/internal/runtime"
 	"go.uber.org/zap"
 )
+
+var errMissingLogger = errors.New("resolver: logger is required")
 
 // Resolver is the root GraphQL resolver
 type Resolver struct {
@@ -18,19 +23,39 @@ type Resolver struct {
 	service        *Service
 	authMiddleware *middleware.AuthMiddleware
 	storageDataDir string // data_dir used to build storagePath in responses; defaults to "/data"
+	clock          apiruntime.Clock
+}
+
+// ResolverDeps contains dependencies for the root GraphQL resolver.
+type ResolverDeps struct {
+	Store       datastore.Datastore
+	GitWriter   GitWriter
+	Logger      *zap.Logger
+	Clock       apiruntime.Clock
+	IDGenerator apiruntime.IDGenerator
 }
 
 // NewResolver creates a new GraphQL resolver.
-// writer is the GitWriter backed by the gRPC client; pass nil to disable writes.
-func NewResolver(store datastore.Datastore, writer GitWriter, logger *zap.Logger) *Resolver {
-	SetConverterLogger(logger)
-	svc := NewServiceWithWriter(store, writer, logger)
+func NewResolver(deps ResolverDeps) (*Resolver, error) {
+	if deps.Logger == nil {
+		return nil, errMissingLogger
+	}
+	SetConverterLogger(deps.Logger)
+	svc, err := NewService(ServiceDeps(deps))
+	if err != nil {
+		return nil, err
+	}
+	clock := deps.Clock
+	if clock == nil {
+		clock = apiruntime.SystemClock{}
+	}
 	return &Resolver{
-		logger:         logger,
-		store:          store,
+		logger:         deps.Logger,
+		store:          deps.Store,
 		service:        svc,
 		storageDataDir: "/data",
-	}
+		clock:          clock,
+	}, nil
 }
 
 // WithStorageDataDir sets the data directory for deriving storage paths.

--- a/gitstore-api/internal/graph/resolver/resolver_global_id_test.go
+++ b/gitstore-api/internal/graph/resolver/resolver_global_id_test.go
@@ -125,7 +125,9 @@ func newGlobalIDTestResolver(t *testing.T) (datastore.Datastore, *Resolver) {
 	t.Helper()
 	store, err := memdb.New()
 	require.NoError(t, err)
-	return store, NewResolver(store, nil, zap.NewNop())
+	r, err := NewResolver(ResolverDeps{Store: store, Logger: zap.NewNop()})
+	require.NoError(t, err)
+	return store, r
 }
 
 func seedGlobalIDTestData(t *testing.T, ctx context.Context, store datastore.Datastore) {

--- a/gitstore-api/internal/graph/resolver/schema.resolvers.go
+++ b/gitstore-api/internal/graph/resolver/schema.resolvers.go
@@ -7,7 +7,6 @@ package resolver
 
 import (
 	"context"
-	"time"
 
 	"github.com/gitstore-dev/gitstore/api/internal/graph/generated"
 	"github.com/gitstore-dev/gitstore/api/internal/graph/model"
@@ -25,7 +24,7 @@ func (r *mutationResolver) PublishCatalog(ctx context.Context, input model.Publi
 	version := &model.CatalogVersion{
 		Tag:         input.Version,
 		Commit:      "abc123def456", // TODO: resolve actual commit from git push result
-		PublishedAt: time.Now(),
+		PublishedAt: r.clock.Now(),
 		Message:     &message,
 		Stats:       stats,
 	}
@@ -67,7 +66,7 @@ func (r *queryResolver) CatalogVersion(ctx context.Context) (*model.CatalogVersi
 	return &model.CatalogVersion{
 		Tag:         "",
 		Commit:      "",
-		PublishedAt: time.Now(),
+		PublishedAt: r.clock.Now(),
 		Message:     nil,
 		Stats:       stats,
 	}, nil

--- a/gitstore-api/internal/graph/resolver/service.go
+++ b/gitstore-api/internal/graph/resolver/service.go
@@ -12,13 +12,12 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-	"time"
 
 	"github.com/gitstore-dev/gitstore/api/internal/catalog"
 	"github.com/gitstore-dev/gitstore/api/internal/datastore"
 	"github.com/gitstore-dev/gitstore/api/internal/gitclient"
 	"github.com/gitstore-dev/gitstore/api/internal/graph/model"
-	"github.com/google/uuid"
+	apiruntime "github.com/gitstore-dev/gitstore/api/internal/runtime"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 	"go.uber.org/zap"
 )
@@ -42,6 +41,8 @@ type Service struct {
 	store     datastore.Datastore
 	gitWriter GitWriter
 	logger    *zap.Logger
+	clock     apiruntime.Clock
+	ids       apiruntime.IDGenerator
 }
 
 // GitWriter is the write subset of gitclient.Client used by the Service.
@@ -54,21 +55,38 @@ type GitWriter interface {
 	CreateTag(ctx context.Context, p gitclient.CreateTagParams) (string, error)
 }
 
-// NewService creates a new service instance backed by the datastore.
-func NewService(store datastore.Datastore, logger *zap.Logger) *Service {
-	return &Service{
-		store:  store,
-		logger: logger,
-	}
+// ServiceDeps contains dependencies for GraphQL business logic.
+type ServiceDeps struct {
+	Store       datastore.Datastore
+	GitWriter   GitWriter
+	Logger      *zap.Logger
+	Clock       apiruntime.Clock
+	IDGenerator apiruntime.IDGenerator
 }
 
-// NewServiceWithWriter creates a service with an explicit GitWriter (for tests).
-func NewServiceWithWriter(store datastore.Datastore, writer GitWriter, logger *zap.Logger) *Service {
-	return &Service{
-		store:     store,
-		gitWriter: writer,
-		logger:    logger,
+// NewService creates a new service instance backed by the datastore.
+func NewService(deps ServiceDeps) (*Service, error) {
+	if deps.Store == nil {
+		return nil, fmt.Errorf("resolver: datastore is required")
 	}
+	if deps.Logger == nil {
+		return nil, fmt.Errorf("resolver: logger is required")
+	}
+	clock := deps.Clock
+	if clock == nil {
+		clock = apiruntime.SystemClock{}
+	}
+	ids := deps.IDGenerator
+	if ids == nil {
+		ids = apiruntime.UUIDGenerator{}
+	}
+	return &Service{
+		store:     deps.Store,
+		gitWriter: deps.GitWriter,
+		logger:    deps.Logger,
+		clock:     clock,
+		ids:       ids,
+	}, nil
 }
 
 // SetGitWriter wires the gRPC client after construction (called from main.go).
@@ -175,7 +193,7 @@ func (s *Service) DeleteProduct(ctx context.Context, uid string) error {
 // This is a transitional method; collection admission via git push is the primary path.
 func (s *Service) CreateCollection(ctx context.Context, input map[string]interface{}) (*datastore.Collection, error) {
 	c := &datastore.Collection{
-		UID:  uuid.New().String(),
+		UID:  s.ids.NewID(),
 		Name: getStringOrEmpty(input, "name"),
 		Body: getStringOrEmpty(input, "body"),
 	}
@@ -240,13 +258,13 @@ func (s *Service) CreateNamespace(ctx context.Context, input model.CreateNamespa
 		parentEnterpriseID = &parent.ID
 	}
 
-	now := time.Now()
+	now := s.clock.Now()
 	var displayName string
 	if input.DisplayName != nil {
 		displayName = *input.DisplayName
 	}
 	ns := &datastore.Namespace{
-		ID:                 uuid.New().String(),
+		ID:                 s.ids.NewID(),
 		Identifier:         identifier,
 		DisplayName:        displayName,
 		Tier:               tier,
@@ -373,13 +391,13 @@ func (s *Service) CreateRepository(ctx context.Context, namespaceID, name, defau
 	if storageClass == "" {
 		storageClass = "default"
 	}
-	repoID, err := uuid.NewV7()
+	repoID, err := s.ids.NewV7ID()
 	if err != nil {
 		return nil, gqlerror.Errorf("failed to generate repository ID")
 	}
-	now := time.Now().UTC()
+	now := s.clock.Now().UTC()
 	repo := &datastore.Repository{
-		ID:            repoID.String(),
+		ID:            repoID,
 		NamespaceID:   namespaceID,
 		Name:          name,
 		DefaultBranch: defaultBranch,
@@ -518,7 +536,7 @@ func (s *Service) RenameRepository(ctx context.Context, repoID, newName, callerU
 		return nil, gqlerror.Errorf("failed to rename repository")
 	}
 	repo.Name = newName
-	repo.UpdatedAt = time.Now().UTC()
+	repo.UpdatedAt = s.clock.Now().UTC()
 	repo.UpdatedBy = callerUsername
 	if err := s.store.UpdateRepository(ctx, repo); err != nil {
 		s.logger.Error("failed to update repository record after rename",
@@ -555,7 +573,7 @@ func (s *Service) TransferRepository(ctx context.Context, repoID, toNamespaceID,
 		return nil, gqlerror.Errorf("failed to transfer repository")
 	}
 	repo.NamespaceID = toNamespaceID
-	repo.UpdatedAt = time.Now().UTC()
+	repo.UpdatedAt = s.clock.Now().UTC()
 	repo.UpdatedBy = callerUsername
 	if err := s.store.UpdateRepository(ctx, repo); err != nil {
 		s.logger.Error("failed to update repository record after transfer",

--- a/gitstore-api/internal/graph/resolver/service_constructor_test.go
+++ b/gitstore-api/internal/graph/resolver/service_constructor_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package resolver_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gitstore-dev/gitstore/api/internal/datastore/memdb"
+	"github.com/gitstore-dev/gitstore/api/internal/graph/model"
+	"github.com/gitstore-dev/gitstore/api/internal/graph/resolver"
+	apiruntime "github.com/gitstore-dev/gitstore/api/internal/runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestNewServiceRequiresDatastore(t *testing.T) {
+	_, err := resolver.NewService(resolver.ServiceDeps{Logger: zap.NewNop()})
+	require.ErrorContains(t, err, "datastore is required")
+}
+
+func TestNewServiceRequiresLogger(t *testing.T) {
+	store, err := memdb.New()
+	require.NoError(t, err)
+	defer store.Close()
+
+	_, err = resolver.NewService(resolver.ServiceDeps{Store: store})
+	require.ErrorContains(t, err, "logger is required")
+}
+
+func TestNewServiceDefaultsOptionalDependencies(t *testing.T) {
+	store, err := memdb.New()
+	require.NoError(t, err)
+	defer store.Close()
+
+	svc, err := resolver.NewService(resolver.ServiceDeps{
+		Store:  store,
+		Logger: zap.NewNop(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, svc)
+}
+
+func TestServiceCreateNamespaceAndRepositoryUsesInjectedClockAndIDs(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	namespaceID := "11111111-1111-4111-8111-111111111111"
+	repositoryID := "22222222-2222-7222-8222-222222222222"
+	store, err := memdb.New()
+	require.NoError(t, err)
+	defer store.Close()
+	writer := &mockGitWriter{}
+	svc, err := resolver.NewService(resolver.ServiceDeps{
+		Store:       store,
+		GitWriter:   writer,
+		Logger:      zap.NewNop(),
+		Clock:       apiruntime.NewFixedClock(now),
+		IDGenerator: apiruntime.NewSequenceIDGenerator(namespaceID, repositoryID),
+	})
+	require.NoError(t, err)
+
+	ns, err := svc.CreateNamespace(ctx, model.CreateNamespaceInput{
+		Identifier: "acme",
+		Tier:       model.NamespaceTierUser,
+	}, "admin", true)
+	require.NoError(t, err)
+	assert.Equal(t, namespaceID, ns.ID)
+	assert.Equal(t, now, ns.CreatedAt)
+	assert.Equal(t, now, ns.UpdatedAt)
+
+	repo, err := svc.CreateRepository(ctx, ns.ID, "catalog", "", "", "admin")
+	require.NoError(t, err)
+	assert.Equal(t, repositoryID, repo.ID)
+	assert.Equal(t, now, repo.CreatedAt)
+	assert.Equal(t, now, repo.UpdatedAt)
+	assert.Equal(t, []string{repositoryID}, writer.createRepoCalls)
+}

--- a/gitstore-api/internal/graph/resolver/service_mutations_test.go
+++ b/gitstore-api/internal/graph/resolver/service_mutations_test.go
@@ -82,14 +82,25 @@ func newTestSvc(t *testing.T, writer *mockGitWriter) *resolver.Service {
 	t.Helper()
 	store, err := memdb.New()
 	require.NoError(t, err)
-	return resolver.NewServiceWithWriter(store, writer, zap.NewNop())
+	svc, err := resolver.NewService(resolver.ServiceDeps{
+		Store:     store,
+		GitWriter: writer,
+		Logger:    zap.NewNop(),
+	})
+	require.NoError(t, err)
+	return svc
 }
 
 func TestServiceDeleteProductRemovesFromDatastore(t *testing.T) {
 	ctx := context.Background()
 	store, err := memdb.New()
 	require.NoError(t, err)
-	svc := resolver.NewServiceWithWriter(store, &mockGitWriter{}, zap.NewNop())
+	svc, err := resolver.NewService(resolver.ServiceDeps{
+		Store:     store,
+		GitWriter: &mockGitWriter{},
+		Logger:    zap.NewNop(),
+	})
+	require.NoError(t, err)
 
 	uid := "a0000000-0000-0000-0000-000000000001"
 	require.NoError(t, store.CreateProduct(ctx, &datastore.Product{

--- a/gitstore-api/internal/handler/auth_handlers_test.go
+++ b/gitstore-api/internal/handler/auth_handlers_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package handler
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	apiruntime "github.com/gitstore-dev/gitstore/api/internal/runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+type fakeAuthService struct {
+	duration time.Duration
+}
+
+func (fakeAuthService) ValidateCredentials(username, password string) bool {
+	return username == "admin" && password == "correct-password"
+}
+
+func (fakeAuthService) GenerateSessionToken(string, bool) (string, error) {
+	return "login-token", nil
+}
+
+func (fakeAuthService) RefreshSessionToken(string) (string, error) {
+	return "refresh-token", nil
+}
+
+func (f fakeAuthService) GetTokenDuration() time.Duration {
+	return f.duration
+}
+
+func TestLoginHandlerUsesConfiguredTokenDurationForExpiry(t *testing.T) {
+	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	h := NewLoginHandler(LoginHandlerDeps{
+		Auth:   fakeAuthService{duration: 2 * time.Hour},
+		Logger: zap.NewNop(),
+		Clock:  apiruntime.NewFixedClock(now),
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/login", nil)
+	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("admin:correct-password")))
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp LoginResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "login-token", resp.Token)
+	assert.Equal(t, now.Add(2*time.Hour).Format(time.RFC3339), resp.ExpiresAt)
+}
+
+func TestRefreshTokenHandlerUsesConfiguredTokenDurationForExpiry(t *testing.T) {
+	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	h := NewRefreshTokenHandler(RefreshTokenHandlerDeps{
+		Auth:   fakeAuthService{duration: 90 * time.Minute},
+		Logger: zap.NewNop(),
+		Clock:  apiruntime.NewFixedClock(now),
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/refresh", nil)
+	req.Header.Set("Authorization", "Bearer old-token")
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp RefreshTokenResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "refresh-token", resp.Token)
+	assert.Equal(t, now.Add(90*time.Minute).Format(time.RFC3339), resp.ExpiresAt)
+}

--- a/gitstore-api/internal/handler/auth_service.go
+++ b/gitstore-api/internal/handler/auth_service.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package handler
+
+import "time"
+
+// AuthService is the authentication behavior required by HTTP auth handlers.
+type AuthService interface {
+	ValidateCredentials(username, password string) bool
+	GenerateSessionToken(username string, isAdmin bool) (string, error)
+	RefreshSessionToken(token string) (string, error)
+	GetTokenDuration() time.Duration
+}

--- a/gitstore-api/internal/handler/login.go
+++ b/gitstore-api/internal/handler/login.go
@@ -9,21 +9,38 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gitstore-dev/gitstore/api/internal/middleware"
+	apiruntime "github.com/gitstore-dev/gitstore/api/internal/runtime"
 	"go.uber.org/zap"
 )
 
 // LoginHandler handles authentication requests
 type LoginHandler struct {
-	authMiddleware *middleware.AuthMiddleware
-	logger         *zap.Logger
+	auth   AuthService
+	logger *zap.Logger
+	clock  apiruntime.Clock
+}
+
+// LoginHandlerDeps contains dependencies for LoginHandler.
+type LoginHandlerDeps struct {
+	Auth   AuthService
+	Logger *zap.Logger
+	Clock  apiruntime.Clock
 }
 
 // NewLoginHandler creates a new login handler
-func NewLoginHandler(authMiddleware *middleware.AuthMiddleware, logger *zap.Logger) *LoginHandler {
+func NewLoginHandler(deps LoginHandlerDeps) *LoginHandler {
+	logger := deps.Logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	clock := deps.Clock
+	if clock == nil {
+		clock = apiruntime.SystemClock{}
+	}
 	return &LoginHandler{
-		authMiddleware: authMiddleware,
-		logger:         logger,
+		auth:   deps.Auth,
+		logger: logger,
+		clock:  clock,
 	}
 }
 
@@ -60,7 +77,7 @@ func (h *LoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Validate credentials
-	if !h.authMiddleware.ValidateCredentials(username, password) {
+	if h.auth == nil || !h.auth.ValidateCredentials(username, password) {
 		h.logger.Debug("Invalid credentials",
 			zap.String("username", username),
 		)
@@ -69,7 +86,7 @@ func (h *LoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Generate JWT token
-	token, err := h.authMiddleware.GenerateSessionToken(username, true)
+	token, err := h.auth.GenerateSessionToken(username, true)
 	if err != nil {
 		h.logger.Error("Failed to generate session token",
 			zap.Error(err),
@@ -78,8 +95,7 @@ func (h *LoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Calculate expiry time (24 hours from now)
-	expiresAt := time.Now().Add(24 * time.Hour)
+	expiresAt := h.clock.Now().Add(h.auth.GetTokenDuration())
 
 	// Return response
 	response := LoginResponse{

--- a/gitstore-api/internal/handler/refresh.go
+++ b/gitstore-api/internal/handler/refresh.go
@@ -9,21 +9,38 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gitstore-dev/gitstore/api/internal/middleware"
+	apiruntime "github.com/gitstore-dev/gitstore/api/internal/runtime"
 	"go.uber.org/zap"
 )
 
 // RefreshTokenHandler handles token refresh requests
 type RefreshTokenHandler struct {
-	authMiddleware *middleware.AuthMiddleware
-	logger         *zap.Logger
+	auth   AuthService
+	logger *zap.Logger
+	clock  apiruntime.Clock
+}
+
+// RefreshTokenHandlerDeps contains dependencies for RefreshTokenHandler.
+type RefreshTokenHandlerDeps struct {
+	Auth   AuthService
+	Logger *zap.Logger
+	Clock  apiruntime.Clock
 }
 
 // NewRefreshTokenHandler creates a new refresh token handler
-func NewRefreshTokenHandler(authMiddleware *middleware.AuthMiddleware, logger *zap.Logger) *RefreshTokenHandler {
+func NewRefreshTokenHandler(deps RefreshTokenHandlerDeps) *RefreshTokenHandler {
+	logger := deps.Logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	clock := deps.Clock
+	if clock == nil {
+		clock = apiruntime.SystemClock{}
+	}
 	return &RefreshTokenHandler{
-		authMiddleware: authMiddleware,
-		logger:         logger,
+		auth:   deps.Auth,
+		logger: logger,
+		clock:  clock,
 	}
 }
 
@@ -56,7 +73,12 @@ func (h *RefreshTokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// Refresh the token
-	newToken, err := h.authMiddleware.RefreshSessionToken(token)
+	if h.auth == nil {
+		h.logger.Debug("auth service not configured")
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+	newToken, err := h.auth.RefreshSessionToken(token)
 	if err != nil {
 		h.logger.Debug("Failed to refresh token",
 			zap.Error(err),
@@ -65,8 +87,7 @@ func (h *RefreshTokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Calculate expiry time (24 hours from now)
-	expiresAt := time.Now().Add(24 * time.Hour)
+	expiresAt := h.clock.Now().Add(h.auth.GetTokenDuration())
 
 	// Return response
 	response := RefreshTokenResponse{

--- a/gitstore-api/internal/health/health.go
+++ b/gitstore-api/internal/health/health.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gitstore-dev/gitstore/api/internal/datastore"
+	apiruntime "github.com/gitstore-dev/gitstore/api/internal/runtime"
 	"go.uber.org/zap"
 )
 
@@ -44,15 +45,33 @@ type Handler struct {
 	logger    *zap.Logger
 	version   string
 	startTime time.Time
+	clock     apiruntime.Clock
+}
+
+// HandlerDeps contains dependencies for Handler.
+type HandlerDeps struct {
+	Store   datastore.Datastore
+	Logger  *zap.Logger
+	Version string
+	Clock   apiruntime.Clock
 }
 
 // NewHandler creates a new health check handler
-func NewHandler(store datastore.Datastore, logger *zap.Logger, version string) *Handler {
+func NewHandler(deps HandlerDeps) *Handler {
+	logger := deps.Logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	clock := deps.Clock
+	if clock == nil {
+		clock = apiruntime.SystemClock{}
+	}
 	return &Handler{
-		store:     store,
+		store:     deps.Store,
 		logger:    logger,
-		version:   version,
-		startTime: time.Now(),
+		version:   deps.Version,
+		startTime: clock.Now(),
+		clock:     clock,
 	}
 }
 
@@ -62,7 +81,7 @@ func (h *Handler) Health(w http.ResponseWriter, r *http.Request) {
 	response := HealthResponse{
 		Status:    StatusHealthy,
 		Version:   h.version,
-		Timestamp: time.Now(),
+		Timestamp: h.clock.Now(),
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -94,7 +113,7 @@ func (h *Handler) Ready(w http.ResponseWriter, r *http.Request) {
 	response := HealthResponse{
 		Status:    overallStatus,
 		Version:   h.version,
-		Timestamp: time.Now(),
+		Timestamp: h.clock.Now(),
 		Checks:    checks,
 	}
 
@@ -131,6 +150,13 @@ func (h *Handler) performChecks(ctx context.Context) map[string]Check {
 }
 
 func (h *Handler) checkDatastore(ctx context.Context) Check {
+	if h.store == nil {
+		h.logger.Warn("Datastore check failed", zap.String("reason", "datastore not configured"))
+		return Check{
+			Status:  StatusUnhealthy,
+			Message: "datastore unavailable",
+		}
+	}
 	_, err := h.store.ListProducts(ctx, "", datastore.PageParams{First: 1})
 	if err != nil {
 		h.logger.Warn("Datastore check failed", zap.Error(err))
@@ -147,7 +173,7 @@ func (h *Handler) checkDatastore(ctx context.Context) Check {
 }
 
 func (h *Handler) checkUptime() Check {
-	if time.Since(h.startTime) < 5*time.Second {
+	if h.clock.Now().Sub(h.startTime) < 5*time.Second {
 		return Check{
 			Status:  StatusDegraded,
 			Message: "service warming up",

--- a/gitstore-api/internal/logger/logger.go
+++ b/gitstore-api/internal/logger/logger.go
@@ -15,9 +15,9 @@ import (
 
 var Log *zap.Logger
 
-// InitLogger initializes the global structured logger with the given log level and format.
+// InitLogger initializes and returns a structured logger with the given log level and format.
 // If logLevel is empty or invalid, INFO level is used.
-func InitLogger(logLevel, logFormat string) error {
+func InitLogger(logLevel, logFormat string) (*zap.Logger, error) {
 	config := zap.NewProductionConfig()
 
 	level, err := zapcore.ParseLevel(logLevel)
@@ -32,7 +32,7 @@ func InitLogger(logLevel, logFormat string) error {
 	case "text":
 		config.Encoding = "console"
 	default:
-		return fmt.Errorf("invalid log format %q; valid values: json, text", logFormat)
+		return nil, fmt.Errorf("invalid log format %q; valid values: json, text", logFormat)
 	}
 
 	config.EncoderConfig.TimeKey = "timestamp"
@@ -40,11 +40,11 @@ func InitLogger(logLevel, logFormat string) error {
 
 	logger, err := config.Build()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	Log = logger
-	return nil
+	return logger, nil
 }
 
 // Sync flushes any buffered log entries

--- a/gitstore-api/internal/logger/logger_test.go
+++ b/gitstore-api/internal/logger/logger_test.go
@@ -10,15 +10,20 @@ import (
 )
 
 func TestInitLoggerSupportsJSONFormat(t *testing.T) {
-	require.NoError(t, InitLogger("info", "json"))
+	log, err := InitLogger("info", "json")
+	require.NoError(t, err)
+	require.NotNil(t, log)
 	Sync()
 }
 
 func TestInitLoggerSupportsTextFormat(t *testing.T) {
-	require.NoError(t, InitLogger("debug", "text"))
+	log, err := InitLogger("debug", "text")
+	require.NoError(t, err)
+	require.NotNil(t, log)
 	Sync()
 }
 
 func TestInitLoggerRejectsInvalidFormat(t *testing.T) {
-	require.ErrorContains(t, InitLogger("info", "xml"), "invalid log format")
+	_, err := InitLogger("info", "xml")
+	require.ErrorContains(t, err, "invalid log format")
 }

--- a/gitstore-api/internal/middleware/auth.go
+++ b/gitstore-api/internal/middleware/auth.go
@@ -31,18 +31,48 @@ type AuthMiddleware struct {
 	sessionManager    *auth.SessionManager
 }
 
+// AuthDeps contains authentication middleware dependencies and configuration.
+type AuthDeps struct {
+	AdminUsername     string
+	AdminPasswordHash string
+	SessionManager    *auth.SessionManager
+	JWTSecret         string
+	JWTDuration       string
+	JWTIssuer         string
+}
+
 // NewAuthMiddleware creates a new authentication middleware from explicit config values.
-func NewAuthMiddleware(username, passwordHash, jwtSecret, jwtDuration, jwtIssuer string) (*AuthMiddleware, error) {
-	sessionManager, err := auth.NewSessionManager(jwtSecret, jwtDuration, jwtIssuer)
-	if err != nil {
-		return nil, err
+func NewAuthMiddleware(deps AuthDeps) (*AuthMiddleware, error) {
+	if deps.AdminUsername == "" {
+		return nil, authConfigError("admin username is required")
+	}
+	if deps.AdminPasswordHash == "" {
+		return nil, authConfigError("admin password hash is required")
+	}
+	sessionManager := deps.SessionManager
+	if sessionManager == nil {
+		var err error
+		sessionManager, err = auth.NewSessionManager(auth.SessionManagerDeps{
+			Secret:   deps.JWTSecret,
+			Duration: deps.JWTDuration,
+			Issuer:   deps.JWTIssuer,
+		})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &AuthMiddleware{
-		adminUsername:     username,
-		adminPasswordHash: passwordHash,
+		adminUsername:     deps.AdminUsername,
+		adminPasswordHash: deps.AdminPasswordHash,
 		sessionManager:    sessionManager,
 	}, nil
+}
+
+type authConfigError string
+
+func (e authConfigError) Error() string {
+	return "auth: " + string(e)
 }
 
 // ValidateCredentials checks if the provided username and password are valid

--- a/gitstore-api/internal/middleware/auth_test.go
+++ b/gitstore-api/internal/middleware/auth_test.go
@@ -17,7 +17,13 @@ func newTestAuthMiddleware(t *testing.T) *AuthMiddleware {
 	t.Helper()
 	hash, err := HashPassword("admin123")
 	require.NoError(t, err)
-	am, err := NewAuthMiddleware("admin", hash, "dev-secret-change-in-production", "24h", "gitstore")
+	am, err := NewAuthMiddleware(AuthDeps{
+		AdminUsername:     "admin",
+		AdminPasswordHash: hash,
+		JWTSecret:         "dev-secret-change-in-production",
+		JWTDuration:       "24h",
+		JWTIssuer:         "gitstore",
+	})
 	require.NoError(t, err)
 	return am
 }
@@ -26,7 +32,13 @@ func TestNewAuthMiddleware(t *testing.T) {
 	t.Run("should create with provided credentials", func(t *testing.T) {
 		hash, err := HashPassword("testpass123")
 		require.NoError(t, err)
-		am, err := NewAuthMiddleware("admin", hash, "dev-secret-change-in-production", "24h", "gitstore")
+		am, err := NewAuthMiddleware(AuthDeps{
+			AdminUsername:     "admin",
+			AdminPasswordHash: hash,
+			JWTSecret:         "dev-secret-change-in-production",
+			JWTDuration:       "24h",
+			JWTIssuer:         "gitstore",
+		})
 		require.NoError(t, err)
 		require.NotNil(t, am)
 		assert.Equal(t, "admin", am.adminUsername)
@@ -36,10 +48,38 @@ func TestNewAuthMiddleware(t *testing.T) {
 	t.Run("should use injected credentials", func(t *testing.T) {
 		hash, err := HashPassword("testpass123")
 		require.NoError(t, err)
-		am, err := NewAuthMiddleware("testadmin", hash, "dev-secret-change-in-production", "24h", "gitstore")
+		am, err := NewAuthMiddleware(AuthDeps{
+			AdminUsername:     "testadmin",
+			AdminPasswordHash: hash,
+			JWTSecret:         "dev-secret-change-in-production",
+			JWTDuration:       "24h",
+			JWTIssuer:         "gitstore",
+		})
 		require.NoError(t, err)
 		assert.Equal(t, "testadmin", am.adminUsername)
 		assert.Equal(t, hash, am.adminPasswordHash)
+	})
+
+	t.Run("should reject missing admin username", func(t *testing.T) {
+		hash, err := HashPassword("testpass123")
+		require.NoError(t, err)
+		_, err = NewAuthMiddleware(AuthDeps{
+			AdminPasswordHash: hash,
+			JWTSecret:         "dev-secret-change-in-production",
+			JWTDuration:       "24h",
+			JWTIssuer:         "gitstore",
+		})
+		require.ErrorContains(t, err, "admin username is required")
+	})
+
+	t.Run("should reject missing admin password hash", func(t *testing.T) {
+		_, err := NewAuthMiddleware(AuthDeps{
+			AdminUsername: "admin",
+			JWTSecret:     "dev-secret-change-in-production",
+			JWTDuration:   "24h",
+			JWTIssuer:     "gitstore",
+		})
+		require.ErrorContains(t, err, "admin password hash is required")
 	})
 }
 

--- a/gitstore-api/internal/runtime/runtime.go
+++ b/gitstore-api/internal/runtime/runtime.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 GitStore contributors
+
+package runtime
+
+import (
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Clock supplies wall-clock time to business code.
+type Clock interface {
+	Now() time.Time
+}
+
+// SystemClock reads the process wall clock.
+type SystemClock struct{}
+
+// Now returns the current local time.
+func (SystemClock) Now() time.Time {
+	return time.Now()
+}
+
+// FixedClock returns a fixed instant. It is intended for deterministic tests.
+type FixedClock struct {
+	now time.Time
+}
+
+// NewFixedClock creates a clock fixed at now.
+func NewFixedClock(now time.Time) FixedClock {
+	return FixedClock{now: now}
+}
+
+// Now returns the fixed instant.
+func (c FixedClock) Now() time.Time {
+	return c.now
+}
+
+// IDGenerator supplies identifiers to business code.
+type IDGenerator interface {
+	NewID() string
+	NewV7ID() (string, error)
+}
+
+// UUIDGenerator produces random UUID identifiers.
+type UUIDGenerator struct{}
+
+// NewID returns a random UUID string.
+func (UUIDGenerator) NewID() string {
+	return uuid.New().String()
+}
+
+// NewV7ID returns a UUIDv7 string.
+func (UUIDGenerator) NewV7ID() (string, error) {
+	id, err := uuid.NewV7()
+	if err != nil {
+		return "", err
+	}
+	return id.String(), nil
+}
+
+// SequenceIDGenerator returns preconfigured IDs in order. When exhausted, it
+// falls back to UUIDGenerator so tests can supply only the values they assert.
+type SequenceIDGenerator struct {
+	mu       sync.Mutex
+	ids      []string
+	fallback UUIDGenerator
+}
+
+// NewSequenceIDGenerator creates an ID generator backed by ids.
+func NewSequenceIDGenerator(ids ...string) *SequenceIDGenerator {
+	return &SequenceIDGenerator{ids: append([]string(nil), ids...)}
+}
+
+// NewID returns the next configured ID or a random UUID string.
+func (g *SequenceIDGenerator) NewID() string {
+	if id, ok := g.pop(); ok {
+		return id
+	}
+	return g.fallback.NewID()
+}
+
+// NewV7ID returns the next configured ID or a UUIDv7 string.
+func (g *SequenceIDGenerator) NewV7ID() (string, error) {
+	if id, ok := g.pop(); ok {
+		return id, nil
+	}
+	return g.fallback.NewV7ID()
+}
+
+func (g *SequenceIDGenerator) pop() (string, bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if len(g.ids) == 0 {
+		return "", false
+	}
+	id := g.ids[0]
+	g.ids = g.ids[1:]
+	return id, true
+}

--- a/gitstore-api/internal/validate/validator.go
+++ b/gitstore-api/internal/validate/validator.go
@@ -17,7 +17,22 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var validate = validator.New()
+// Parser owns catalog frontmatter parsing and struct validation state.
+type Parser struct {
+	structValidator *validator.Validate
+}
+
+// NewParser creates a parser with a fresh struct validator.
+func NewParser() *Parser {
+	return &Parser{structValidator: validator.New()}
+}
+
+func (p *Parser) validator() *validator.Validate {
+	if p == nil || p.structValidator == nil {
+		return validator.New()
+	}
+	return p.structValidator
+}
 
 // ParsedResource is the result of ParseResource; exactly one of Product,
 // CategoryTaxonomy, Collection, or ProductVariant is set, matching the Kind field.
@@ -29,76 +44,10 @@ type ParsedResource struct {
 	ProductVariant   *catalog.ProductVariantResource
 }
 
-// Parse reads a Markdown document, extracts the YAML frontmatter into a
-// ProductResource, validates it, and returns the parsed resource, the
-// remaining Markdown body, and any error.
-//
-// Validation is two-pass:
-//  1. Pre-parse: detect legacy format, forbidden top-level keys (status,
-//     read-only metadata fields) from the raw YAML map before struct binding.
-//  2. Post-parse: struct-tag validation via go-playground/validator, plus
-//     spec-level rules (options.name required/unique, label length).
-func Parse(r io.Reader) (*catalog.ProductResource, []byte, error) {
-	raw, err := io.ReadAll(r)
-	if err != nil {
-		return nil, nil, fmt.Errorf("validate: read: %w", err)
-	}
-
-	// Opt-in: files that don't begin with --- are not product resources; skip.
-	if !bytes.HasPrefix(bytes.TrimLeftFunc(raw, unicode.IsSpace), []byte("---")) {
-		return nil, raw, nil
-	}
-
-	// Extract the raw YAML block between the first --- delimiters.
-	fmRaw, err := extractFrontmatterBlock(raw)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Pre-parse checks on the raw map.
-	if err := preParseChecks(fmRaw); err != nil {
-		return nil, nil, err
-	}
-
-	// Struct binding via frontmatter.Parse.
-	var res catalog.ProductResource
-	formats := []*frontmatter.Format{
-		frontmatter.NewFormat("---", "---", yaml.Unmarshal),
-	}
-	body, err := frontmatter.Parse(bytes.NewReader(raw), &res, formats...)
-	if err != nil {
-		return nil, nil, fmt.Errorf("validate: parse frontmatter: %w", err)
-	}
-
-	// Post-parse: collect all violations before returning.
-	var errs []error
-
-	// Struct-tag validation — map to user-friendly messages.
-	if err := validate.Struct(res); err != nil {
-		errs = append(errs, toFriendlyError(err))
-	}
-
-	// Spec-level validation.
-	if err := validateSpec(res.Spec); err != nil {
-		errs = append(errs, err)
-	}
-
-	// Label length validation.
-	if err := validateLabels(res.Metadata.Labels); err != nil {
-		errs = append(errs, err)
-	}
-
-	if len(errs) > 0 {
-		return nil, nil, errors.Join(errs...)
-	}
-
-	return &res, body, nil
-}
-
-// ParseResource reads a Markdown document, extracts YAML frontmatter, dispatches
-// on the kind field, validates the resource, and returns a ParsedResource.
-// Recognized kinds: Product, CategoryTaxonomy.
-func ParseResource(r io.Reader) (*ParsedResource, []byte, error) {
+// ParseResource reads a Markdown document, extracts YAML frontmatter,
+// dispatches on the kind field, validates the resource, and returns a
+// ParsedResource.
+func (p *Parser) ParseResource(r io.Reader) (*ParsedResource, []byte, error) {
 	raw, err := io.ReadAll(r)
 	if err != nil {
 		return nil, nil, fmt.Errorf("validate: read: %w", err)
@@ -137,7 +86,7 @@ func ParseResource(r io.Reader) (*ParsedResource, []byte, error) {
 			return nil, nil, fmt.Errorf("validate: parse frontmatter: %w", err)
 		}
 		var errs []error
-		if err := validate.Struct(res); err != nil {
+		if err := p.validator().Struct(res); err != nil {
 			errs = append(errs, toFriendlyError(err))
 		}
 		if err := validateSpec(res.Spec); err != nil {
@@ -158,7 +107,7 @@ func ParseResource(r io.Reader) (*ParsedResource, []byte, error) {
 			return nil, nil, fmt.Errorf("validate: parse frontmatter: %w", err)
 		}
 		var errs []error
-		if err := validate.Struct(res); err != nil {
+		if err := p.validator().Struct(res); err != nil {
 			errs = append(errs, toFriendlyError(err))
 		}
 		if err := validateCategorySpec(res.Metadata.Name, res.Spec); err != nil {
@@ -179,7 +128,7 @@ func ParseResource(r io.Reader) (*ParsedResource, []byte, error) {
 			return nil, nil, fmt.Errorf("validate: parse frontmatter: %w", err)
 		}
 		var errs []error
-		if err := validate.Struct(res); err != nil {
+		if err := p.validator().Struct(res); err != nil {
 			errs = append(errs, toFriendlyError(err))
 		}
 		if err := validateLabels(res.Metadata.Labels); err != nil {
@@ -200,7 +149,7 @@ func ParseResource(r io.Reader) (*ParsedResource, []byte, error) {
 			return nil, nil, fmt.Errorf("validate: parse frontmatter: %w", err)
 		}
 		var errs []error
-		if err := validate.Struct(res); err != nil {
+		if err := p.validator().Struct(res); err != nil {
 			errs = append(errs, toFriendlyError(err))
 		}
 		if err := validateProductVariantSpec(res.Spec); err != nil {

--- a/gitstore-api/internal/validate/validator_test.go
+++ b/gitstore-api/internal/validate/validator_test.go
@@ -5,9 +5,12 @@ package validate_test
 
 import (
 	"embed"
+	"fmt"
+	"io"
 	"strings"
 	"testing"
 
+	"github.com/gitstore-dev/gitstore/api/internal/catalog"
 	"github.com/gitstore-dev/gitstore/api/internal/validate"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,12 +19,23 @@ import (
 //go:embed testdata/*
 var testFS embed.FS
 
+func parseProduct(r io.Reader) (*catalog.ProductResource, []byte, error) {
+	parsed, body, err := validate.NewParser().ParseResource(r)
+	if err != nil || parsed == nil {
+		return nil, body, err
+	}
+	if parsed.Product == nil {
+		return nil, body, fmt.Errorf("expected Product resource, got %q", parsed.Kind)
+	}
+	return parsed.Product, body, nil
+}
+
 // ── US1: Valid product parsing ────────────────────────────────────────────────
 
 func TestParse_ValidProductAccepted(t *testing.T) {
 	f, err := testFS.Open("testdata/macbook-pro-64gb-1tb-ssd-m4.md")
 	require.NoError(t, err)
-	res, body, err := validate.Parse(f)
+	res, body, err := parseProduct(f)
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	assert.Equal(t, "catalog.gitstore.dev/v1beta1", res.APIVersion)
@@ -40,7 +54,7 @@ spec: {}
 ---
 body
 `
-	res, body, err := validate.Parse(strings.NewReader(doc))
+	res, body, err := parseProduct(strings.NewReader(doc))
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	assert.Equal(t, "minimal-product", res.Metadata.Name)
@@ -65,7 +79,7 @@ spec: {}
 ---
 body
 `
-	res, _, err := validate.Parse(strings.NewReader(doc))
+	res, _, err := parseProduct(strings.NewReader(doc))
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	assert.Equal(t, "production", res.Metadata.Labels["env"])
@@ -85,7 +99,7 @@ spec: {}
 ---
 body
 `
-	_, _, err := validate.Parse(strings.NewReader(doc))
+	_, _, err := parseProduct(strings.NewReader(doc))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "kind")
 }
@@ -100,7 +114,7 @@ spec: {}
 ---
 body
 `
-	_, _, err := validate.Parse(strings.NewReader(doc))
+	_, _, err := parseProduct(strings.NewReader(doc))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "name")
 }
@@ -115,7 +129,7 @@ spec: {}
 ---
 body
 `
-	_, _, err := validate.Parse(strings.NewReader(doc))
+	_, _, err := parseProduct(strings.NewReader(doc))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "kind")
 }
@@ -130,7 +144,7 @@ metadata:
 ---
 body
 `
-	_, _, err := validate.Parse(strings.NewReader(doc))
+	_, _, err := parseProduct(strings.NewReader(doc))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "migration is not supported in alpha")
 }
@@ -147,7 +161,7 @@ status:
 ---
 body
 `
-	_, _, err := validate.Parse(strings.NewReader(doc))
+	_, _, err := parseProduct(strings.NewReader(doc))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "status")
 }
@@ -162,7 +176,7 @@ spec: {}
 ---
 body
 `
-	_, _, err := validate.Parse(strings.NewReader(doc))
+	_, _, err := parseProduct(strings.NewReader(doc))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "catalog.gitstore.dev/v1beta1")
 }
@@ -176,7 +190,7 @@ metadata:
 ---
 body
 `
-	_, _, err := validate.Parse(strings.NewReader(doc))
+	_, _, err := parseProduct(strings.NewReader(doc))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "spec")
 }
@@ -191,7 +205,7 @@ spec: {}
 ---
 body
 `
-	_, _, err := validate.Parse(strings.NewReader(doc))
+	_, _, err := parseProduct(strings.NewReader(doc))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "name")
 }
@@ -209,7 +223,7 @@ spec: {}
 ---
 body
 `
-	_, _, err := validate.Parse(strings.NewReader(doc))
+	_, _, err := parseProduct(strings.NewReader(doc))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "uid")
 }
@@ -228,7 +242,7 @@ spec:
 ---
 body
 `
-	_, _, err := validate.Parse(strings.NewReader(doc))
+	_, _, err := parseProduct(strings.NewReader(doc))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "options[0].name")
 }
@@ -246,7 +260,7 @@ spec:
 ---
 body
 `
-	_, _, err := validate.Parse(strings.NewReader(doc))
+	_, _, err := parseProduct(strings.NewReader(doc))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "duplicate")
 	assert.Contains(t, err.Error(), "color")
@@ -263,7 +277,7 @@ spec: {}
 ---
 body
 `
-	_, _, err := validate.Parse(strings.NewReader(doc))
+	_, _, err := parseProduct(strings.NewReader(doc))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ownerReferences")
 }
@@ -282,7 +296,7 @@ func TestParse_ReadOnlyMetadataAllFieldsRejected(t *testing.T) {
 		t.Run(tc.field, func(t *testing.T) {
 			doc := "---\napiVersion: catalog.gitstore.dev/v1beta1\nkind: Product\nmetadata:\n  name: my-product\n" +
 				tc.yaml + "\nspec: {}\n---\nbody\n"
-			_, _, err := validate.Parse(strings.NewReader(doc))
+			_, _, err := parseProduct(strings.NewReader(doc))
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.field)
 		})
@@ -295,7 +309,7 @@ func TestParse_LabelKeyTooLongRejected(t *testing.T) {
 	longKey := strings.Repeat("a", 64) // exceeds 63-char segment limit
 	doc := "---\napiVersion: catalog.gitstore.dev/v1beta1\nkind: Product\nmetadata:\n  name: my-product\n  labels:\n    " +
 		longKey + ": value\nspec: {}\n---\nbody\n"
-	_, _, err := validate.Parse(strings.NewReader(doc))
+	_, _, err := parseProduct(strings.NewReader(doc))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "label")
 }
@@ -305,7 +319,7 @@ func TestParse_LabelKeyPrefixTooLongRejected(t *testing.T) {
 	key := longPrefix + "/name"
 	doc := "---\napiVersion: catalog.gitstore.dev/v1beta1\nkind: Product\nmetadata:\n  name: my-product\n  labels:\n    \"" +
 		key + "\": value\nspec: {}\n---\nbody\n"
-	_, _, err := validate.Parse(strings.NewReader(doc))
+	_, _, err := parseProduct(strings.NewReader(doc))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "prefix")
 }
@@ -314,18 +328,21 @@ func TestParse_LabelValueTooLongRejected(t *testing.T) {
 	longVal := strings.Repeat("v", 64) // exceeds 63-char value limit
 	doc := "---\napiVersion: catalog.gitstore.dev/v1beta1\nkind: Product\nmetadata:\n  name: my-product\n  labels:\n    env: " +
 		longVal + "\nspec: {}\n---\nbody\n"
-	_, _, err := validate.Parse(strings.NewReader(doc))
+	_, _, err := parseProduct(strings.NewReader(doc))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "label value")
 }
 
 func TestParse_MultipleViolationsReportedTogether(t *testing.T) {
-	// Both kind wrong AND duplicate options — both violations must appear.
+	// Duplicate options and invalid label value must both appear for a Product.
+	longVal := strings.Repeat("v", 64)
 	doc := `---
 apiVersion: catalog.gitstore.dev/v1beta1
-kind: Widget
+kind: Product
 metadata:
   name: my-product
+  labels:
+    env: ` + longVal + `
 spec:
   options:
   - name: color
@@ -333,15 +350,15 @@ spec:
 ---
 body
 `
-	_, _, err := validate.Parse(strings.NewReader(doc))
+	_, _, err := parseProduct(strings.NewReader(doc))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "kind")
 	assert.Contains(t, err.Error(), "duplicate")
+	assert.Contains(t, err.Error(), "label value")
 }
 
 func TestParse_NoFrontmatterSkipped(t *testing.T) {
 	doc := "# README\n\nThis is a plain Markdown file with no frontmatter.\n"
-	res, body, err := validate.Parse(strings.NewReader(doc))
+	res, body, err := parseProduct(strings.NewReader(doc))
 	require.NoError(t, err)
 	assert.Nil(t, res)
 	assert.NotEmpty(t, body)
@@ -353,7 +370,7 @@ func TestParse_SpecTitle_TooLong_Rejected(t *testing.T) {
 	longTitle := strings.Repeat("x", 201) // 201 chars — exceeds max=200
 	doc := "---\napiVersion: catalog.gitstore.dev/v1beta1\nkind: Product\nmetadata:\n  name: my-product\nspec:\n  title: \"" +
 		longTitle + "\"\n---\nbody\n"
-	_, _, err := validate.Parse(strings.NewReader(doc))
+	_, _, err := parseProduct(strings.NewReader(doc))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "title")
 }
@@ -362,7 +379,7 @@ func TestParse_SpecTitle_MaxLength_Accepted(t *testing.T) {
 	exactTitle := strings.Repeat("x", 200) // 200 chars — at limit, must pass
 	doc := "---\napiVersion: catalog.gitstore.dev/v1beta1\nkind: Product\nmetadata:\n  name: my-product\nspec:\n  title: \"" +
 		exactTitle + "\"\n---\nbody\n"
-	res, _, err := validate.Parse(strings.NewReader(doc))
+	res, _, err := parseProduct(strings.NewReader(doc))
 	require.NoError(t, err)
 	require.NotNil(t, res)
 }
@@ -381,7 +398,7 @@ spec:
 ---
 body
 `
-	_, _, err := validate.Parse(strings.NewReader(doc))
+	_, _, err := parseProduct(strings.NewReader(doc))
 	require.Error(t, err)
 	// go-playground/validator reports the leaf field name; "name" is the field
 	// inside FileReference that failed the "required" constraint.
@@ -402,7 +419,7 @@ spec:
 ---
 body
 `
-	_, _, err := validate.Parse(strings.NewReader(doc))
+	_, _, err := parseProduct(strings.NewReader(doc))
 	require.Error(t, err)
 	// go-playground/validator reports the leaf field name; "kind" is the field
 	// inside FileReference that failed the "required" constraint.
@@ -423,7 +440,7 @@ spec:
 ---
 body
 `
-	res, _, err := validate.Parse(strings.NewReader(doc))
+	res, _, err := parseProduct(strings.NewReader(doc))
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.Len(t, res.Spec.Media, 1)
@@ -436,7 +453,7 @@ func TestParse_SpecTitle_TooLong_FieldNamedInError(t *testing.T) {
 	longTitle := strings.Repeat("x", 201)
 	doc := "---\napiVersion: catalog.gitstore.dev/v1beta1\nkind: Product\nmetadata:\n  name: my-product\nspec:\n  title: \"" +
 		longTitle + "\"\n---\nbody\n"
-	_, _, err := validate.Parse(strings.NewReader(doc))
+	_, _, err := parseProduct(strings.NewReader(doc))
 	require.Error(t, err)
 	// Must name the qualified field path and the limit (FR-001).
 	assert.Contains(t, err.Error(), "spec.title")
@@ -456,7 +473,7 @@ spec:
 ---
 body
 `
-	_, _, err := validate.Parse(strings.NewReader(doc))
+	_, _, err := parseProduct(strings.NewReader(doc))
 	require.Error(t, err)
 	// Must name the indexed path (FR-002).
 	assert.Contains(t, err.Error(), "spec.media[0]")
@@ -475,7 +492,7 @@ spec:
 ---
 body
 `
-	_, _, err := validate.Parse(strings.NewReader(doc))
+	_, _, err := parseProduct(strings.NewReader(doc))
 	require.Error(t, err)
 	// Must name the qualified path (FR-005).
 	assert.Contains(t, err.Error(), "categoryref.name")
@@ -492,7 +509,7 @@ spec:
 ---
 body
 `
-	res, _, err := validate.Parse(strings.NewReader(doc))
+	res, _, err := parseProduct(strings.NewReader(doc))
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	assert.Empty(t, res.Spec.Options)
@@ -508,7 +525,7 @@ spec: {}
 ---
 body
 `
-	res, _, err := validate.Parse(strings.NewReader(doc))
+	res, _, err := parseProduct(strings.NewReader(doc))
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	assert.Nil(t, res.Spec.Options)
@@ -528,7 +545,7 @@ spec:
 ---
 body
 `
-	_, _, err := validate.Parse(strings.NewReader(doc))
+	_, _, err := parseProduct(strings.NewReader(doc))
 	require.Error(t, err)
 	// optional: true does NOT waive the name requirement.
 	assert.Contains(t, err.Error(), "fileref.name")
@@ -547,7 +564,7 @@ status: {}
 ---
 body
 `
-	_, _, err := validate.Parse(strings.NewReader(doc))
+	_, _, err := parseProduct(strings.NewReader(doc))
 	require.Error(t, err)
 	// Presence of key, not content, triggers rejection (FR-007).
 	assert.Contains(t, err.Error(), "status")
@@ -567,7 +584,7 @@ spec: {}
 ---
 body
 `
-	_, _, err := validate.Parse(strings.NewReader(doc))
+	_, _, err := parseProduct(strings.NewReader(doc))
 	require.Error(t, err)
 	// All three forbidden fields must appear (FR-008, FR-009).
 	assert.Contains(t, err.Error(), "uid")
@@ -589,7 +606,7 @@ spec: {}
 ---
 body
 `
-	_, _, err := validate.Parse(strings.NewReader(doc))
+	_, _, err := parseProduct(strings.NewReader(doc))
 	require.Error(t, err)
 	// Both forbidden fields must appear in the single error response (FR-008, FR-009).
 	assert.Contains(t, err.Error(), "uid")
@@ -611,7 +628,7 @@ spec:
 ---
 body
 `
-	_, _, err := validate.Parse(strings.NewReader(doc))
+	_, _, err := parseProduct(strings.NewReader(doc))
 	require.Error(t, err)
 	// The error must name the full qualified path, not just the leaf "name" (FR-002).
 	assert.Contains(t, err.Error(), "spec.media[0]")
@@ -631,7 +648,7 @@ spec:
 ---
 body
 `
-	res, body, err := validate.ParseResource(strings.NewReader(doc))
+	res, body, err := validate.NewParser().ParseResource(strings.NewReader(doc))
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.NotNil(t, res.CategoryTaxonomy)
@@ -651,7 +668,7 @@ spec: {}
 ---
 body
 `
-	_, _, err := validate.ParseResource(strings.NewReader(doc))
+	_, _, err := validate.NewParser().ParseResource(strings.NewReader(doc))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "spec.title")
 }
@@ -666,7 +683,7 @@ spec:
 ---
 body
 `
-	_, _, err := validate.ParseResource(strings.NewReader(doc))
+	_, _, err := validate.NewParser().ParseResource(strings.NewReader(doc))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "metadata.name")
 }
@@ -682,7 +699,7 @@ spec:
 ---
 body
 `
-	_, _, err := validate.ParseResource(strings.NewReader(doc))
+	_, _, err := validate.NewParser().ParseResource(strings.NewReader(doc))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "UnknownKind")
 	assert.Contains(t, err.Error(), "not a recognized")
@@ -701,7 +718,7 @@ spec:
 ---
 body
 `
-	_, _, err := validate.ParseResource(strings.NewReader(doc))
+	_, _, err := validate.NewParser().ParseResource(strings.NewReader(doc))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "must not reference the category itself")
 }
@@ -716,7 +733,7 @@ spec: {}
 ---
 body
 `
-	res, body, err := validate.ParseResource(strings.NewReader(doc))
+	res, body, err := validate.NewParser().ParseResource(strings.NewReader(doc))
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.NotNil(t, res.Product)
@@ -742,7 +759,7 @@ spec:
 ---
 body
 `
-	res, _, err := validate.ParseResource(strings.NewReader(doc))
+	res, _, err := validate.NewParser().ParseResource(strings.NewReader(doc))
 	require.NoError(t, err)
 	require.NotNil(t, res.CategoryTaxonomy)
 	require.Len(t, res.CategoryTaxonomy.Spec.Media, 1)
@@ -763,7 +780,7 @@ spec:
 ---
 body
 `
-	_, _, err := validate.ParseResource(strings.NewReader(doc))
+	_, _, err := validate.NewParser().ParseResource(strings.NewReader(doc))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "media[0]")
 	assert.Contains(t, err.Error(), "name")
@@ -783,7 +800,7 @@ spec:
 ---
 body
 `
-	_, _, err := validate.ParseResource(strings.NewReader(doc))
+	_, _, err := validate.NewParser().ParseResource(strings.NewReader(doc))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "media[0]")
 	assert.Contains(t, err.Error(), "kind")
@@ -807,7 +824,7 @@ spec:
 ---
 body
 `
-	res, _, err := validate.ParseResource(strings.NewReader(doc))
+	res, _, err := validate.NewParser().ParseResource(strings.NewReader(doc))
 	require.NoError(t, err)
 	require.NotNil(t, res.CategoryTaxonomy)
 	assert.True(t, res.CategoryTaxonomy.Spec.Media[0].FileRef.Optional)
@@ -828,7 +845,7 @@ spec:
 ---
 body
 `
-	res, _, err := validate.ParseResource(strings.NewReader(doc))
+	res, _, err := validate.NewParser().ParseResource(strings.NewReader(doc))
 	require.NoError(t, err)
 	require.NotNil(t, res.Product)
 	require.NotNil(t, res.Product.Spec.CategoryRef)
@@ -845,7 +862,7 @@ spec: {}
 ---
 body
 `
-	res, _, err := validate.ParseResource(strings.NewReader(doc))
+	res, _, err := validate.NewParser().ParseResource(strings.NewReader(doc))
 	require.NoError(t, err)
 	require.NotNil(t, res.Product)
 	assert.Nil(t, res.Product.Spec.CategoryRef)
@@ -865,7 +882,7 @@ spec:
 ---
 body
 `
-	_, _, err := validate.ParseResource(strings.NewReader(doc))
+	_, _, err := validate.NewParser().ParseResource(strings.NewReader(doc))
 	require.Error(t, err)
 }
 
@@ -881,7 +898,7 @@ spec:
 ---
 body
 `
-	_, _, err := validate.ParseResource(strings.NewReader(doc))
+	_, _, err := validate.NewParser().ParseResource(strings.NewReader(doc))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "categoryref.name")
 }


### PR DESCRIPTION
## Summary
- centralize gitstore-api runtime wiring in internal/app and keep cmd/server thin
- add explicit dependency structs plus clock and ID generator seams for resolver, catalog gRPC, auth, and health code
- convert catalog parsing/auth handlers to injected dependencies and make token expiry responses use the configured JWT duration
- document the manual DI composition approach

## Tests
- go test ./... (from gitstore-api)
- make pr-ready