### PR TITLE
[codex] Add commerce resource storage docs

### DIFF
--- a/docs/resources/README.md
+++ b/docs/resources/README.md
@@ -1,0 +1,152 @@
+# Commerce Resource Storage Overview
+
+This section classifies GitStore resource types by where their source of truth
+should live. The goal is to keep Git history useful for reviewable desired state,
+while keeping high-churn runtime state, PII, payment state, and computed data out
+of Git.
+
+The resource shape intentionally follows Kubernetes conventions:
+
+- `apiVersion`
+- `kind`
+- `metadata`
+- `spec`
+- `status`
+
+That shape does not imply Git storage. Some resources are Git-authored and
+hydrated into ScyllaDB or memDB. Others are datastore-only durable records or
+transient request/response objects.
+
+The resource list is anchored in the Kubernetes-style frontmatter initiative
+tracked by `gitstore-dev/GitStore#40`. That initiative currently covers
+`Product`, `ProductVariant`, `CategoryTaxonomy`, `Collection`, `Translation`,
+`File`, `Namespace`, `Repository`, and research tracks for `Order` and
+`PaymentIntent`.
+
+## Storage Groups
+
+| Group | Source of truth | Use for | Details |
+|---|---|---|---|
+| Git + datastore | Git for author input; datastore for hydrated read model and status | Reviewable business configuration and catalog desired state | [Git-backed resources](git-backed.md) |
+| Datastore only | ScyllaDB or memDB | Durable operational records, PII, payments, inventory movement, sessions, audit, and runtime state | [Datastore-only resources](datastore-only.md) |
+| LFS or object storage | Git LFS or object storage for payloads; Git/datastore for manifests | Binary files, media originals, generated variants, imports, exports, labels, invoices, and archived payloads | [LFS and object storage resources](lfs-object-storage.md) |
+| Transient | Not persisted as resources | Calculations, checks, previews, quotes, admission/review calls, auth reviews, and signed upload requests | [Transient resources](transient.md) |
+
+## Core vs Extension/CRD
+
+Each resource is marked with an initial scope:
+
+| Scope | Meaning |
+|---|---|
+| Core | Should be built into GitStore because it is part of the base control plane, catalog, checkout, inventory, fulfillment, auth, or platform runtime. |
+| Extension/CRD | Should be implemented through future custom resource definitions, plugins, or optional modules. These are important for enterprise commerce but should not expand the core API surface by default. |
+
+The scope is not a persistence decision. A resource can be `Core` and
+datastore-only, for example `Order` or `Session`.
+
+## Common Git-Backed Markdown Shape
+
+Git-backed resources are committed as Markdown files with YAML frontmatter.
+Authors set desired state in `spec` and optional Markdown body content. System
+fields and `status` are written to the datastore, not committed by users.
+
+```markdown
+---
+apiVersion: catalog.gitstore.dev/v1beta1
+kind: Product
+metadata:
+  name: example-product
+  namespace: example-store
+  labels:
+    gitstore.dev/brand: example
+  annotations:
+    gitstore.dev/source: merch-team
+spec:
+  title: Example Product
+---
+
+Markdown body content for the resource.
+```
+
+System-managed fields that author files must not set:
+
+- `metadata.uid`
+- `metadata.resourceVersion`
+- `metadata.generation`
+- `metadata.creationTimestamp`
+- `metadata.revision`
+- `metadata.ownerReferences`
+- `status`
+
+## Common Datastore-Only Shape
+
+Datastore-only resources can still use the same API envelope internally and over
+GraphQL/HTTP/gRPC. They are created by APIs, controllers, webhooks, or workers
+instead of Git pushes.
+
+```yaml
+apiVersion: checkout.gitstore.dev/v1beta1
+kind: Order
+metadata:
+  name: ord-10001
+  namespace: example-store
+spec:
+  customerRef:
+    kind: Customer
+    name: cus-10001
+  currencyCode: EUR
+status:
+  conditions: []
+```
+
+## Persistence Rules
+
+Use Git + datastore when:
+
+- humans should review and approve the change;
+- the resource is desired state rather than a transaction log;
+- rollback through Git history is useful;
+- the document does not contain secrets, payment data, regulated PII, or
+  high-churn runtime state.
+
+Use datastore only when:
+
+- the resource is created by customers, checkout flows, payment gateways,
+  inventory workers, fulfillment systems, auth providers, or controllers;
+- the resource changes frequently;
+- redaction, retention, privacy, or legal deletion requirements apply;
+- the resource is an append-only event, ledger, session, audit, or delivery log.
+
+Use LFS or object storage when:
+
+- the primary payload is binary or large;
+- the object is generated or high-churn;
+- direct Git storage would make repository history noisy;
+- the payload may require retention, encryption, CDN delivery, or signed URLs.
+
+Use transient resources when:
+
+- the output is a calculation or authorization result;
+- the resource has no useful independent lifecycle;
+- replay can be represented by durable events or logs when needed.
+
+## Subresource Conventions
+
+Subresources should use the same storage decision as the data they represent:
+
+| Subresource style | Storage group | Examples | Notes |
+|---|---|---|---|
+| System status | Datastore field on Git-backed resource | `Product/status`, `ProductVariant/status`, `Collection/status` | Author files must not include `status`; controllers and admission own it. |
+| Finalization and deletion gates | Datastore field on durable resource | `Namespace/finalize`, `Repository/finalize`, `Order/cancel` | Keep finalizers and deletion blockers out of Git-authored desired state unless they are policy declarations. |
+| Review/check endpoints | Transient | `TokenReview`, `SubjectAccessReview`, `AdmissionReview`, `ValidationReview` | Persist only audit or decision logs if required. |
+| Runtime child records | Datastore only | `Order/events`, `PaymentIntent/authorizations`, `PaymentIntent/captures`, `Payment/refunds`, `Shipment/trackingEvents` | These are independent operational records even when exposed under a parent API path. |
+| Generated projections | Datastore only or transient | `Product/searchDocument`, `Collection/members`, `Inventory/availability` | Store only when needed for query performance or watch semantics. |
+| Binary variants | Object storage | `File/variants`, `MediaAsset/renditions`, `Invoice/pdf` | Store manifest and resolved URLs separately from payload bytes. |
+
+## Related Existing Resource Docs
+
+- [Product Spec Reference](../products/product-spec.md)
+- [ProductVariant Spec Reference](../products/product-variants.md)
+- [CategoryTaxonomy Document Format](../categories/category-taxonomy.md)
+- [Collection Spec Reference](../collections/collection-spec.md)
+- [Pluggable Identity and Access Design](../implementation/pluggable_auth_design.md)

--- a/docs/resources/datastore-only.md
+++ b/docs/resources/datastore-only.md
@@ -1,0 +1,169 @@
+# Datastore-Only Resources
+
+Datastore-only resources are durable records but are not Git-authored. They are
+created by APIs, checkout flows, controllers, workers, identity providers,
+payment gateways, inventory systems, or webhooks.
+
+These resources may still use `apiVersion`, `kind`, `metadata`, `spec`, and
+`status` internally. The key difference is source of truth: ScyllaDB or memDB
+owns the record, not Git.
+
+## API Shape
+
+```yaml
+apiVersion: checkout.gitstore.dev/v1beta1
+kind: Order
+metadata:
+  name: ord-10001
+  namespace: example-store
+  labels: {}
+  annotations: {}
+spec:
+  customerRef:
+    kind: Customer
+    name: cus-10001
+status:
+  observedGeneration: 1
+  conditions: []
+```
+
+Use generated IDs where names are not human-authored. Do not write these
+resources back to Git unless a separate export or audit feature is explicitly
+designed.
+
+## Customer And B2B
+
+| Resource | Scope | Summary | Initial spec shape |
+|---|---|---|---|
+| `Customer` | Core | Customer account identity within a namespace. | `spec: {externalIds, emailHash, profileRef, defaultAddressRef, customerGroupRefs}` |
+| `CustomerProfile` | Core | Customer profile data subject to privacy and deletion rules. | `spec: {name, email, phone, locale, preferences}` |
+| `Address` | Core | Customer, company, billing, or shipping address. | `spec: {recipient, lines, city, region, postalCode, countryCode, phone}` |
+| `CustomerGroupMembership` | Core | Runtime membership of customers in groups or segments. | `spec: {customerRef, groupRef, source, validUntilTime}` |
+| `Company` | Core | B2B company account. | `spec: {displayName, identifiers, billingAddressRef, creditLimit}` |
+| `CompanyLocation` | Core | B2B location, branch, or buying unit. | `spec: {companyRef, addressRef, taxIds, buyerPolicy}` |
+| `BuyerRoleAssignment` | Core | Assigns customer users to B2B buyer roles. | `spec: {companyRef, customerRef, role, spendingLimit}` |
+| `ConsentRecord` | Core | Record of consent captured from a subject. | `spec: {subjectRef, policyRef, granted, evidence, capturedAt}` |
+| `PrivacyRequest` | Core | GDPR/CCPA access, deletion, export, or correction request. | `spec: {subjectRef, type, requestedAt, verification}` |
+
+## Authentication Runtime
+
+| Resource | Scope | Summary | Initial spec shape |
+|---|---|---|---|
+| `Session` | Core | Authenticated session and expiry metadata. | `spec: {principal, issuedAt, expiresAt, authMethod}` |
+| `RefreshToken` | Core | Refresh token record or hash. | `spec: {subject, tokenHash, issuedAt, expiresAt, revokedAt}` |
+| `TokenJTI` | Core | JWT ID allow/deny or replay tracking record. | `spec: {issuer, subject, jti, expiresAt, revoked}` |
+| `APIKeyHash` | Core | API key metadata and hash, never the raw key. | `spec: {subject, keyHash, scopes, expiresAt, lastUsedAt}` |
+| `MFADevice` | Extension/CRD | Multi-factor authentication device registration. | `spec: {subject, type, provider, verifiedAt, disabledAt}` |
+| `IdentityLink` | Core | Mapping from external `(issuer, subject)` to GitStore principal. | `spec: {issuer, subject, principalRef, claims}` |
+| `Invite` | Core | User or collaborator invitation. | `spec: {emailHash, roleRefs, tokenHash, expiresAt}` |
+| `PasswordReset` | Extension/CRD | Password reset challenge for local identity providers. | `spec: {subject, tokenHash, expiresAt, usedAt}` |
+| `LoginAttempt` | Core | Login attempt, risk, and rate-limit record. | `spec: {subjectHint, ipHash, userAgentHash, outcome, occurredAt}` |
+
+## Runtime AuthZ
+
+| Resource | Scope | Summary | Initial spec shape |
+|---|---|---|---|
+| `PolicyDecisionLog` | Core | Durable authorization decision log when configured. | `spec: {principal, action, resourceRef, decision, reason, evaluatedAt}` |
+| `SubjectCache` | Core | Cached provider groups, roles, or claims for a subject. | `spec: {issuer, subject, groups, roles, scopes, expiresAt}` |
+
+## Cart And Checkout
+
+| Resource | Scope | Summary | Initial spec shape |
+|---|---|---|---|
+| `Cart` | Core | Mutable shopping cart. | `spec: {customerRef, anonymousId, currencyCode, marketRef, channelRef}` |
+| `CartLine` | Core | Cart line item. | `spec: {cartRef, variantRef, quantity, customAttributes}` |
+| `Checkout` | Core | Checkout aggregate derived from a cart. | `spec: {cartRef, customerRef, email, shippingAddressRef, billingAddressRef}` |
+| `CheckoutSession` | Core | Short-lived checkout session, idempotency, and client state. | `spec: {checkoutRef, idempotencyKey, expiresAt, state}` |
+| `PriceSnapshot` | Core | Applied price details frozen for checkout/order integrity. | `spec: {sourceRef, lines, currencyCode, computedAt}` |
+| `TaxSnapshot` | Core | Applied tax calculation frozen for checkout/order integrity. | `spec: {sourceRef, taxLines, provider, computedAt}` |
+| `ShippingSelection` | Core | Selected shipping method/rate for checkout. | `spec: {checkoutRef, shippingMethodRef, rate, deliveryEstimate}` |
+
+## Orders
+
+Orders are datastore-only by default. Git-backed `Order` resources are not
+recommended for the main purchase lifecycle because orders are high-churn, often
+contain PII, and require privacy-aware retention.
+
+| Resource | Scope | Summary | Initial spec shape |
+|---|---|---|---|
+| `Order` | Core | Purchase lifecycle aggregate from checkout through fulfillment. | `spec: {customerRef, lineItems, currencyCode, shippingAddressRef, billingAddressRef}` |
+| `OrderLine` | Core | Purchased line item with price, tax, and fulfillment state. | `spec: {orderRef, variantRef, quantity, priceSnapshotRef, taxSnapshotRef}` |
+| `OrderEvent` | Core | Append-only order timeline event. | `spec: {orderRef, type, payload, occurredAt, actor}` |
+| `OrderEdit` | Core | Proposed or applied order modification. | `spec: {orderRef, changes, reason, requestedBy}` |
+| `DraftOrder` | Core | Merchant-created draft order or invoice workflow. | `spec: {customerRef, lineItems, discounts, expiresAt}` |
+| `Quote` | Extension/CRD | B2B quote with negotiated prices and validity window. | `spec: {customerRef, companyRef, lineItems, validUntilTime}` |
+| `Cancellation` | Core | Order or line cancellation request and result. | `spec: {orderRef, lineRefs, reason, requestedBy}` |
+| `OrderNote` | Core | Internal or customer-visible order note. | `spec: {orderRef, visibility, body, author}` |
+
+## Payments
+
+Payment resources are datastore-only. Payment credentials, card data, and gateway
+secrets must never be committed to Git.
+
+| Resource | Scope | Summary | Initial spec shape |
+|---|---|---|---|
+| `PaymentIntent` | Core | Intent to authorize or collect payment for checkout/order. | `spec: {amount, currencyCode, gatewayRef, orderRef, idempotencyKey}` |
+| `PaymentAuthorization` | Core | Gateway authorization result. | `spec: {paymentIntentRef, gatewayAuthorizationId, amount, expiresAt}` |
+| `Capture` | Core | Payment capture operation. | `spec: {authorizationRef, amount, gatewayCaptureId, capturedAt}` |
+| `Refund` | Core | Refund request/result. | `spec: {paymentRef, amount, reason, gatewayRefundId}` |
+| `Dispute` | Core | Payment dispute or chargeback record. | `spec: {paymentRef, gatewayDisputeId, amount, reason, evidenceRefs}` |
+| `Payout` | Extension/CRD | Settlement payout from payment provider. | `spec: {gatewayRef, amount, currencyCode, arrivalDate, entries}` |
+| `PaymentMethodRef` | Core | Tokenized reference to a customer payment method. | `spec: {customerRef, gatewayRef, tokenRef, brand, expires}` |
+| `FraudReview` | Core | Manual or automated fraud review state. | `spec: {orderRef, riskAssessmentRef, decision, reviewer}` |
+| `RiskAssessment` | Core | Risk signals and score for checkout/order/payment. | `spec: {subjectRef, score, signals, provider, assessedAt}` |
+
+## Inventory Runtime
+
+| Resource | Scope | Summary | Initial spec shape |
+|---|---|---|---|
+| `StockLevel` | Core | Current quantity at a stock location. | `spec: {variantRef, stockLocationRef, onHand, available}` |
+| `InventoryLedgerEntry` | Core | Append-only stock movement ledger. | `spec: {variantRef, stockLocationRef, delta, reason, sourceRef}` |
+| `Reservation` | Core | Temporary inventory hold for cart or checkout. | `spec: {variantRef, stockLocationRef, quantity, ownerRef, expiresAt}` |
+| `Allocation` | Core | Assigned inventory for an order or fulfillment. | `spec: {orderLineRef, stockLocationRef, quantity}` |
+| `Transfer` | Core | Movement of stock between locations. | `spec: {fromLocationRef, toLocationRef, variantRefs, status}` |
+| `Adjustment` | Core | Manual or system stock correction. | `spec: {variantRef, stockLocationRef, delta, reason, evidenceRef}` |
+| `StockCount` | Extension/CRD | Cycle count or physical stock count. | `spec: {stockLocationRef, countedItems, countedAt, countedBy}` |
+| `Receiving` | Extension/CRD | Inbound receiving event from purchase order or supplier. | `spec: {stockLocationRef, sourceRef, receivedItems, receivedAt}` |
+| `AvailabilitySnapshot` | Core | Cached availability projection for storefront reads. | `spec: {variantRef, marketRef, channelRef, availableQuantity, computedAt}` |
+
+## Fulfillment Runtime
+
+| Resource | Scope | Summary | Initial spec shape |
+|---|---|---|---|
+| `FulfillmentOrder` | Core | Fulfillment work item derived from an order. | `spec: {orderRef, lines, assignedLocationRef, serviceLevel}` |
+| `Fulfillment` | Core | Fulfilled subset of an order. | `spec: {fulfillmentOrderRef, lines, shipmentRefs, fulfilledAt}` |
+| `Shipment` | Core | Carrier shipment and tracking. | `spec: {fulfillmentRef, carrier, trackingNumber, packages}` |
+| `Package` | Core | Physical package contents and dimensions. | `spec: {shipmentRef, lineRefs, weight, dimensions}` |
+| `TrackingEvent` | Core | Carrier tracking event. | `spec: {shipmentRef, status, message, location, occurredAt}` |
+| `DeliveryAttempt` | Extension/CRD | Delivery attempt record. | `spec: {shipmentRef, outcome, occurredAt, evidenceRef}` |
+| `Return` | Core | Return request and lifecycle. | `spec: {orderRef, lineRefs, reason, requestedAt}` |
+| `Exchange` | Extension/CRD | Exchange workflow linking returned and replacement items. | `spec: {returnRef, replacementLineItems, priceDifference}` |
+| `RMA` | Core | Return merchandise authorization. | `spec: {returnRef, number, expiresAt, instructions}` |
+
+## Value Instruments
+
+Generated codes and balances are datastore-only even when their campaign or
+policy is Git-backed.
+
+| Resource | Scope | Summary | Initial spec shape |
+|---|---|---|---|
+| `CouponCode` | Core | Individual generated or imported coupon code. | `spec: {campaignRef, codeHash, usageLimit, expiresAt}` |
+| `Voucher` | Extension/CRD | Voucher with value or entitlement. | `spec: {ownerRef, value, currencyCode, expiresAt}` |
+| `GiftCard` | Core | Gift card balance instrument. | `spec: {codeHash, initialBalance, currencyCode, ownerRef}` |
+| `StoreCredit` | Core | Customer store credit balance. | `spec: {customerRef, balance, currencyCode, expiresAt}` |
+| `LoyaltyAccount` | Extension/CRD | Customer loyalty account. | `spec: {customerRef, tier, pointsBalance}` |
+| `PointsLedger` | Extension/CRD | Loyalty points ledger entry. | `spec: {loyaltyAccountRef, delta, reason, sourceRef}` |
+| `Redemption` | Extension/CRD | Redemption of coupon, voucher, gift card, credit, or points. | `spec: {instrumentRef, orderRef, amount, redeemedAt}` |
+
+## Platform Runtime
+
+| Resource | Scope | Summary | Initial spec shape |
+|---|---|---|---|
+| `HydrationRecord` | Core | Records hydration of a Git resource into datastore. | `spec: {resourceRef, gitRef, gitCommitSHA, result}` |
+| `AdmissionResult` | Core | Admission outcome for pushed resources. | `spec: {resourceRef, revision, accepted, errors}` |
+| `ReconcileJob` | Core | Controller reconciliation work item. | `spec: {resourceRef, reason, attempt, scheduledAt}` |
+| `WatchEvent` | Core | Stored watch event for resume or fanout when enabled. | `spec: {type, resourceRef, resourceVersion, payload}` |
+| `OutboxEvent` | Core | Transactional outbox event for integrations. | `spec: {eventType, aggregateRef, payload, availableAt}` |
+| `WebhookDelivery` | Core | Delivery attempt to a webhook endpoint. | `spec: {endpointRef, eventRef, attempt, response, nextAttemptAt}` |
+| `AuditLog` | Core | Append-only audit event. | `spec: {actor, action, resourceRef, before, after, occurredAt}` |
+| `IndexState` | Core | Search or projection index cursor and health. | `spec: {indexName, cursor, lastIndexedAt, status}` |

--- a/docs/resources/git-backed.md
+++ b/docs/resources/git-backed.md
@@ -1,0 +1,423 @@
+# Git-Backed Resources
+
+Git-backed resources are desired-state documents. Git stores the author-written
+frontmatter and Markdown body. ScyllaDB or memDB stores hydrated records,
+indexes, Git provenance, resource versions, generated metadata, and
+system-managed `status`.
+
+## Authoring Shell
+
+Every resource in this page uses this Markdown shell unless noted otherwise.
+Replace `apiVersion`, `kind`, and `spec` with the resource-specific shape.
+
+```markdown
+---
+apiVersion: <group>.gitstore.dev/v1beta1
+kind: <Kind>
+metadata:
+  name: example-name
+  namespace: example-store
+  labels: {}
+  annotations: {}
+spec: {}
+---
+
+Optional Markdown body content.
+```
+
+`status` is not author-writable. Controllers and admission write status to the
+datastore.
+
+## Control Plane
+
+| Resource | Scope | Summary | Initial spec shape |
+|---|---|---|---|
+| `Namespace` | Core | Tenant or account boundary for repositories and commerce resources. | `spec: {displayName, tier, parentEnterpriseRef, defaults, limits}` |
+| `Repository` | Core | Git repository declaration for catalog or configuration storage. | `spec: {name, defaultBranch, visibility, storageClass, description}` |
+| `Environment` | Core | Deployment or runtime environment such as dev, staging, prod. | `spec: {type, branchRef, promotionPolicy, variablesRef}` |
+| `CatalogRelease` | Core | Immutable publication marker for a catalog Git revision. | `spec: {repositoryRef, gitRef, gitCommitSHA, notes}` |
+| `Publication` | Core | Maps a release or branch to a market/channel/storefront target. | `spec: {releaseRef, targetRef, effectiveFromTime, rollbackRef}` |
+| `WorkflowPolicy` | Extension/CRD | Review, approval, and automation policy for Git-backed changes. | `spec: {resourceSelector, requiredApprovals, checks, autoMerge}` |
+
+Example:
+
+```markdown
+---
+apiVersion: core.gitstore.dev/v1beta1
+kind: Namespace
+metadata:
+  name: acme-store
+spec:
+  displayName: Acme Store
+  tier: enterprise
+---
+
+Primary namespace for Acme commerce resources.
+```
+
+## Catalog And Merchandising
+
+| Resource | Scope | Summary | Initial spec shape |
+|---|---|---|---|
+| `Product` | Core | Non-sellable product descriptor with copy, classification, options, and media references. | `spec: {title, categoryRef, tags, media, options}` |
+| `ProductVariant` | Core | Purchasable SKU with selected options, pricing rules, inventory policy, and media. | `spec: {title, sku, productRef, selectedOptions, pricing, inventory, media}` |
+| `CategoryTaxonomy` | Core | Hierarchical category node. Products belong to exactly one category in the current model. | `spec: {title, parentRef, media}` |
+| `Collection` | Core | Selector-driven product grouping for merchandising. | `spec: {title, targetRef, selector, media}` |
+| `Bundle` | Extension/CRD | Sellable or merchandised group of variants with bundle-level pricing and rules. | `spec: {title, componentRefs, pricing, inventoryPolicy, media}` |
+| `Kit` | Extension/CRD | Operational kit assembled from required components, often fulfilled as one unit. | `spec: {title, componentRefs, assemblyPolicy, fulfillmentPolicy}` |
+| `Brand` | Core | Brand identity, display metadata, and brand-level media. | `spec: {title, slug, media, websiteURL}` |
+| `Vendor` | Core | Commercial vendor or supplier shown in catalog data. | `spec: {displayName, accountRef, contact, termsRef}` |
+| `Manufacturer` | Extension/CRD | Manufacturer metadata distinct from vendor/seller. | `spec: {displayName, countryCode, identifiers, contact}` |
+| `ProductType` | Core | Product type taxonomy used for validation, facets, and default attributes. | `spec: {title, attributeRefs, optionSetRefs, facetRefs}` |
+| `AttributeDefinition` | Core | Typed product or variant attribute definition. | `spec: {title, dataType, allowedValues, unit, validation}` |
+| `OptionSet` | Core | Reusable product option names and allowed values. | `spec: {options}` |
+| `FacetDefinition` | Core | Search/filter facet declaration for storefront discovery. | `spec: {fieldPath, title, type, display, sort}` |
+
+Example:
+
+```markdown
+---
+apiVersion: catalog.gitstore.dev/v1beta1
+kind: Product
+metadata:
+  name: macbook-pro
+  namespace: acme-store
+spec:
+  title: MacBook Pro
+  categoryRef:
+    kind: CategoryTaxonomy
+    name: laptops
+  tags: [laptop]
+  options:
+  - name: color
+    values: [silver, space-black]
+---
+
+Long-form product description.
+```
+
+## Localization And Content
+
+| Resource | Scope | Summary | Initial spec shape |
+|---|---|---|---|
+| `Translation` | Core | Locale-specific field patches and translated Markdown body for another resource. | `spec: {locale, targetRef, patches}` |
+| `Locale` | Core | Supported locale declaration and fallback behavior. | `spec: {languageTag, fallbackLocaleRef, textDirection, enabled}` |
+| `MarketLocalization` | Extension/CRD | Market-specific localization defaults and overrides. | `spec: {marketRef, localeRefs, fallbackPolicy}` |
+| `ContentPage` | Extension/CRD | CMS-style page content that belongs in Git review workflows. | `spec: {title, slug, template, seo, publish}` |
+| `NavigationMenu` | Extension/CRD | Storefront menu tree with resource links. | `spec: {title, items, channelRefs}` |
+| `SearchSynonymSet` | Extension/CRD | Search synonyms and equivalent terms. | `spec: {locale, synonyms}` |
+| `SearchRedirect` | Extension/CRD | Search query to destination redirect rules. | `spec: {query, targetURL, locale, channelRefs}` |
+
+Example:
+
+```markdown
+---
+apiVersion: i18n.gitstore.dev/v1beta1
+kind: Translation
+metadata:
+  name: macbook-pro-de-de
+  namespace: acme-store
+spec:
+  locale: de-DE
+  targetRef:
+    apiVersion: catalog.gitstore.dev/v1beta1
+    kind: Product
+    name: macbook-pro
+  patches:
+  - fieldPath: spec.title
+    translation: MacBook Pro
+---
+
+Translated Markdown body.
+```
+
+## Media Manifests
+
+These resources describe files. They do not require binary payloads to be stored
+directly in Git. See [LFS and object storage resources](lfs-object-storage.md).
+
+| Resource | Scope | Summary | Initial spec shape |
+|---|---|---|---|
+| `File` | Core | Generic file manifest with content type, source URI, checksum, and processing hints. | `spec: {contentType, type, source, processing}` |
+| `MediaAsset` | Core | Image, video, or audio asset with semantic usage and derived variants. | `spec: {fileRef, role, altTextRef, focalPoint, variants}` |
+| `DigitalAsset` | Extension/CRD | Downloadable commercial asset such as software, ebook, warranty PDF, or license file. | `spec: {fileRef, entitlementPolicyRef, deliveryPolicy, version}` |
+
+Example:
+
+```markdown
+---
+apiVersion: storage.gitstore.dev/v1beta1
+kind: File
+metadata:
+  name: product-hero
+  namespace: acme-store
+spec:
+  contentType: image/jpeg
+  type: gitstore.dev/media
+  source:
+    type: git
+    uri: git:///media/product-hero.jpg?ref=main
+    checksum:
+      algorithm: sha256
+      value: example
+---
+
+Alt text for the image.
+```
+
+## Pricing Configuration
+
+| Resource | Scope | Summary | Initial spec shape |
+|---|---|---|---|
+| `PriceList` | Core | Named price list for a market, customer segment, or channel. | `spec: {currencyCode, marketRefs, customerGroupRefs, prices}` |
+| `PriceSet` | Core | Reusable set of price templates and eligibility expressions. | `spec: {prices}` |
+| `PriceRule` | Core | Independent pricing rule that can be referenced by products, variants, or price lists. | `spec: {selector, amount, strategy, eligibility, priority}` |
+| `CurrencyPolicy` | Core | Supported currencies and conversion policy. | `spec: {baseCurrencyCode, allowedCurrencyCodes, conversionProviderRef}` |
+| `RoundingPolicy` | Extension/CRD | Currency and market rounding behavior for computed prices. | `spec: {currencyCode, mode, increment}` |
+| `TaxInclusivePricingPolicy` | Extension/CRD | Defines where prices are tax-inclusive or tax-exclusive. | `spec: {marketRefs, included, displayMode}` |
+
+Example:
+
+```markdown
+---
+apiVersion: pricing.gitstore.dev/v1beta1
+kind: PriceList
+metadata:
+  name: eu-retail
+  namespace: acme-store
+spec:
+  currencyCode: EUR
+  marketRefs:
+  - kind: Market
+    name: eu
+  prices: []
+---
+
+EU retail prices.
+```
+
+## Promotions Configuration
+
+| Resource | Scope | Summary | Initial spec shape |
+|---|---|---|---|
+| `Campaign` | Core | Time-bounded commercial campaign containing promotions or rules. | `spec: {title, activeFromTime, activeUntilTime, promotionRefs, channelRefs}` |
+| `Promotion` | Core | Promotion container with eligibility and benefit rules. | `spec: {title, eligibility, benefits, priority, stackingPolicy}` |
+| `DiscountRule` | Core | Reusable discount calculation rule. | `spec: {selector, amount, strategy, eligibility, limits}` |
+| `CouponCampaign` | Core | Coupon campaign configuration; generated codes are datastore-only. | `spec: {codePattern, discountRuleRef, usageLimits, activeWindow}` |
+| `GiftWithPurchaseRule` | Extension/CRD | Adds a gift item when cart conditions match. | `spec: {eligibility, giftVariantRefs, quantity, limits}` |
+| `LoyaltyRule` | Extension/CRD | Loyalty earning or redemption policy. | `spec: {event, points, eligibility, limits}` |
+
+Example:
+
+```markdown
+---
+apiVersion: promotions.gitstore.dev/v1beta1
+kind: Promotion
+metadata:
+  name: summer-sale
+  namespace: acme-store
+spec:
+  title: Summer Sale
+  priority: 100
+  eligibility: {}
+  benefits: []
+---
+
+Promotion notes.
+```
+
+## Markets And Channels
+
+| Resource | Scope | Summary | Initial spec shape |
+|---|---|---|---|
+| `Market` | Core | Commercial market made of countries, currency, tax, and localization defaults. | `spec: {title, countrySetRef, currencyCode, localeRefs, taxPolicyRefs}` |
+| `Region` | Core | Geographic grouping for pricing, tax, shipping, or compliance. | `spec: {title, countryCodes, subdivisionCodes}` |
+| `SalesChannel` | Core | Channel such as web, mobile, marketplace, B2B portal, or POS. | `spec: {title, type, marketRefs, storefrontRefs}` |
+| `Storefront` | Core | Storefront configuration and routing for a channel. | `spec: {title, domains, defaultLocaleRef, defaultMarketRef, themeRef}` |
+| `CountrySet` | Core | Reusable set of countries or subdivisions. | `spec: {countryCodes, subdivisionCodes}` |
+| `CurrencyZone` | Extension/CRD | Group of markets sharing currency and conversion behavior. | `spec: {currencyCode, marketRefs, roundingPolicyRef}` |
+
+Example:
+
+```markdown
+---
+apiVersion: markets.gitstore.dev/v1beta1
+kind: Market
+metadata:
+  name: eu
+  namespace: acme-store
+spec:
+  title: European Union
+  countrySetRef:
+    kind: CountrySet
+    name: eu-countries
+  currencyCode: EUR
+---
+
+EU market configuration.
+```
+
+## Inventory Configuration
+
+Runtime stock quantities and reservations are datastore-only. These resources
+declare desired inventory topology and policies.
+
+| Resource | Scope | Summary | Initial spec shape |
+|---|---|---|---|
+| `StockLocation` | Core | Sellable stock location reference used by variants and availability. | `spec: {title, type, addressRef, enabled}` |
+| `Warehouse` | Core | Physical warehouse configuration and capabilities. | `spec: {title, address, capabilities, operatingHours}` |
+| `SupplySource` | Extension/CRD | Supplier, dropship, or upstream inventory source. | `spec: {type, vendorRef, leadTime, capabilities}` |
+| `InventoryPolicy` | Core | Availability rules for managed inventory. | `spec: {selector, allocationPolicyRef, reservationPolicyRef, backorderPolicyRef}` |
+| `AllocationPolicy` | Core | Rules for assigning demand to stock locations. | `spec: {strategy, locationPriority, splitShipmentAllowed}` |
+| `ReservationPolicy` | Core | Hold duration and reservation release behavior. | `spec: {ttlSeconds, refreshAllowed, releaseOnEvents}` |
+| `BackorderPolicy` | Core | Backorder eligibility and limits. | `spec: {enabled, maxQuantity, expectedAvailability, customerMessage}` |
+| `SafetyStockPolicy` | Extension/CRD | Buffer stock rules to protect operational inventory. | `spec: {selector, quantity, percent, locationRefs}` |
+
+Example:
+
+```markdown
+---
+apiVersion: inventory.gitstore.dev/v1beta1
+kind: StockLocation
+metadata:
+  name: berlin-warehouse
+  namespace: acme-store
+spec:
+  title: Berlin Warehouse
+  type: warehouse
+  enabled: true
+---
+
+Primary EU stock location.
+```
+
+## Fulfillment Configuration
+
+| Resource | Scope | Summary | Initial spec shape |
+|---|---|---|---|
+| `FulfillmentLocation` | Core | Location that can fulfill orders, distinct from sellable stock if needed. | `spec: {title, stockLocationRef, address, capabilities}` |
+| `ShippingZone` | Core | Destination zone for shipping rates and restrictions. | `spec: {countrySetRef, postalCodeRules, subdivisionRules}` |
+| `ShippingMethod` | Core | Customer-selectable shipping method. | `spec: {title, carrierServiceRef, shippingZoneRefs, constraints}` |
+| `ShippingRateTable` | Core | Deterministic shipping rates by zone, weight, price, or quantity. | `spec: {currencyCode, rates}` |
+| `CarrierService` | Extension/CRD | Carrier integration configuration without secrets. | `spec: {provider, serviceCodes, credentialsRef, sandbox}` |
+| `FulfillmentPolicy` | Core | Fulfillment routing, splitting, and SLA policy. | `spec: {selector, routingStrategy, splitPolicy, sla}` |
+| `ReturnPolicy` | Core | Return eligibility and refund rules. | `spec: {windowDays, eligibility, restockingFee, refundMethod}` |
+| `PackagingProfile` | Extension/CRD | Package sizes, weights, and constraints for rating and fulfillment. | `spec: {packages, defaultPackage, constraints}` |
+| `PickupLocation` | Extension/CRD | Customer pickup location metadata and schedule. | `spec: {address, operatingHours, instructions, enabled}` |
+
+Example:
+
+```markdown
+---
+apiVersion: fulfillment.gitstore.dev/v1beta1
+kind: ShippingMethod
+metadata:
+  name: standard-eu
+  namespace: acme-store
+spec:
+  title: Standard EU
+  shippingZoneRefs:
+  - kind: ShippingZone
+    name: eu
+  constraints: {}
+---
+
+Standard EU delivery method.
+```
+
+## Tax And Compliance Configuration
+
+| Resource | Scope | Summary | Initial spec shape |
+|---|---|---|---|
+| `TaxCategory` | Core | Product tax category used by tax rules and providers. | `spec: {title, taxCodeRef, productSelector}` |
+| `TaxCode` | Core | Canonical tax code mapping for a provider or jurisdiction. | `spec: {code, provider, description}` |
+| `TaxRegion` | Core | Jurisdiction or tax region. | `spec: {countryCode, subdivisionCode, postalCodeRules}` |
+| `TaxRate` | Core | Static tax rate for a region and category. | `spec: {taxRegionRef, taxCategoryRef, rate, included}` |
+| `TaxRule` | Core | Tax selection or override rule. | `spec: {selector, taxRateRef, eligibility, priority}` |
+| `TaxProviderConfig` | Extension/CRD | External tax provider configuration without secrets. | `spec: {provider, accountRef, credentialsRef, nexusRules}` |
+| `RestrictedGoodsPolicy` | Extension/CRD | Restricts products by market, customer, or destination. | `spec: {selector, destinationRules, customerRules, action}` |
+| `AgeGatePolicy` | Extension/CRD | Age verification requirements for products or markets. | `spec: {selector, minimumAge, verificationProviderRef}` |
+| `LegalPolicy` | Core | Terms, privacy, refund, or legal document policy. | `spec: {type, localeRefs, contentRef, effectiveFromTime}` |
+| `ConsentPolicy` | Core | Consent collection requirements and retention. | `spec: {purpose, required, localeRefs, retention}` |
+
+Example:
+
+```markdown
+---
+apiVersion: compliance.gitstore.dev/v1beta1
+kind: TaxCategory
+metadata:
+  name: standard-goods
+  namespace: acme-store
+spec:
+  title: Standard Goods
+  taxCodeRef:
+    kind: TaxCode
+    name: standard
+---
+
+Default taxable goods category.
+```
+
+## AuthZ Configuration
+
+Authentication runtime records are datastore-only. These resources are
+reviewable desired-state authorization and policy configuration.
+
+| Resource | Scope | Summary | Initial spec shape |
+|---|---|---|---|
+| `Role` | Core | Named role containing permission references. | `spec: {permissionRefs, description}` |
+| `RoleBinding` | Core | Binds users, groups, service accounts, or external subjects to roles. | `spec: {subjects, roleRef, resourceSelector}` |
+| `PermissionSet` | Core | Reusable set of actions on resource types. | `spec: {permissions}` |
+| `Policy` | Core | Declarative authorization policy for an authz provider such as RBAC, OPA, or OpenFGA. | `spec: {provider, rules}` |
+| `PolicyBinding` | Core | Attaches policies to namespaces, repositories, or resource selectors. | `spec: {policyRef, targetRef, selector}` |
+| `ServiceAccount` | Core | Non-human principal metadata; secrets and tokens are datastore/secret-manager only. | `spec: {displayName, scopes, ownerRefs}` |
+| `ApprovalPolicy` | Extension/CRD | Required approval workflow for sensitive resources or environments. | `spec: {selector, approvers, minApprovals, conditions}` |
+
+Example:
+
+```markdown
+---
+apiVersion: authz.gitstore.dev/v1beta1
+kind: Role
+metadata:
+  name: catalog-editor
+  namespace: acme-store
+spec:
+  permissionRefs:
+  - kind: PermissionSet
+    name: catalog-write
+---
+
+Catalog editing role.
+```
+
+## Integration Configuration
+
+| Resource | Scope | Summary | Initial spec shape |
+|---|---|---|---|
+| `WebhookEndpoint` | Core | Webhook target and event subscription configuration. | `spec: {url, eventTypes, secretRef, retryPolicy}` |
+| `Integration` | Core | External system integration metadata and enabled capabilities. | `spec: {provider, capabilities, config, credentialsRef}` |
+| `PaymentGatewayConfig` | Core | Payment provider configuration without customer payment data or credentials. | `spec: {provider, mode, credentialsRef, supportedMethods, capturePolicy}` |
+| `NotificationTemplate` | Extension/CRD | Generic notification template for event-driven messages. | `spec: {channel, locale, subjectTemplate, bodyTemplate, variables}` |
+| `EmailTemplate` | Extension/CRD | Email-specific template with locale and brand variants. | `spec: {locale, subject, htmlFileRef, textFileRef, variables}` |
+
+Example:
+
+```markdown
+---
+apiVersion: integrations.gitstore.dev/v1beta1
+kind: WebhookEndpoint
+metadata:
+  name: erp-order-events
+  namespace: acme-store
+spec:
+  url: https://erp.example.com/gitstore/events
+  eventTypes:
+  - order.created
+  retryPolicy:
+    maxAttempts: 10
+---
+
+ERP webhook subscription.
+```

--- a/docs/resources/lfs-object-storage.md
+++ b/docs/resources/lfs-object-storage.md
@@ -1,0 +1,124 @@
+# LFS And Object Storage Resources
+
+This group covers binary or large payloads. GitStore should keep reviewable
+manifests in Git and hydrated metadata in the datastore, while payload bytes live
+in Git LFS or object storage.
+
+## Storage Rules
+
+Use Git LFS when:
+
+- the asset is catalog-owned desired state;
+- versioning the original is useful;
+- churn is low enough that repository history remains useful.
+
+Use object storage when:
+
+- the asset is generated, temporary, customer-provided, or high-churn;
+- the asset needs CDN delivery, encryption, retention, legal hold, or signed URLs;
+- the asset contains PII or operational documents.
+
+Use a secret manager or KMS, not Git or LFS, for credentials, signing keys,
+webhook secrets, payment provider secrets, private certificates, and encryption
+keys.
+
+## Manifest Shape
+
+```markdown
+---
+apiVersion: storage.gitstore.dev/v1beta1
+kind: File
+metadata:
+  name: product-hero
+  namespace: example-store
+spec:
+  contentType: image/jpeg
+  type: gitstore.dev/media
+  source:
+    type: git
+    uri: git:///media/product-hero.jpg?ref=main
+    checksum:
+      algorithm: sha256
+      value: example
+  processing:
+    image:
+      variants:
+      - name: thumbnail
+        width: 400
+        format: webp
+---
+
+Alt text or file description.
+```
+
+## Git-Backed Manifests
+
+| Resource | Scope | Summary | Initial spec shape |
+|---|---|---|---|
+| `File` | Core | Generic file manifest with source URI, checksum, content type, and processing hints. | `spec: {contentType, type, source, processing}` |
+| `MediaAsset` | Core | Catalog media manifest for images, videos, audio, and derived variants. | `spec: {fileRef, role, focalPoint, altTextRef, variants}` |
+| `DigitalAsset` | Extension/CRD | Downloadable commerce asset controlled by entitlement or delivery rules. | `spec: {fileRef, entitlementPolicyRef, deliveryPolicy, version}` |
+
+## Payload Classes
+
+These are not usually standalone API resources. They are payload classes
+referenced by `File`, `MediaAsset`, `DigitalAsset`, or datastore-only records.
+
+| Payload class | Scope | Preferred storage | Summary | Initial metadata shape |
+|---|---|---|---|---|
+| `ProductImageOriginal` | Core | Git LFS or object storage | Original catalog image. | `{contentType, sizeBytes, checksum, sourceRef}` |
+| `ProductImageVariant` | Core | Object storage | Generated resized or reformatted image. | `{originalRef, width, height, format, url}` |
+| `VideoOriginal` | Extension/CRD | Object storage | Original product or content video. | `{contentType, sizeBytes, checksum, duration}` |
+| `VideoTranscode` | Extension/CRD | Object storage | Generated video rendition. | `{originalRef, codec, bitrate, resolution, url}` |
+| `DocumentAsset` | Core | Git LFS or object storage | Manual, warranty, spec sheet, certificate, or PDF. | `{contentType, checksum, locale, title}` |
+| `ImportExportFile` | Core | Object storage | Bulk import, export, report, or reconciliation file. | `{jobRef, contentType, checksum, expiresAt}` |
+| `CustomerUpload` | Core | Object storage | File uploaded by a customer, such as return evidence. | `{customerRef, purpose, contentType, retention}` |
+| `InvoicePDF` | Core | Object storage | Generated invoice or credit note PDF. | `{orderRef, invoiceNumber, contentType, checksum}` |
+| `ReturnLabel` | Core | Object storage | Carrier-generated return label. | `{returnRef, carrier, trackingNumber, contentType}` |
+| `WebhookPayloadArchive` | Core | Object storage | Archived inbound or outbound webhook body. | `{deliveryRef, eventType, checksum, retainedUntil}` |
+| `BackupArtifact` | Extension/CRD | Object storage | Backup, restore, or migration artifact. | `{source, createdAt, checksum, encryptionRef}` |
+
+## Object URI References
+
+Prefer explicit source types:
+
+```yaml
+source:
+  type: s3
+  uri: s3://catalog-assets/products/product-hero.jpg
+  checksum:
+    algorithm: sha256
+    value: example
+```
+
+```yaml
+source:
+  type: git
+  uri: git:///media/product-hero.jpg?ref=main
+  checksum:
+    algorithm: sha256
+    value: example
+```
+
+```yaml
+source:
+  type: b2
+  uri: b2://catalog-assets/products/product-hero.jpg
+  checksum:
+    algorithm: sha256
+    value: example
+```
+
+Credentials should be referenced indirectly:
+
+```yaml
+source:
+  type: s3
+  uri: s3://catalog-assets/products/product-hero.jpg
+  credentialsRef:
+    kind: SecretRef
+    name: catalog-assets-writer
+```
+
+The `SecretRef` target is not a Git-backed secret. It should resolve through the
+deployment secret manager or Kubernetes secret integration.

--- a/docs/resources/transient.md
+++ b/docs/resources/transient.md
@@ -1,0 +1,174 @@
+# Transient Resources
+
+Transient resources use Kubernetes-style shapes for consistency, but they are
+not stored as durable resources. They are request/response contracts for checks,
+quotes, previews, authorization decisions, signed URL creation, or dry runs.
+
+Durable traces can be emitted separately as datastore-only events such as
+`AuditLog`, `OrderEvent`, `OutboxEvent`, `WebhookDelivery`, or provider-specific
+logs.
+
+## Request/Response Shape
+
+```yaml
+apiVersion: checkout.gitstore.dev/v1beta1
+kind: PriceQuote
+spec:
+  marketRef:
+    kind: Market
+    name: eu
+  lines:
+  - variantRef:
+      kind: ProductVariant
+      name: example-sku
+    quantity: 1
+status:
+  result:
+    currencyCode: EUR
+    total: "19.99"
+```
+
+`metadata.name` is usually omitted unless idempotency or correlation requires it.
+
+## AuthN And AuthZ Checks
+
+| Resource | Scope | Summary | Initial spec shape |
+|---|---|---|---|
+| `Login` | Core | Authenticates a principal and returns a session. | `spec: {credentials, provider}` |
+| `Logout` | Core | Invalidates the current session or token. | `spec: {sessionRef, token}` |
+| `RefreshToken` | Core | Exchanges a refresh token for a new session. | `spec: {refreshToken}` |
+| `TokenReview` | Core | Authenticates or introspects a token. | `spec: {token, audiences}` |
+| `SubjectAccessReview` | Core | Checks whether a principal can perform an action on a resource. | `spec: {principal, action, resourceRef, context}` |
+
+Example:
+
+```yaml
+apiVersion: authz.gitstore.dev/v1beta1
+kind: SubjectAccessReview
+spec:
+  principal:
+    subject: user-123
+    issuer: oidc
+  action: repository.write
+  resourceRef:
+    kind: Repository
+    name: catalog
+status:
+  allowed: true
+  reason: RoleBindingMatched
+```
+
+## Admission And Validation
+
+| Resource | Scope | Summary | Initial spec shape |
+|---|---|---|---|
+| `AdmissionReview` | Core | Reviews a proposed resource write before persistence. | `spec: {operation, resource, oldResource, dryRun}` |
+| `ValidationReview` | Core | Performs structural validation without writing anything. | `spec: {resource, schemaRef, strict}` |
+| `CatalogDiff` | Core | Computes differences between two Git refs or releases. | `spec: {baseRef, targetRef, resourceSelector}` |
+| `ImportDryRun` | Core | Validates an import file and reports proposed changes. | `spec: {fileRef, format, mapping, options}` |
+
+Example:
+
+```yaml
+apiVersion: admission.gitstore.dev/v1beta1
+kind: ValidationReview
+spec:
+  strict: true
+  resource:
+    apiVersion: catalog.gitstore.dev/v1beta1
+    kind: Product
+    metadata:
+      name: example-product
+    spec:
+      title: Example Product
+status:
+  valid: true
+  errors: []
+```
+
+## Pricing, Tax, Shipping, And Inventory Calculations
+
+| Resource | Scope | Summary | Initial spec shape |
+|---|---|---|---|
+| `PriceQuote` | Core | Computes applicable prices for lines and context. | `spec: {lines, marketRef, channelRef, customerRef, currencyCode}` |
+| `TaxQuote` | Core | Computes taxes for checkout/order context. | `spec: {lines, addresses, taxCategoryRefs, providerRef}` |
+| `ShippingRateQuote` | Core | Returns eligible shipping methods and rates. | `spec: {destination, lines, packageHints, marketRef}` |
+| `InventoryAvailabilityReview` | Core | Checks availability for variants and quantities. | `spec: {lines, marketRef, channelRef, locationRefs}` |
+| `PromotionEvaluation` | Core | Evaluates promotion eligibility and benefits. | `spec: {cartRef, lines, customerRef, couponCodes}` |
+| `CheckoutValidation` | Core | Validates checkout readiness before order creation. | `spec: {checkoutRef, checks}` |
+| `RefundCalculation` | Core | Computes refundable amounts and adjustments. | `spec: {orderRef, lineRefs, reason, includeShipping}` |
+
+Example:
+
+```yaml
+apiVersion: inventory.gitstore.dev/v1beta1
+kind: InventoryAvailabilityReview
+spec:
+  lines:
+  - variantRef:
+      kind: ProductVariant
+      name: macbook-pro-silver
+    quantity: 1
+  marketRef:
+    kind: Market
+    name: eu
+status:
+  available: true
+  lines:
+  - availableQuantity: 18
+```
+
+## Payments And Fraud
+
+Payment provider calls are transient at the API boundary. Durable outcomes are
+stored as datastore-only payment resources.
+
+| Resource | Scope | Summary | Initial spec shape |
+|---|---|---|---|
+| `FraudScoreRequest` | Core | Requests risk scoring from internal or external systems. | `spec: {checkoutRef, orderRef, paymentIntentRef, signals}` |
+| `PaymentAuthorizeRequest` | Core | Requests gateway authorization. | `spec: {paymentIntentRef, paymentMethodRef, amount, idempotencyKey}` |
+| `PaymentCaptureRequest` | Core | Requests capture of an authorization. | `spec: {authorizationRef, amount, idempotencyKey}` |
+
+Example:
+
+```yaml
+apiVersion: payments.gitstore.dev/v1beta1
+kind: PaymentAuthorizeRequest
+spec:
+  paymentIntentRef:
+    kind: PaymentIntent
+    name: pi-10001
+  amount: "49.99"
+  currencyCode: EUR
+  idempotencyKey: checkout-10001-authorize
+status:
+  accepted: true
+  authorizationRef:
+    kind: PaymentAuthorization
+    name: pa-10001
+```
+
+## Search, Preview, And Upload
+
+| Resource | Scope | Summary | Initial spec shape |
+|---|---|---|---|
+| `SearchQuery` | Core | Executes a search request. | `spec: {query, filters, sort, pagination, context}` |
+| `ProductPreview` | Core | Renders or resolves a product preview from a Git ref. | `spec: {productRef, gitRef, locale, marketRef}` |
+| `UploadSession` | Core | Starts a resumable or multipart upload session. | `spec: {purpose, contentType, sizeBytes, checksum}` |
+| `PresignedUploadURL` | Core | Returns a signed URL for direct upload. | `spec: {uploadSessionRef, partNumber, expiresInSeconds}` |
+| `WebhookTest` | Core | Sends a synthetic event to a webhook endpoint. | `spec: {endpointRef, eventType, payload}` |
+
+Example:
+
+```yaml
+apiVersion: storage.gitstore.dev/v1beta1
+kind: PresignedUploadURL
+spec:
+  uploadSessionRef:
+    kind: UploadSession
+    name: upload-10001
+  expiresInSeconds: 900
+status:
+  url: https://storage.example.com/signed-upload
+  expiresAt: "2026-06-17T12:15:00Z"
+```


### PR DESCRIPTION
## Summary

Adds a new `docs/resources/` section that classifies commerce resource types by persistence model:

- Git-backed resources for reviewable desired state
- Datastore-only resources for durable operational state, PII, payments, inventory movement, sessions, audit, and runtime records
- LFS/object storage resources for binary and large payloads
- Transient resources for request/response calculations, checks, previews, and signed URL flows

The overview anchors the taxonomy to the Kubernetes-style resource shape and links the new category pages together.

## Impact

This gives implementation and API design work a shared reference for deciding whether a resource belongs in Git, ScyllaDB/memDB, object storage, or only as a transient contract.

## Validation

- `make pr-ready`